### PR TITLE
Nuget error handling

### DIFF
--- a/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
+++ b/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
@@ -82,7 +82,13 @@ namespace LCT.PackageIdentifier
             catch (InvalidProjectFileException ex)
             {
                 Logger.Debug($"IsTestProject(): Failed to read project file : " + projectPath, ex);
-                Logger.Warn($"IsTestProject: Failed to read project file : " + projectPath);
+                Logger.Warn($"IsTestProject: Failed to read project file, evaluation fails for : " + projectPath);
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logger.Debug($"IsTestProject(): Failed to read project file : " + projectPath, ex);
+                Logger.Warn($"IsTestProject: Failed to read project file, Maybe there is already an equivalent project loaded in the project collection " + projectPath);
                 return false;
             }
             catch (MissingFieldException ex)
@@ -92,6 +98,12 @@ namespace LCT.PackageIdentifier
                 return false;
             }
             catch (ArgumentException ex)
+            {
+                Logger.Debug($"IsTestProject(): Failed to read project file : " + projectPath, ex);
+                Logger.Warn($"IsTestProject: Failed to read project file : " + projectPath);
+                return false;
+            }
+            catch (IOException ex)
             {
                 Logger.Debug($"IsTestProject(): Failed to read project file : " + projectPath, ex);
                 Logger.Warn($"IsTestProject: Failed to read project file : " + projectPath);


### PR DESCRIPTION
![image](https://github.com/siemens/continuous-clearing/assets/84563853/1f118dd2-9cd7-4fb5-ae0b-ad82ceebd87b)
I
If Different input file refers to same .csproj project we will be getting this error
SO we're handling that exception
