### PR TITLE
Develop 3 18 24

### DIFF
--- a/CA.nuspec
+++ b/CA.nuspec
@@ -4,7 +4,7 @@
 <package >
   <metadata>
     <id>continuous-clearing</id>
-    <version>6.1.0</version>
+    <version>6.2.0</version>
     <authors>Siemens AG</authors>
     <owners>continuous-clearing contributors</owners>
     <projectUrl>https://github.com/siemens/continuous-clearing</projectUrl>
@@ -17,7 +17,7 @@
       for clearing license
     </description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright 2023</copyright>
+    <copyright>Copyright 2024</copyright>
     <tags>ClearingTool SW360 OSS Clearing Software Continuous-Clearing NPM NUGET DEBIAN MAVEN PYTHON SBOM</tags>
   </metadata>
 

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/NugetComparisonBOM.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/NugetComparisonBOM.json
@@ -42,23 +42,23 @@
       "Components": null,
       "Properties": [
         {
-          "Name": "internal",
+          "Name": "internal:siemens:clearing:development",
           "Value": "false"
         },
         {
-          "Name": "ArtifactoryRepoName",
+          "Name": "internal:siemens:clearing:repo-name",
           "Value": "siparty-release-nuget-egll"
         },
         {
-          "Name": "ProjectType",
+          "Name": "internal:siemens:clearing:project-type",
           "Value": "NUGET"
         },
         {
-          "Name": "ApprovedStatus",
+          "Name": "internal:siemens:clearing:clearing-state",
           "Value": "APPROVED"
         },
         {
-          "Name": "ReleaseLink",
+          "Name": "internal:siemens:clearing:sw360:release-url",
           "Value": "http://localhost:8090/resource/api/releases/48fe0619e8f64cc3a5c1563bf15e6240"
         }
       ],
@@ -87,23 +87,23 @@
       "Components": null,
       "Properties": [
         {
-          "Name": "internal",
+          "Name": "internal:siemens:clearing:development",
           "Value": "false"
         },
         {
-          "Name": "ArtifactoryRepoName",
+          "Name": "internal:siemens:clearing:repo-name",
           "Value": "siparty-release-nuget-egll"
         },
         {
-          "Name": "ProjectType",
+          "Name": "internal:siemens:clearing:project-type",
           "Value": "NUGET"
         },
         {
-          "Name": "ApprovedStatus",
+          "Name": "internal:siemens:clearing:clearing-state",
           "Value": "Not Available"
         },
         {
-          "Name": "ReleaseLink",
+          "Name": "internal:siemens:clearing:sw360:release-url",
           "Value": "http://localhost:8090/resource/api/releases/eb5f54a94a544138a86bc423d66a4bb1"
         }
       ],

--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -207,36 +207,20 @@ Currently LTA support is not provided for SBOM, hence until that is implemented 
           * Input file repository should contain **conan.lock** file. 
 		  
     
-      - **Project Type :**  **Debian** 
+      - **Project Type :**  **Debian & Alpine** 
        
    	      **Note** : below steps is required only if you have `tar` file to process , otherwise you can keep `CycloneDx.json` file in the InputDirectory.
           *  Create `InputImage` directory for keeping `tar` images and `InputDirectory` for resulted file storing .
 
           *  Run the command given below by replacing the place holder values (i.e., path to input image directory, path to input directory and file name of the Debian image to be cleared) with actual values.
             
-              **Example**:   `docker run --rm -v <path/to/InputImageDirectory>:/tmp/InputImages -v <path/to/InputDirectory>:/tmp/OutputFiles ghcr.io/siemens/continuous-clearing ./syft packages /tmp/InputImages/<fileNameofthedebianImageTobeCleared.tar> -o cyclonedx-json --file "/tmp/OutputFiles/output.json"`
+              **Example**:   `docker run --rm -v <path/to/InputImageDirectory>:/tmp/InputImages -v <path/to/InputDirectory>:/tmp/OutputFiles ghcr.io/siemens/continuous-clearing ./syft packages /tmp/InputImages/<fileNameoftheImageTobeCleared.tar> -o cyclonedx-json --file "/tmp/OutputFiles/output.json"`
            
            
              After successful execution, `output.json` (_CycloneDX.json_) file will be created in specified directory
            
              ![image.png](../usagedocimg/output.PNG)
            
-             Resulted `output.json` file will be having the list of installed packages  and the same file will be used as  an input to `Continuous clearing tool - Bom creator` as an argument(`--packagefilepath`). The remaining process is same as other project types.
-      - **Project Type :**  **Alpine** 
-
-   	      **Note** : below steps is required only if you have `tar` file to process , otherwise you can keep `CycloneDx.json` file in the InputDirectory.
-   	`       
-          *  Create `InputImage` directory for keeping `tar` images and `InputDirectory` for resulted file storing .
-
-          *  Run the command given below by replacing the place holder values (i.e., path to input image directory, path to input directory and file name of the Alpine image to be cleared) with actual values.
-
-              **Example**:   `docker run --rm -v <path/to/InputImageDirectory>:/tmp/InputImages -v <path/to/InputDirectory>:/tmp/OutputFiles ghcr.io/siemens/continuous-clearing ./syft packages /tmp/InputImages/<fileNameoftheAlpineImageTobeCleared.tar> -o cyclonedx-json --file "/tmp/OutputFiles/output.json"`
-
-
-             After successful execution, `output.json` (_CycloneDX.json_) file will be created in specified directory
-
-             ![image.png](../usagedocimg/output.PNG)
-
              Resulted `output.json` file will be having the list of installed packages  and the same file will be used as  an input to `Continuous clearing tool - Bom creator` as an argument(`--packagefilepath`). The remaining process is same as other project types.
 
 ### **Configuring the Continuous Clearing Tool**
@@ -253,7 +237,7 @@ Currently LTA support is not provided for SBOM, hence until that is implemented 
  
 ```
 {
-  "CaVersion": "4.0.0",
+  "CaVersion": "6.2.0",
   "TimeOut": 200,
   "ProjectType": "<Insert ProjectType>",
   "SW360ProjectName": "<Insert SW360 Project Name>",
@@ -563,4 +547,4 @@ For reporting any bug or enhancement and for your feedbacks click [here](https:/
 - SW360 API Guide : [https://www.eclipse.org/sw360/docs/development/restapi/dev-rest-api/](https://www.eclipse.org/sw360/docs/development/restapi/dev-rest-api/)
 - FOSSology API Guide: [https://www.fossology.org/get-started/basic-rest-api-calls/](https://www.fossology.org/get-started/basic-rest-api-calls/)
 
-Copyright © Siemens AG ▪ 2023
+Copyright © Siemens AG ▪ 2024

--- a/src/AritfactoryUploader.UTest/ArtifactoryUploaderTest.cs
+++ b/src/AritfactoryUploader.UTest/ArtifactoryUploaderTest.cs
@@ -21,6 +21,7 @@ using LCT.Facade;
 using LCT.Services.Interface;
 using LCT.Services;
 using UnitTestUtilities;
+using LCT.ArtifactoryUploader.Model;
 
 namespace AritfactoryUploader.UTest
 {
@@ -42,6 +43,7 @@ namespace AritfactoryUploader.UTest
                 JFrogApi = UTParams.JFrogURL
             };
             ArtfactoryUploader.jFrogService = GetJfrogService(appSettings);
+            DisplayPackagesInfo displayPackagesInfo = PackageUploadHelper.GetComponentsToBePackages();
             var componentsToArtifactory = new ComponentsToArtifactory
             {
                 Name = "html5lib",
@@ -63,7 +65,7 @@ namespace AritfactoryUploader.UTest
             };
 
             //Act
-            var responseMessage = await ArtfactoryUploader.UploadPackageToRepo(componentsToArtifactory, 100);
+            var responseMessage = await ArtfactoryUploader.UploadPackageToRepo(componentsToArtifactory, 100, displayPackagesInfo);
             Assert.AreEqual(HttpStatusCode.NotFound, responseMessage.StatusCode);
             Assert.AreEqual("Package Not Found", responseMessage.ReasonPhrase);
 

--- a/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
+++ b/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
@@ -16,6 +16,7 @@ using System.IO;
 using UnitTestUtilities;
 using System.Threading.Tasks;
 using System.Linq;
+using LCT.ArtifactoryUploader.Model;
 
 namespace AritfactoryUploader.UTest
 {
@@ -64,6 +65,7 @@ namespace AritfactoryUploader.UTest
             List<Component> componentLists = GetComponentList();
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string outFolder = Path.GetDirectoryName(exePath);
+            DisplayPackagesInfo displayPackagesInfo = PackageUploadHelper.GetComponentsToBePackages();
             CommonAppSettings appSettings = new CommonAppSettings()
             {
                 ArtifactoryUploadApiKey = "wfwfwfwfwegwgweg",
@@ -76,7 +78,7 @@ namespace AritfactoryUploader.UTest
             };
 
             //Act
-            List<ComponentsToArtifactory> uploadList = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings);
+            List<ComponentsToArtifactory> uploadList = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings, displayPackagesInfo);
             // Assert
             Assert.That(3, Is.EqualTo(uploadList.Count), "Checks for 2  no of components to upload");
         }
@@ -87,6 +89,7 @@ namespace AritfactoryUploader.UTest
         {
             //Arrange
             List<Component> componentLists = GetComponentList();
+            DisplayPackagesInfo displayPackagesInfo = PackageUploadHelper.GetComponentsToBePackages();
             foreach (var component in componentLists)
             {
                 if (component.Name == "@angular/core")
@@ -108,7 +111,7 @@ namespace AritfactoryUploader.UTest
             };
 
             //Act
-            List<ComponentsToArtifactory> uploadList = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings);
+            List<ComponentsToArtifactory> uploadList = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings, displayPackagesInfo);
 
             // Assert
             Assert.That(4, Is.EqualTo(uploadList.Count), "Checks for 3 no of components to upload");
@@ -119,6 +122,7 @@ namespace AritfactoryUploader.UTest
         {
             //Arrange
             List<Component> componentLists = GetComponentList();
+            DisplayPackagesInfo displayPackagesInfo = PackageUploadHelper.GetComponentsToBePackages();
             foreach (var component in componentLists)
             {
                 component.Properties[1].Value = "NEW_CLEARING";
@@ -136,7 +140,7 @@ namespace AritfactoryUploader.UTest
             };
 
             //Act
-            List<ComponentsToArtifactory> uploadList =await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings);
+            List<ComponentsToArtifactory> uploadList =await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(componentLists, appSettings, displayPackagesInfo);
 
             // Assert
             Assert.That(0, Is.EqualTo(uploadList.Count), "Checks for components to upload to be zero");

--- a/src/AritfactoryUploader.UTest/PackageUploaderTest.cs
+++ b/src/AritfactoryUploader.UTest/PackageUploaderTest.cs
@@ -20,6 +20,10 @@ using LCT.APICommunications;
 using LCT.Facade.Interfaces;
 using LCT.Facade;
 using LCT.Services;
+using CycloneDX.Models;
+using LCT.Common.Constants;
+using LCT.Common.Model;
+using System.Collections.Generic;
 
 namespace AritfactoryUploader.UTest
 {
@@ -68,6 +72,89 @@ namespace AritfactoryUploader.UTest
             Assert.That(10, Is.EqualTo(PackageUploader.uploaderKpiData.PackagesNotExistingInRemoteCache), "Checks for no of components not present in remote cache");
             Assert.That(2, Is.EqualTo(PackageUploader.uploaderKpiData.PackagesNotUploadedDueToError), "Checks for no of components not uploaded due to error");
         }
+
+        [Test]
+        public void DisplayAllSettings_GivenListOfComponents_ReturnPackageSettings()
+        {
+            //Arrange
+            CommonAppSettings CommonAppSettings = new CommonAppSettings()
+            {
+
+                JFrogApi = UTParams.JFrogURL,
+                Npm = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "npm-test",
+                    JfrogDevDestRepoName = "npm-test",
+                    JfrogInternalDestRepoName = "npm-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                Conan = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "conan-test",
+                    JfrogDevDestRepoName = "conan-test",
+                    JfrogInternalDestRepoName = "conan-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                Nuget = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "nuget-test",
+                    JfrogDevDestRepoName = "nuget-test",
+                    JfrogInternalDestRepoName = "nuget-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                Python = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "python-test",
+                    JfrogDevDestRepoName = "python-test",
+                    JfrogInternalDestRepoName = "python-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                Maven = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "maven-test",
+                    JfrogDevDestRepoName = "maven-test",
+                    JfrogInternalDestRepoName = "maven-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                Debian = new Config
+                {
+                    JfrogThirdPartyDestRepoName = "debian-test",
+                    JfrogDevDestRepoName = "debian-test",
+                    JfrogInternalDestRepoName = "debian-test",
+                    Include = { },
+                    Exclude = { },
+                },
+                TimeOut = 100,
+                Release = false
+            };
+            List<Component> m_ComponentsInBOM = new()
+            {
+                new Component {
+                Name="test",
+                Version="1.0.0",
+                Properties=new List<Property>()
+                {
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="NPM"},
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="CONAN"},
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="NUGET"},
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="MAVEN"},
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="DEBIAN"},
+                new Property{Name=Dataconstant.Cdx_ProjectType,Value="PYTHON"}
+                }
+            }
+            };
+            //Act
+            PackageUploader.DisplayAllSettings(m_ComponentsInBOM, CommonAppSettings);
+
+            //Assert
+            Assert.IsTrue(true);
+        }
+
 
 
         private static IJFrogService GetJfrogService(CommonAppSettings appSettings)

--- a/src/ArtifactoryUploader/ArtifactoryUploader.cs
+++ b/src/ArtifactoryUploader/ArtifactoryUploader.cs
@@ -8,6 +8,7 @@ using LCT.APICommunications;
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;
 using LCT.APICommunications.Model.AQL;
+using LCT.ArtifactoryUploader.Model;
 using LCT.Services.Interface;
 using log4net;
 using System;
@@ -28,7 +29,7 @@ namespace LCT.ArtifactoryUploader
         private static string srcRepoName = Environment.GetEnvironmentVariable("JfrogSrcRepo");
         public static IJFrogService jFrogService { get; set; }
 
-        public static async Task<HttpResponseMessage> UploadPackageToRepo(ComponentsToArtifactory component, int timeout)
+        public static async Task<HttpResponseMessage> UploadPackageToRepo(ComponentsToArtifactory component, int timeout, DisplayPackagesInfo displayPackagesInfo)
         {
             Logger.Debug("Starting UploadPackageToArtifactory method");
             string operationType = component.PackageType == PackageType.ClearedThirdParty || component.PackageType == PackageType.Development ? "copy" : "move";
@@ -77,8 +78,7 @@ namespace LCT.ArtifactoryUploader
                     return responsemessage;
                 }
 
-                Logger.Info($"Successful{dryRunSuffix} {operationType} package {component.PackageName}-{component.Version}" +
-                                    $" from {component.SrcRepoName} to {component.DestRepoName}");
+                await PackageUploadHelper.JfrogFoundPackagesAsync(component, displayPackagesInfo, operationType, responsemessage, dryRunSuffix);
 
             }
             catch (HttpRequestException ex)

--- a/src/ArtifactoryUploader/ArtifactoryValidator.cs
+++ b/src/ArtifactoryUploader/ArtifactoryValidator.cs
@@ -20,8 +20,6 @@ namespace LCT.ArtifactoryUploader
 {
     public class ArtifactoryValidator
     {
-        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
         private readonly NpmJfrogApiCommunication JfrogApiCommunication;
 
         public ArtifactoryValidator(NpmJfrogApiCommunication jfrogApiCommunication)

--- a/src/ArtifactoryUploader/ArtifactoryValidator.cs
+++ b/src/ArtifactoryUploader/ArtifactoryValidator.cs
@@ -14,6 +14,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Net;
+using System;
 
 namespace LCT.ArtifactoryUploader
 {
@@ -30,13 +31,18 @@ namespace LCT.ArtifactoryUploader
 
         public async Task ValidateArtifactoryCredentials(CommonAppSettings appSettings)
         {
-            HttpResponseMessage responseMessage = await JfrogApiCommunication.GetApiKey();
-
-            if (responseMessage.StatusCode != HttpStatusCode.OK)
+            HttpResponseMessage responseMessage = new HttpResponseMessage();
+            try
             {
-                Logger.Error("Artifactory Token entered is invalid!");
-                throw new InvalidDataException($"Invalid Artifactory Token");
+                responseMessage = await JfrogApiCommunication.GetApiKey();
+                responseMessage.EnsureSuccessStatusCode();
             }
+            catch(HttpRequestException ex)
+            {
+                ExceptionHandling.HttpException(ex,responseMessage, "Artifactory");
+                Environment.Exit(-1);
+            }
+           
         }
     }
 }

--- a/src/ArtifactoryUploader/Model/DisplayPackagesInfo.cs
+++ b/src/ArtifactoryUploader/Model/DisplayPackagesInfo.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+using LCT.APICommunications.Model;
+using System.Collections.Generic;
+
+namespace LCT.ArtifactoryUploader.Model
+{
+    /// <summary>
+    /// The Model class for UnkmownPackagesAll
+    /// </summary>
+    public class DisplayPackagesInfo
+    {
+        public List<ComponentsToArtifactory> UnknownPackagesNpm { get; set; }
+        public List<ComponentsToArtifactory> UnknownPackagesNuget { get; set; }
+        public List<ComponentsToArtifactory> UnknownPackagesConan { get; set; }
+        public List<ComponentsToArtifactory> UnknownPackagesPython { get; set; }
+        public List<ComponentsToArtifactory> UnknownPackagesDebian { get; set; }
+        public List<ComponentsToArtifactory> UnknownPackagesMaven { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesNpm { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesNuget { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesConan { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesPython { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesDebian { get; set; }
+        public List<ComponentsToArtifactory> JfrogNotFoundPackagesMaven { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesNpm { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesNuget { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesConan { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesPython { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesDebian { get; set; }
+        public List<ComponentsToArtifactory> JfrogFoundPackagesMaven { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesNpm { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesNuget { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesConan { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesPython { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesDebian { get; set; }
+        public List<ComponentsToArtifactory> SuccessfullPackagesMaven { get; set; }
+
+    }
+}

--- a/src/ArtifactoryUploader/PackageUploadHelper.cs
+++ b/src/ArtifactoryUploader/PackageUploadHelper.cs
@@ -64,7 +64,7 @@ namespace LCT.ArtifactoryUploader
             return componentsToBoms;
         }
 
-        public async static Task<List<ComponentsToArtifactory>> GetComponentsToBeUploadedToArtifactory(List<Component> comparisonBomData, CommonAppSettings appSettings)
+        public async static Task<List<ComponentsToArtifactory>> GetComponentsToBeUploadedToArtifactory(List<Component> comparisonBomData, CommonAppSettings appSettings, DisplayPackagesInfo displayPackagesInfo)
         {
             Logger.Debug("Starting GetComponentsToBeUploadedToArtifactory() method");
             List<ComponentsToArtifactory> componentsToBeUploaded = new List<ComponentsToArtifactory>();
@@ -112,12 +112,333 @@ namespace LCT.ArtifactoryUploader
                 {
                     PackageUploader.uploaderKpiData.ComponentNotApproved++;
                     PackageUploader.uploaderKpiData.PackagesNotUploadedToJfrog++;
-                    Logger.Warn($"Package {item.Name}-{item.Version} is not in report approved state,hence artifactory upload will not be done!");
+                    await AddUnknownPackagesAsync(item, displayPackagesInfo);
                 }               
             }
             Logger.Debug("Ending GetComponentsToBeUploadedToArtifactory() method");
             return componentsToBeUploaded;
         }
+
+        public static DisplayPackagesInfo GetComponentsToBePackages()
+        {
+            DisplayPackagesInfo displayPackagesInfo = new DisplayPackagesInfo();
+            displayPackagesInfo.UnknownPackagesNpm = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.UnknownPackagesNuget = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.UnknownPackagesMaven = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.UnknownPackagesConan = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.UnknownPackagesPython = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.UnknownPackagesDebian = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesNpm = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesNuget = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesPython = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesMaven = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesConan = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogNotFoundPackagesDebian = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesNpm = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesNuget = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesPython = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesMaven = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesConan = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.JfrogFoundPackagesDebian = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesNpm = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesNuget = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesPython = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesMaven = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesConan = new List<ComponentsToArtifactory>();
+            displayPackagesInfo.SuccessfullPackagesDebian = new List<ComponentsToArtifactory>();
+
+
+            return displayPackagesInfo;
+
+        }
+
+        private static void DisplaySortedForeachComponents(List<ComponentsToArtifactory> unknownPackages, List<ComponentsToArtifactory> JfrogNotFoundPackages, List<ComponentsToArtifactory> SucessfullPackages, List<ComponentsToArtifactory> JfrogFoundPackages, string name)
+        {
+            if (unknownPackages.Any() || JfrogNotFoundPackages.Any() || SucessfullPackages.Any() || JfrogFoundPackages.Any())
+            {
+                Logger.Info("\n" + name + "\n");
+                DisplayErrorForUnknownPackages(unknownPackages);
+                DisplayErrorForJfrogFoundPackages(JfrogFoundPackages);
+                DisplayErrorForJfrogPackages(JfrogNotFoundPackages);
+                DisplayErrorForSucessfullPackages(SucessfullPackages);
+            }
+
+        }
+
+        private static void DisplayErrorForJfrogFoundPackages(List<ComponentsToArtifactory> JfrogFoundPackages)
+        {
+
+            if (JfrogFoundPackages.Any())
+            {
+
+                foreach (var jfrogFoundPackage in JfrogFoundPackages)
+                {
+                    Logger.Info($"Successful{jfrogFoundPackage.DryRunSuffix} {jfrogFoundPackage.OperationType} package {jfrogFoundPackage.PackageName}-{jfrogFoundPackage.Version}" +
+                   $" from {jfrogFoundPackage.SrcRepoName} to {jfrogFoundPackage.DestRepoName}");
+
+                    if (jfrogFoundPackage.ResponseMessage.ReasonPhrase == ApiConstant.ErrorInUpload)
+                    {
+                        Logger.Error($"Package {jfrogFoundPackage.Name}-{jfrogFoundPackage.Version} {jfrogFoundPackage.OperationType} Failed!! {jfrogFoundPackage.SrcRepoName} ---> {jfrogFoundPackage.DestRepoName}");
+                    }
+                    else if (jfrogFoundPackage.ResponseMessage.ReasonPhrase == ApiConstant.PackageNotFound)
+                    {
+                        Logger.Error($"Package {jfrogFoundPackage.Name}-{jfrogFoundPackage.Version} not found in {jfrogFoundPackage.SrcRepoName}, Upload Failed!!");
+                    }
+
+                }
+                Logger.Info("\n");
+
+            }
+        }
+
+        private static void DisplayErrorForJfrogPackages(List<ComponentsToArtifactory> JfrogNotFoundPackages)
+        {
+
+            if (JfrogNotFoundPackages.Any())
+            {
+
+                foreach (var jfrogNotFoundPackage in JfrogNotFoundPackages)
+                {
+                    Logger.Warn($"Package {jfrogNotFoundPackage.Name}-{jfrogNotFoundPackage.Version} is not found in jfrog");
+
+                }
+                Logger.Info("\n");
+
+            }
+        }
+        private static void DisplayErrorForUnknownPackages(List<ComponentsToArtifactory> unknownPackages)
+        {
+
+            if (unknownPackages.Any())
+            {
+
+                foreach (var unknownPackage in unknownPackages)
+                {
+                    Logger.Warn($"Package {unknownPackage.Name}-{unknownPackage.Version} is not in report approved state,hence artifactory upload will not be done!");
+                }
+                Logger.Info("\n");
+
+            }
+        }
+        private static void DisplayErrorForSucessfullPackages(List<ComponentsToArtifactory> SucessfullPackages)
+        {
+
+            if (SucessfullPackages.Any())
+            {
+
+                foreach (var sucessfullPackage in SucessfullPackages)
+                {
+                    Logger.Info($"Package {sucessfullPackage.Name}-{sucessfullPackage.Version} is already uploaded");
+                }
+                Logger.Info("\n");
+
+            }
+        }
+        public static void DisplayPackageUploadInformation(DisplayPackagesInfo displayPackagesInfo)
+        {
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesNpm, displayPackagesInfo.JfrogNotFoundPackagesNpm, displayPackagesInfo.SuccessfullPackagesNpm, displayPackagesInfo.JfrogFoundPackagesNpm, "NPM:");
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesNuget, displayPackagesInfo.JfrogNotFoundPackagesNuget, displayPackagesInfo.SuccessfullPackagesNuget, displayPackagesInfo.JfrogFoundPackagesNuget, "Nuget:");
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesMaven, displayPackagesInfo.JfrogNotFoundPackagesMaven, displayPackagesInfo.SuccessfullPackagesMaven, displayPackagesInfo.JfrogFoundPackagesMaven, "Maven:");
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesConan, displayPackagesInfo.JfrogNotFoundPackagesConan, displayPackagesInfo.SuccessfullPackagesConan, displayPackagesInfo.JfrogFoundPackagesConan, "Conan:");
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesPython, displayPackagesInfo.JfrogNotFoundPackagesPython, displayPackagesInfo.SuccessfullPackagesPython, displayPackagesInfo.JfrogFoundPackagesPython, "Python:");
+            DisplaySortedForeachComponents(displayPackagesInfo.UnknownPackagesDebian, displayPackagesInfo.JfrogNotFoundPackagesDebian, displayPackagesInfo.SuccessfullPackagesDebian, displayPackagesInfo.JfrogFoundPackagesDebian, "Debian:");
+
+        }
+
+        private static Task<ComponentsToArtifactory> GetUnknownPackageinfo(Component item)
+        {
+
+            ComponentsToArtifactory components = new ComponentsToArtifactory()
+            {
+                Name = item.Name,
+                Version = item.Version
+            };
+            return Task.FromResult(components);
+
+        }
+
+        private static Task<ComponentsToArtifactory> GetPackageinfo(ComponentsToArtifactory item, string operationType, HttpResponseMessage responseMessage, string dryRunSuffix)
+        {
+
+            ComponentsToArtifactory components = new ComponentsToArtifactory()
+            {
+                Name = item.Name,
+                Version = item.Version,
+                SrcRepoName = item.SrcRepoName,
+                DestRepoName = item.DestRepoName,
+                OperationType = operationType,
+                ResponseMessage = responseMessage,
+                DryRunSuffix = dryRunSuffix
+
+            };
+            return Task.FromResult(components);
+
+        }
+        private static Task<ComponentsToArtifactory> GetSucessFulPackageinfo(ComponentsToArtifactory item)
+        {
+
+            ComponentsToArtifactory components = new ComponentsToArtifactory()
+            {
+               Name = item.Name,
+                Version = item.Version,
+
+            };
+            return Task.FromResult(components);
+
+        }
+
+        private static async Task AddUnknownPackagesAsync(Component item, DisplayPackagesInfo displayPackagesInfo)
+        {
+            string GetPropertyValue(string propertyName) =>
+                  item.Properties
+                      .Find(p => p.Name == propertyName)?
+                      .Value?
+                      .ToUpperInvariant();
+
+            if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "NPM")
+            {
+
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesNpm.Add(components);
+            }
+            else if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "NUGET")
+            {
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesNuget.Add(components);
+            }
+            else if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "MAVEN")
+            {
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesPython.Add(components);
+            }
+            else if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "PYTHON")
+            {
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesMaven.Add(components);
+            }
+            else if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "CONAN")
+            {
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesConan.Add(components);
+            }
+            else if (GetPropertyValue(Dataconstant.Cdx_ProjectType) == "DEBIAN")
+            {
+                ComponentsToArtifactory components = await GetUnknownPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesDebian.Add(components);
+            }
+
+        }
+
+        private static async Task JfrogNotFoundPackagesAsync(ComponentsToArtifactory item, DisplayPackagesInfo displayPackagesInfo)
+        {
+
+            if (item.ComponentType == "NPM")
+            {
+
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesNpm.Add(components);
+            }
+            else if (item.ComponentType == "NUGET")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesNuget.Add(components);
+            }
+            else if (item.ComponentType == "MAVEN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesMaven.Add(components);
+            }
+            else if (item.ComponentType == "PYTHON")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesPython.Add(components);
+            }
+            else if (item.ComponentType == "CONAN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesConan.Add(components);
+            }
+            else if (item.ComponentType == "DEBIAN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.JfrogNotFoundPackagesDebian.Add(components);
+            }
+
+        }
+
+        public static async Task JfrogFoundPackagesAsync(ComponentsToArtifactory item, DisplayPackagesInfo displayPackagesInfo, string operationType, HttpResponseMessage responseMessage, string dryRunSuffix)
+        {
+
+            if (item.ComponentType == "NPM")
+            {
+
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesNpm.Add(components);
+            }
+            else if (item.ComponentType == "NUGET")
+            {
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesNuget.Add(components);
+            }
+            else if (item.ComponentType == "MAVEN")
+            {
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesMaven.Add(components);
+            }
+            else if (item.ComponentType == "PYTHON")
+            {
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesPython.Add(components);
+            }
+            else if (item.ComponentType == "CONAN")
+            {
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesConan.Add(components);
+            }
+            else if (item.ComponentType == "DEBIAN")
+            {
+                ComponentsToArtifactory components = await GetPackageinfo(item, operationType, responseMessage, dryRunSuffix);
+                displayPackagesInfo.JfrogFoundPackagesDebian.Add(components);
+            }
+
+        }
+        private static async Task SucessfullPackagesAsync(ComponentsToArtifactory item, DisplayPackagesInfo displayPackagesInfo)
+        {
+
+            if (item.ComponentType == "NPM")
+            {
+
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.SuccessfullPackagesNpm.Add(components);
+            }
+            else if (item.ComponentType == "NUGET")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.SuccessfullPackagesNuget.Add(components);
+            }
+            else if (item.ComponentType == "MAVEN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.SuccessfullPackagesMaven.Add(components);
+            }
+            else if (item.ComponentType == "PYTHON")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.UnknownPackagesPython.Add(components);
+            }
+            else if (item.ComponentType == "CONAN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.SuccessfullPackagesConan.Add(components);
+            }
+            else if (item.ComponentType == "DEBIAN")
+            {
+                ComponentsToArtifactory components = await GetSucessFulPackageinfo(item);
+                displayPackagesInfo.SuccessfullPackagesDebian.Add(components);
+            }
+
+        }
+
 
         private static PackageType GetPackageType(Component item)
         {
@@ -388,12 +709,12 @@ namespace LCT.ArtifactoryUploader
             return null;
         }
 
-        public static async Task UploadingThePackages(List<ComponentsToArtifactory> componentsToUpload, int timeout)
+        public static async Task UploadingThePackages(List<ComponentsToArtifactory> componentsToUpload, int timeout, DisplayPackagesInfo displayPackagesInfo)
         {
             Logger.Debug("Starting UploadingThePackages() method");
             foreach (var item in componentsToUpload)
             {
-                await PackageUploadToArtifactory(PackageUploader.uploaderKpiData, item, timeout);
+                await PackageUploadToArtifactory(PackageUploader.uploaderKpiData, item, timeout, displayPackagesInfo);
             }
 
             if (SetWarningCode)
@@ -406,7 +727,7 @@ namespace LCT.ArtifactoryUploader
             Program.UploaderStopWatch?.Stop();
         }
 
-        private static async Task PackageUploadToArtifactory(UploaderKpiData uploaderKpiData, ComponentsToArtifactory item, int timeout)
+        private static async Task PackageUploadToArtifactory(UploaderKpiData uploaderKpiData, ComponentsToArtifactory item, int timeout, DisplayPackagesInfo displayPackagesInfo)
         {
             var packageType = item.PackageType;
 
@@ -414,46 +735,52 @@ namespace LCT.ArtifactoryUploader
             {
                 if (!(item.SrcRepoName.Contains("Not Found in JFrog")))
                 {
-                    string operationType = item.PackageType == PackageType.ClearedThirdParty || item.PackageType == PackageType.Development ? "copy" : "move";
-                    ArtfactoryUploader.jFrogService = jFrogService;
-                    HttpResponseMessage responseMessage = await ArtfactoryUploader.UploadPackageToRepo(item, timeout);
-
-                    if (responseMessage.StatusCode == HttpStatusCode.OK && !item.DryRun)
-                    {
-                        IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, true);
-                    }
-                    else if (responseMessage.ReasonPhrase == ApiConstant.PackageNotFound)
-                    {
-                        Logger.Error($"Package {item.Name}-{item.Version} not found in {item.SrcRepoName}, Upload Failed!!");
-                        IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, false);
-                        item.DestRepoName = null;
-                        SetWarningCode = true;
-                    }
-                    else if (responseMessage.ReasonPhrase == ApiConstant.ErrorInUpload)
-                    {
-                        Logger.Error($"Package {item.Name}-{item.Version} {operationType} Failed!! {item.SrcRepoName} ---> {item.DestRepoName}");
-                        IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, false);
-                        item.DestRepoName = null;
-                        var responseContent = await responseMessage.Content.ReadAsStringAsync();
-                        Logger.Debug($"JFrog Response - {responseContent}");
-                    }
-                    else
-                    {
-                        // do nothing
-                    }
+                    await SourceRepoFoundToUploadArtifactory(packageType, uploaderKpiData, item, timeout, displayPackagesInfo);
                 }
                 else
                 {
                     uploaderKpiData.PackagesNotExistingInRemoteCache++;
                     item.DestRepoName = null;
-                    Logger.Warn($"Package {item.Name}-{item.Version} is not found in jfrog");
+                    await JfrogNotFoundPackagesAsync(item, displayPackagesInfo);
                 }
             }
             else
             {
                 IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, true);
-                Logger.Info($"Package {item.Name}-{item.Version} is already uploaded");
+                await SucessfullPackagesAsync(item, displayPackagesInfo);
                 item.DestRepoName = null;
+            }
+        }
+
+        private static async Task SourceRepoFoundToUploadArtifactory(PackageType packageType, UploaderKpiData uploaderKpiData, ComponentsToArtifactory item, int timeout, DisplayPackagesInfo displayPackagesInfo)
+        {
+            const string dryRunSuffix = null;
+            string operationType = item.PackageType == PackageType.ClearedThirdParty || item.PackageType == PackageType.Development ? "copy" : "move";
+            ArtfactoryUploader.jFrogService = jFrogService;
+            HttpResponseMessage responseMessage = await ArtfactoryUploader.UploadPackageToRepo(item, timeout, displayPackagesInfo);
+
+            if (responseMessage.StatusCode == HttpStatusCode.OK && !item.DryRun)
+            {
+                IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, true);
+            }
+            else if (responseMessage.ReasonPhrase == ApiConstant.PackageNotFound)
+            {
+                await JfrogFoundPackagesAsync(item, displayPackagesInfo, operationType, responseMessage, dryRunSuffix);
+                IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, false);
+                item.DestRepoName = null;
+                SetWarningCode = true;
+            }
+            else if (responseMessage.ReasonPhrase == ApiConstant.ErrorInUpload)
+            {
+                await JfrogFoundPackagesAsync(item, displayPackagesInfo, operationType, responseMessage, dryRunSuffix);
+                IncrementCountersBasedOnPackageType(uploaderKpiData, packageType, false);
+                item.DestRepoName = null;
+                var responseContent = await responseMessage.Content.ReadAsStringAsync();
+                Logger.Debug($"JFrog Response - {responseContent}");
+            }
+            else
+            {
+                // do nothing
             }
         }
 

--- a/src/ArtifactoryUploader/PackageUploader.cs
+++ b/src/ArtifactoryUploader/PackageUploader.cs
@@ -17,6 +17,8 @@ using LCT.Common;
 using System.Linq;
 using LCT.Common.Constants;
 using System.IO;
+using LCT.Common.Model;
+using log4net.Core;
 
 namespace LCT.ArtifactoryUploader
 {
@@ -34,16 +36,23 @@ namespace LCT.ArtifactoryUploader
 
             Bom m_ComponentsInBOM = PackageUploadHelper.GetComponentListFromComparisonBOM(appSettings.BomFilePath);
 
+            DisplayAllSettings(m_ComponentsInBOM.Components, appSettings);
             uploaderKpiData.ComponentInComparisonBOM = m_ComponentsInBOM.Components.Count;
 
-            List<ComponentsToArtifactory> m_ComponentsToBeUploaded = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(m_ComponentsInBOM.Components, appSettings);
+            DisplayPackagesInfo displayPackagesInfo = PackageUploadHelper.GetComponentsToBePackages();
+
+            List<ComponentsToArtifactory> m_ComponentsToBeUploaded = await PackageUploadHelper.GetComponentsToBeUploadedToArtifactory(m_ComponentsInBOM.Components, appSettings, displayPackagesInfo);
             //Uploading the component to artifactory
 
             uploaderKpiData.PackagesToBeUploaded = m_ComponentsToBeUploaded.Count(x => x.PackageType == PackageType.ClearedThirdParty);
             uploaderKpiData.DevPackagesToBeUploaded = m_ComponentsToBeUploaded.Count(x => x.PackageType == PackageType.Development);
             uploaderKpiData.InternalPackagesToBeUploaded = m_ComponentsToBeUploaded.Count(x => x.PackageType == PackageType.Internal);
 
-            await PackageUploadHelper.UploadingThePackages(m_ComponentsToBeUploaded, appSettings.TimeOut);
+            await PackageUploadHelper.UploadingThePackages(m_ComponentsToBeUploaded, appSettings.TimeOut, displayPackagesInfo);
+
+            //Display packages information 
+            PackageUploadHelper.DisplayPackageUploadInformation(displayPackagesInfo);
+
 
             //Updating the component's new location
             var fileOperations = new FileOperations();
@@ -59,11 +68,69 @@ namespace LCT.ArtifactoryUploader
             Logger.Debug($"UploadPackageToArtifactory():End");
 
             // set the error code
-            if(uploaderKpiData.PackagesNotUploadedDueToError > 0 || uploaderKpiData.PackagesNotExistingInRemoteCache > 0)
+            if (uploaderKpiData.PackagesNotUploadedDueToError > 0 || uploaderKpiData.PackagesNotExistingInRemoteCache > 0)
             {
                 Environment.ExitCode = 2;
                 Logger.Debug("Setting ExitCode to 2");
             }
+
+        }
+        public static void DisplayAllSettings(List<Component> m_ComponentsInBOM, CommonAppSettings appSettings)
+        {
+            Logger.Info("Current Application Settings:");
+            List<string> projectTypeList = new();
+            foreach (var item in m_ComponentsInBOM)
+            {
+
+                projectTypeList.Add(item.Properties.First(x => x.Name == Dataconstant.Cdx_ProjectType).Value);
+            }
+            var projectType = projectTypeList.Distinct().ToList();
+
+            for (int i = 0; i < projectType.Count; i++)
+            {
+                string type = projectType[i];
+                Logger.Info($"{projectType[i]}:\n\t");
+                switch (type.ToUpperInvariant())
+                {
+                    case "NPM":
+                        PackageSettings(appSettings.Npm);
+                        break;
+                    case "NUGET":
+                        PackageSettings(appSettings.Nuget);
+                        break;
+                    case "MAVEN":
+                        PackageSettings(appSettings.Maven);
+                        break;
+                    case "DEBIAN":
+                        PackageSettings(appSettings.Debian);
+                        break;
+                    case "PYTHON":
+                        PackageSettings(appSettings.Python);
+                        break;
+                    case "CONAN":
+                        PackageSettings(appSettings.Conan);
+                        break;
+
+                    default:
+                        Logger.Error($"DiplayAllSettings():Invalid ProjectType - {type}");
+                        break;
+                }
+
+            }
+
+        }
+
+        private static void PackageSettings(Config project)
+        {
+
+            Logger.Logger.Log(null, Level.Notice, $"\tDEVDEP_REPO_NAME:\t`{project.JfrogDevDestRepoName}`\n\t" +
+             $"THIRD_PARTY_REPO_NAME:\t`{project.JfrogThirdPartyDestRepoName}`\n\t" +
+             $"INTERNAL_REPO_NAME:\t`{project.JfrogInternalDestRepoName}`\n\t" +
+             $"Config:\n\t" +
+             $"Include: \t", null);
+            project.Include?.ToList().ForEach(x => Logger.Logger.Log(null, Level.Notice, $"\t\t\t\t`{x}`\t", null));
+            Logger.Logger.Log(null, Level.Notice, $"\tExclude:", null);
+            project.Exclude?.ToList().ForEach(x => Logger.Logger.Log(null, Level.Notice, $"\t\t\t\t`{x}`\n\t", null));
         }
     }
 }

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -43,6 +43,8 @@ namespace ArtifactoryUploader
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
             string FolderPath = InitiateLogger(appSettings);
 
+            settingsManager.CheckRequiredArgsToRun(appSettings, "Uploader");
+
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Artifactory Uploader >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Artifactory Uploader execution: {DateTime.Now}", null);
 

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -53,12 +53,13 @@ namespace ArtifactoryUploader
 
 
 
-            Logger.Logger.Log(null, Level.Notice, $"Input Parameters used in Artifactory Uploader:\n\t" +
-                $"BomFilePath\t\t --> {appSettings.BomFilePath}\n\t" +
-                $"JFrogUrl\t\t --> {appSettings.JFrogApi}\n\t" +
-                $"Artifactory User\t --> {appSettings.ArtifactoryUploadUser}\n\t" +
-                $"Release\t\t\t --> {appSettings.Release}\n\t" +
-                $"LogFolderPath\t\t --> {Path.GetFullPath(FolderPath)}", null);
+            Logger.Logger.Log(null, Level.Info, $"Input Parameters used in Artifactory Uploader:\n\t", null);
+            Logger.Logger.Log(null, Level.Notice, $"\tBomFilePath:\t\t  {appSettings.BomFilePath}\n\t" +
+                $"JFrogUrl:\t\t {appSettings.JFrogApi}\n\t" +
+                $"Artifactory User:\t {appSettings.ArtifactoryUploadUser}\n\t" +
+                $"Artifactory Token:\t {appSettings.ArtifactoryUploadApiKey}\n\t" +
+                $"Release:\t\t {appSettings.Release}\n\t" +
+                $"LogFolderPath:\t\t {Path.GetFullPath(FolderPath)}\n", null);
 
             //Validator method to check token validity
             ArtifactoryCredentials artifactoryCredentials = new ArtifactoryCredentials()

--- a/src/LCT.APICommunications.UTest/DebianJfrogAPICommunicationUTest.cs
+++ b/src/LCT.APICommunications.UTest/DebianJfrogAPICommunicationUTest.cs
@@ -1,0 +1,59 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+
+using LCT.APICommunications.Model;
+
+namespace LCT.APICommunications.UTest
+{
+    public class DebainJfrogAPICommunicationUTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            // Method intentionally left empty.
+        }
+
+        [Test]
+        public void DebainJfrogApiCommunication_CopyFromRemoteRepo_ReturnsInvalidOperationException()
+        {
+            //Arrange
+            ArtifactoryCredentials repoCredentials = new ArtifactoryCredentials();
+
+            //Act
+            JfrogApicommunication jfrogApicommunication = new DebianJfrogAPICommunication("", "", repoCredentials,100);
+
+            //Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await jfrogApicommunication.CopyFromRemoteRepo(new ComponentsToArtifactory()));
+        }
+
+        [Test]
+        public void DebainJfrogApiCommunication_UpdatePackagePropertiesInJfrog_ReturnsInvalidOperationException()
+        {
+            //Arrange
+            ArtifactoryCredentials repoCredentials = new ArtifactoryCredentials();
+
+            //Act
+            JfrogApicommunication jfrogApicommunication = new DebianJfrogAPICommunication("", "", repoCredentials, 100);
+
+            //Assert
+            Assert.ThrowsAsync<InvalidOperationException>(() => { jfrogApicommunication.UpdatePackagePropertiesInJfrog("", "", new UploadArgs()); return Task.CompletedTask; });
+        }
+
+        [Test]
+        public void DebainJfrogApiCommunication_GetPackageInfo_ReturnsInvalidOperationException()
+        {
+            //Arrange
+            ArtifactoryCredentials repoCredentials = new ArtifactoryCredentials();
+
+            //Act
+            JfrogApicommunication jfrogApicommunication = new DebianJfrogAPICommunication("", "", repoCredentials, 100);
+
+            //Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await jfrogApicommunication.GetPackageInfo(new ComponentsToArtifactory()));
+        }
+    }
+}

--- a/src/LCT.APICommunications/Interfaces/ISW360APICommunication.cs
+++ b/src/LCT.APICommunications/Interfaces/ISW360APICommunication.cs
@@ -33,7 +33,7 @@ namespace LCT.APICommunications.Interfaces
         Task<string> GetReleaseByCompoenentName(string componentName);
         Task<HttpResponseMessage> CreateRelease(Releases createReleaseContent);
         Task<HttpResponseMessage> CreateComponent(CreateComponent createComponentContent);
-        Task<HttpResponseMessage> LinkReleasesToProject(string[] releaseidArray, string sw360ProjectId);
+        Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId);
         Task<HttpResponseMessage> UpdateLinkedRelease(string projectId, string releaseId, UpdateLinkedRelease updateLinkedRelease);
         Task<HttpResponseMessage> UpdateRelease(string releaseId, HttpContent httpContent);
         Task<HttpResponseMessage> UpdateComponent(string componentId, HttpContent httpContent);

--- a/src/LCT.APICommunications/LCT.APICommunications.csproj
+++ b/src/LCT.APICommunications/LCT.APICommunications.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.Management.Automation" Version="7.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LCT.APICommunications/Model/AddLinkedRelease.cs
+++ b/src/LCT.APICommunications/Model/AddLinkedRelease.cs
@@ -4,21 +4,18 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+using Newtonsoft.Json;
+
 namespace LCT.APICommunications.Model
 {
-    /// <summary>
-    /// The ReleasesLinked info class
-    /// </summary>
+
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class ReleaseLinked
+    public class AddLinkedRelease
     {
-        public string Name { get; set; } = string.Empty;
+        [JsonProperty("releaseRelation")]
+        public string ReleaseRelation { get; set; }
 
-        public string Version { get; set; } = string.Empty;
-
-        public string ReleaseId { get; set; } = string.Empty;
-
-        public string Comment { get; set; } = string.Empty;
-        public string Relation {  get; set; } = string.Empty;
+        [JsonProperty("comment")]
+        public string Comment { get; set; }
     }
 }

--- a/src/LCT.APICommunications/Model/ComponentsToArtifactory.cs
+++ b/src/LCT.APICommunications/Model/ComponentsToArtifactory.cs
@@ -4,6 +4,8 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+using System.Net.Http;
+
 namespace LCT.APICommunications.Model
 {
 
@@ -30,5 +32,8 @@ namespace LCT.APICommunications.Model
         public bool DryRun { get; set; } = true;
         public string Purl { get; set; }
         public string JfrogPackageName { get;set; }
+        public string OperationType { get; set; }
+        public string DryRunSuffix { get; set; }
+        public HttpResponseMessage ResponseMessage { get; set; }
     }
 }

--- a/src/LCT.APICommunications/NpmJfrogAPICommunication.cs
+++ b/src/LCT.APICommunications/NpmJfrogAPICommunication.cs
@@ -5,6 +5,7 @@
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using LCT.APICommunications.Model;
+using LCT.Common;
 using log4net;
 using System;
 using System.Net.Http;
@@ -61,14 +62,14 @@ namespace LCT.APICommunications
             {
                 HttpClient httpClient = GetHttpClient(ArtifactoryCredentials);
                 result = await httpClient.GetAsync(component.PackageInfoApiUrl);
+                result.EnsureSuccessStatusCode();
             }
             catch (TaskCanceledException ex)
             {
                 Logger.Debug($"{ex.Message}");
-                Logger.Error("A timeout error is thrown from Jfrog server,Please wait for sometime and re run the pipeline again");
+                ExceptionHandling.TaskCancelledException(ex,"Jfrog");                
                 Environment.Exit(-1);
-
-            }
+            }           
             return result;
         }
 

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -104,13 +104,12 @@ namespace LCT.APICommunications
             string projectsByTagUrl = $"{sw360ProjectsApi}/{projectId}";
             try
             {
-
                 result = await httpClient.GetAsync(projectsByTagUrl);
                 result.EnsureSuccessStatusCode();
             }
             catch (HttpRequestException ex)
             {
-                ExceptionHandling.HttpException(ex,result,"SW360");
+                ExceptionHandling.HttpException(ex, result, "SW360");
                 Environment.Exit(-1);
             }
             catch (TaskCanceledException ex)

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -71,7 +71,6 @@ namespace LCT.APICommunications
                 Logger.Debug($"{ex.Message}");
                 Logger.Error("A timeout error is thrown from SW360 server,Please wait for sometime and re run the pipeline again");
                 Environment.Exit(-1);
-
             }
             return result;
         }
@@ -135,7 +134,6 @@ namespace LCT.APICommunications
                 Logger.Debug($"{ex.Message}");
                 Logger.Error("A timeout error is thrown from SW360 server,Please wait for sometime and re run the pipeline again");
                 Environment.Exit(-1);
-
             }
             return result;
         }

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -6,6 +6,7 @@
 
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;
+using LCT.Common;
 using LCT.Common.Model;
 using log4net;
 using Newtonsoft.Json;
@@ -105,11 +106,17 @@ namespace LCT.APICommunications
             {
 
                 result = await httpClient.GetAsync(projectsByTagUrl);
+                result.EnsureSuccessStatusCode();
+            }
+            catch (HttpRequestException ex)
+            {
+                ExceptionHandling.HttpException(ex,result,"SW360");
+                Environment.Exit(-1);
             }
             catch (TaskCanceledException ex)
             {
                 Logger.Debug($"{ex.Message}");
-                Logger.Error("A timeout error is thrown from SW360 server,Please wait for sometime and re run the pipeline again");
+                ExceptionHandling.TaskCancelledException(ex, "SW360");
                 Environment.Exit(-1);
 
             }

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -177,15 +177,11 @@ namespace LCT.APICommunications
             return await httpClient.GetAsync(releaseLink);
         }
 
-        public async Task<HttpResponseMessage> LinkReleasesToProject(string[] releaseidArray, string sw360ProjectId)
+        public async Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId)
         {
             HttpClient httpClient = GetHttpClient();
             string url = $"{sw360ProjectsApi}/{sw360ProjectId}/{ApiConstant.Releases}";
-
-            string releaseidList = JsonConvert.SerializeObject(releaseidArray);
-            HttpContent content = new StringContent(releaseidList, Encoding.UTF8, "application/json");
-
-            return await httpClient.PostAsync(url, content);
+            return await httpClient.PostAsync(url, httpContent);
         }
 
         public async Task<HttpResponseMessage> UpdateLinkedRelease(string projectId, string releaseId, UpdateLinkedRelease updateLinkedRelease)

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace LCT.Common
 {
@@ -24,6 +25,7 @@ namespace LCT.Common
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         public static string ProjectSummaryLink { get; set; }
 
+        #region public
         public static bool IsAzureDevOpsDebugEnabled()
         {
             string azureDevOpsDebug = System.Environment.GetEnvironmentVariable("System.Debug");
@@ -47,8 +49,8 @@ namespace LCT.Common
                     {
                         name = $"{component.Group}/{component.Name}";
                     }
-
-                    if (name.ToLowerInvariant() == excludedcomponent[0].ToLowerInvariant() && excludedcomponent.Length > 0 && (component.Version.ToLowerInvariant() == excludedcomponent[1].ToLowerInvariant() || excludedcomponent[1].ToLowerInvariant() == "*"))
+                    if (excludedcomponent.Length > 0 && (Regex.IsMatch(name.ToLowerInvariant(), WildcardToRegex(excludedcomponent[0].ToLowerInvariant()))) &&
+                        (component.Version.ToLowerInvariant().Contains(excludedcomponent[1].ToLowerInvariant())|| excludedcomponent[1].ToLowerInvariant() == "*"))
                     {
                         noOfExcludedComponents++;
                         ExcludedList.Add(component);
@@ -145,12 +147,6 @@ namespace LCT.Common
             }
         }
 
-        private static string Sw360URL(string sw360Env, string releaseId)
-        {
-            string sw360URL = $"{sw360Env}{"/group/guest/components/-/component/release/detailRelease/"}{releaseId}";
-            return sw360URL;
-        }
-
         public static void WriteComponentsWithoutDownloadURLToKpi(List<ComparisonBomData> componentInfo, List<Components> lstReleaseNotCreated, string sw360URL)
         {
             const string Name = "Name";
@@ -242,7 +238,23 @@ namespace LCT.Common
                 listComponentForBOM.Add(component);
             }
         }
+        #endregion
 
-        
+        #region private
+        private static string WildcardToRegex(string wildcard)
+        {
+            return "^" + Regex.Escape(wildcard).Replace("\\*", ".*") + "$";
+        }
+
+        private static string Sw360URL(string sw360Env, string releaseId)
+        {
+            string sw360URL = $"{sw360Env}{"/group/guest/components/-/component/release/detailRelease/"}{releaseId}";
+            return sw360URL;
+        }
+        #endregion
     }
 }
+
+
+
+

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -64,7 +64,7 @@ namespace LCT.Common
             string result = string.IsNullOrWhiteSpace(value) ? string.Empty : value;
             if (result.Contains(separator))
             {
-                result = result?[(result.LastIndexOf(separator) + separator.Length)..];
+                result = result[(result.LastIndexOf(separator) + separator.Length)..];
             }
 
             return result;

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -46,6 +46,7 @@ namespace LCT.Common.Constants
         public const string SourceUrlNotFound = "Source URL not found";
         public const string PackageUrlNotFound = "Package URL not found";
         public const string LinkedByCATool = "Linked by CA Tool";
+        public const string LinkedByCAToolReleaseRelation = "UNKNOWN";
         public const string ReleaseAttachmentComment = "Attached by CA Tool";
         public const char ForwardSlash = '/';
         public const string SourceURLSuffix = "/srcfiles?fileinfo=1";

--- a/src/LCT.Common/CycloneDXBomParser.cs
+++ b/src/LCT.Common/CycloneDXBomParser.cs
@@ -7,7 +7,6 @@
 using CycloneDX.Json;
 using CycloneDX.Models;
 using LCT.Common.Constants;
-using LCT.Common.Model;
 using log4net;
 using log4net.Core;
 using Newtonsoft.Json;
@@ -82,14 +81,16 @@ namespace LCT.Common
             foreach (var component in bom.ToList())
             {
                 if (!string.IsNullOrEmpty(component.Name) && !string.IsNullOrEmpty(component.Version)
-                    && !string.IsNullOrEmpty(component.Purl) && component.Purl.Contains(Dataconstant.PurlCheck()[projectType.ToUpper()]))
+                    && !string.IsNullOrEmpty(component.Purl) && 
+                    component.Purl.Contains(Dataconstant.PurlCheck()[projectType.ToUpper()]))
                 {
                     //Taking Valid Components for perticular projects
                 }
                 else
                 {
                     bom.Remove(component);
-                    Logger.Debug("CheckValidComponenstForProjectType(): Not valid Component / Purl ID " + component.Purl + " for Project Type :" + projectType);
+                    Logger.Debug("CheckValidComponenstForProjectType(): " +
+                        "Not valid Component / Purl ID " + component.Purl + " for Project Type :" + projectType);
                 }
             }
         }

--- a/src/LCT.Common/ExceptionHandling.cs
+++ b/src/LCT.Common/ExceptionHandling.cs
@@ -27,7 +27,7 @@ namespace LCT.Common
             }
             else if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
             {
-                Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  {exceptionSource} is currently unresponsive:{ex.Message} Please try again later", null);
+                Logger.Logger.Log(null, Level.Error, $"The exception may arise because  {exceptionSource} is currently unresponsive:{ex.Message} Please try again later", null);
             }
 
         }
@@ -35,11 +35,11 @@ namespace LCT.Common
         {
             if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
             {
-                Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  fossology is currently unresponsive:{ex.Message} Please try again later", null);
+                Logger.Logger.Log(null, Level.Error, $"The exception may arise because  fossology is currently unresponsive:{ex.Message} Please try again later", null);
             }
             else
             {
-                Logger.Logger.Log(null, Level.Error, $"\tThe exception may be caused by an incorrect or missing token for  fossology :{ex.Message} Please ensure that a valid token is provided and try again", null);
+                Logger.Logger.Log(null, Level.Error, $"The exception may be caused by an incorrect or missing token for  fossology :{ex.Message} Please ensure that a valid token is provided and try again", null);
             }
         }
 

--- a/src/LCT.Common/ExceptionHandling.cs
+++ b/src/LCT.Common/ExceptionHandling.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+
+
+using log4net;
+using log4net.Core;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+
+
+
+namespace LCT.Common
+{
+    public class ExceptionHandling
+    {
+        protected ExceptionHandling() { }
+        private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public static void HttpException(HttpRequestException ex, HttpResponseMessage response, string exceptionSource)
+        {
+            if (400 <= Convert.ToInt32(response.StatusCode) && Convert.ToInt32(response.StatusCode) <= 499)
+            {
+                Logger.Logger.Log(null, Level.Error, $"The exception may be caused by an incorrect projectid or missing token for {exceptionSource} , Please ensure that a valid token is provided and try again:{ex.Message}", null);
+                
+            }else if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
+            {
+                Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  {exceptionSource} is currently unresponsive:{ex.Message} Please try again later", null);
+            }          
+
+        }
+        public static void FossologyException(HttpRequestException ex)
+        {
+            if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599 )
+            {
+                Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  fossology is currently unresponsive:{ex.Message} Please try again later", null);
+            }
+            else
+            {
+                Logger.Logger.Log(null, Level.Error, $"\tThe exception may be caused by an incorrect or missing token for  fossology :{ex.Message} Please ensure that a valid token is provided and try again", null);
+
+            }
+
+        }
+
+        public static void AggregateException(AggregateException ex, string exceptionSource)
+        {
+            Logger.Logger.Log(null, Level.Error, $"An exception has occurred due to unknown reasons originating from {exceptionSource}:{ex.Message}", null);            
+        }
+        public static void TaskCancelledException(TaskCanceledException ex, string exceptionSource)
+        {
+            Logger.Logger.Log(null, Level.Error, $"A timeout error is thrown from {exceptionSource} server,Please wait for sometime and re run the pipeline again:{ex.Message}", null);
+        }
+        public static void InvalidOperationException(InvalidOperationException ex, string exceptionSource)
+        {
+            Logger.Logger.Log(null, Level.Error, $"An exception has occurred from {exceptionSource}:{ex.Message}", null);
+        }
+    }
+}

--- a/src/LCT.Common/ExceptionHandling.cs
+++ b/src/LCT.Common/ExceptionHandling.cs
@@ -4,17 +4,12 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
-
-
 using log4net;
 using log4net.Core;
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
-
-
 
 namespace LCT.Common
 {
@@ -28,38 +23,34 @@ namespace LCT.Common
             if (400 <= Convert.ToInt32(response.StatusCode) && Convert.ToInt32(response.StatusCode) <= 499)
             {
                 Logger.Logger.Log(null, Level.Error, $"The exception may be caused by an incorrect projectid or missing token for {exceptionSource} , Please ensure that a valid token is provided and try again:{ex.Message}", null);
-                
-            }else if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
+
+            }
+            else if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
             {
                 Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  {exceptionSource} is currently unresponsive:{ex.Message} Please try again later", null);
-            }          
+            }
 
         }
         public static void FossologyException(HttpRequestException ex)
         {
-            if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599 )
+            if (500 <= Convert.ToInt32(ex.StatusCode) && Convert.ToInt32(ex.StatusCode) <= 599)
             {
                 Logger.Logger.Log(null, Level.Error, $"\tThe exception may arise because  fossology is currently unresponsive:{ex.Message} Please try again later", null);
             }
             else
             {
                 Logger.Logger.Log(null, Level.Error, $"\tThe exception may be caused by an incorrect or missing token for  fossology :{ex.Message} Please ensure that a valid token is provided and try again", null);
-
             }
-
         }
 
-        public static void AggregateException(AggregateException ex, string exceptionSource)
+        public static void ArgumentException( string message)
         {
-            Logger.Logger.Log(null, Level.Error, $"An exception has occurred due to unknown reasons originating from {exceptionSource}:{ex.Message}", null);            
+            Logger.Logger.Log(null, Level.Error, $"Missing Arguments: Please provide the below arguments via inline or in the appSettings.json file to proceed.", null);
+            Logger.Logger.Log(null, Level.Warn, $"{message}", null);
         }
         public static void TaskCancelledException(TaskCanceledException ex, string exceptionSource)
         {
             Logger.Logger.Log(null, Level.Error, $"A timeout error is thrown from {exceptionSource} server,Please wait for sometime and re run the pipeline again:{ex.Message}", null);
-        }
-        public static void InvalidOperationException(InvalidOperationException ex, string exceptionSource)
-        {
-            Logger.Logger.Log(null, Level.Error, $"An exception has occurred from {exceptionSource}:{ex.Message}", null);
         }
     }
 }

--- a/src/LCT.Common/FileOperations.cs
+++ b/src/LCT.Common/FileOperations.cs
@@ -167,7 +167,7 @@ namespace LCT.Common
         private static void BackupTheGivenFile(string folderPath, string fileName)
         {
             string oldFile = Path.Combine(folderPath, fileName);
-            string newFile = string.Format("{0}/{1:MM-dd-yyyy_HHmm}_Backup_{2}", folderPath, DateTime.Now, fileName);
+            string newFile = string.Format("{0}/{1:MM-dd-yyyy_HHmm_ss}_Backup_{2}", folderPath, DateTime.Now, fileName);
             Logger.Debug($"BackupTheGivenFile():oldFile{oldFile},newFile{newFile}");
             try
             {
@@ -179,15 +179,18 @@ namespace LCT.Common
             }
             catch (IOException ex)
             {
-                Logger.Debug($"BackupTheGivenFile():", ex);
+                Logger.Error($"Error occurred while generating backup BOM file", ex);
+                Environment.ExitCode = -1;
             }
             catch (NotSupportedException ex)
             {
-                Logger.Debug($"BackupTheGivenFile():", ex);
+                Logger.Error($"Error occurred while generating backup BOM file", ex);
+                Environment.ExitCode = -1;
             }
             catch (UnauthorizedAccessException ex)
             {
-                Logger.Debug($"BackupTheGivenFile():", ex);
+                Logger.Error($"Error occurred while generating backup BOM file", ex);
+                Environment.ExitCode = -1;
             }
         }
     }

--- a/src/LCT.Common/FolderAction.cs
+++ b/src/LCT.Common/FolderAction.cs
@@ -118,7 +118,7 @@ namespace LCT.Common
             return isZiped;
         }
 
-        private void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        private static void CopyAll(DirectoryInfo source, DirectoryInfo target)
         {
             Logger.Debug("FolderAction.CopyAll():Start");
 

--- a/src/LCT.Common/Interface/ICycloneDXBomParser.cs
+++ b/src/LCT.Common/Interface/ICycloneDXBomParser.cs
@@ -5,7 +5,6 @@
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using CycloneDX.Models;
-using System.Collections.Generic;
 
 namespace LCT.Common
 {
@@ -15,5 +14,6 @@ namespace LCT.Common
     public interface ICycloneDXBomParser
     {
         public Bom ParseCycloneDXBom(string filePath);
+
     }
 }

--- a/src/LCT.Common/Interface/ISettingsManager.cs
+++ b/src/LCT.Common/Interface/ISettingsManager.cs
@@ -18,5 +18,7 @@ namespace LCT.Common.Interface
         /// <param name="jsonSettingsFileName">jsonSettingsFileName</param>
         /// <returns>AppSettings</returns>
         public T ReadConfiguration<T>(string[] args, string jsonSettingsFileName);
+
+        public void CheckRequiredArgsToRun(CommonAppSettings appSettings, string currentExe);
     }
 }

--- a/src/LCT.Common/LCT.Common.csproj
+++ b/src/LCT.Common/LCT.Common.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.6.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Include="Tommy" Version="3.1.2" />
   </ItemGroup>
 

--- a/src/LCT.Facade.UTest/SW360ApicommunicationFacadeTest.cs
+++ b/src/LCT.Facade.UTest/SW360ApicommunicationFacadeTest.cs
@@ -7,6 +7,7 @@
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;
 using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
@@ -142,12 +143,12 @@ namespace LCT.Facade.UTest
             //Arrange 
             HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
             Mock<ISw360ApiCommunication> mockSw360comm = new Mock<ISw360ApiCommunication>();
-            mockSw360comm.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
+            mockSw360comm.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
 
             //Act          
             sW360ApicommunicationFacade = new SW360ApicommunicationFacade(mockSw360comm.Object, true);
-            HttpResponseMessage actual =await sW360ApicommunicationFacade.LinkReleasesToProject(
-                new string[] { "releasefowerjr393", "r3rilmmdlmawin48u" }, "ieuroejfklsndksdoldmfiosdfowemlfiwe");
+            StringContent content = new StringContent(JsonConvert.SerializeObject("{ \"12345\" : { \"releaseRelation\" : \"UNKNOWN\", \"comment\" : \"Test Comment 1\" }, \"54321\" : { \"releaseRelation\" : \"UNKNOWN\", \"comment\" : \"Test Comment 2\" } }"), Encoding.UTF8, "application/json");
+            HttpResponseMessage actual =await sW360ApicommunicationFacade.LinkReleasesToProject(content, "ieuroejfklsndksdoldmfiosdfowemlfiwe");
 
             //Assert
             Assert.That(actual.StatusCode, Is.EqualTo(HttpStatusCode.OK));
@@ -159,12 +160,12 @@ namespace LCT.Facade.UTest
             //Arrange 
             HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
             Mock<ISw360ApiCommunication> mockSw360comm = new Mock<ISw360ApiCommunication>();
-            mockSw360comm.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
+            mockSw360comm.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
 
             //Act          
             sW360ApicommunicationFacade = new SW360ApicommunicationFacade(mockSw360comm.Object, false);
-            HttpResponseMessage actual =await sW360ApicommunicationFacade.LinkReleasesToProject(
-                new string[] { "releasefowerjr393", "r3rilmmdlmawin48u" }, "ieuroejfklsndksdoldmfiosdfowemlfiwe");
+            StringContent content = new StringContent(JsonConvert.SerializeObject("{ \"12345\" : { \"releaseRelation\" : \"UNKNOWN\", \"comment\" : \"Test Comment 1\" }, \"54321\" : { \"releaseRelation\" : \"UNKNOWN\", \"comment\" : \"Test Comment 2\" } }"), Encoding.UTF8, "application/json");
+            HttpResponseMessage actual =await sW360ApicommunicationFacade.LinkReleasesToProject(content, "ieuroejfklsndksdoldmfiosdfowemlfiwe");
 
             //Assert
             Assert.That(actual.StatusCode, Is.EqualTo(HttpStatusCode.OK));

--- a/src/LCT.Facade/Interfaces/ISW360ApicommunicationFacade.cs
+++ b/src/LCT.Facade/Interfaces/ISW360ApicommunicationFacade.cs
@@ -34,7 +34,7 @@ namespace LCT.Facade.Interfaces
         Task<string> GetReleaseByCompoenentName(string componentName);
         Task<HttpResponseMessage> CreateRelease(Releases createReleaseContent);
         Task<HttpResponseMessage> CreateComponent(CreateComponent createComponentContent);
-        Task<HttpResponseMessage> LinkReleasesToProject(string[] releaseidArray, string sw360ProjectId);
+        Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId);
         Task<HttpResponseMessage> UpdateRelease(string releaseId, HttpContent httpContent);
         Task<HttpResponseMessage> UpdateComponent(string componentId, HttpContent httpContent);
         string AttachComponentSourceToSW360(AttachReport attachReport);

--- a/src/LCT.Facade/SW360ApicommunicationFacade.cs
+++ b/src/LCT.Facade/SW360ApicommunicationFacade.cs
@@ -88,14 +88,14 @@ namespace LCT.Facade
             return m_sw360ApiCommunication.GetReleaseByLink(releaseLink);
         }
 
-        public async Task<HttpResponseMessage> LinkReleasesToProject(string[] releaseidArray, string sw360ProjectId)
+        public async Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId)
         {
             if (m_TestMode)
             {
                 return new HttpResponseMessage(HttpStatusCode.OK);
             }
 
-            return await m_sw360ApiCommunication.LinkReleasesToProject(releaseidArray, sw360ProjectId);
+            return await m_sw360ApiCommunication.LinkReleasesToProject(httpContent, sw360ProjectId);
         }
 
         public async Task<HttpResponseMessage> CreateComponent(CreateComponent createComponentContent)

--- a/src/LCT.PackageIdentifier.UTest/AlpineParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/AlpineParserTests.cs
@@ -10,20 +10,38 @@ using LCT.Common;
 using NUnit.Framework;
 using System.IO;
 using LCT.Common.Constants;
+using Moq;
+using System.Collections.Generic;
+using Microsoft.Build.Evaluation;
 
 namespace LCT.PackageIdentifier.UTest
 {
     [TestFixture]
-    class AlpineParserTests
+    public class AlpineParserTests
     {
+        private readonly AlpineProcessor _alpineProcessor;
+
+        public AlpineParserTests()
+        {
+            List<Component> components = new List<Component>();
+            components.Add(new Component() { Name = "apk-tools", Version = "2.12.9-r3", Purl = "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=x86_64&distro=alpine-3.16.2" });
+            components.Add(new Component() { Name = "busybox", Version = "1.35.0-r17", Purl = "pkg:apk/alpine/busybox@1.35.0-r17?arch=x86_64&distro=alpine-3.16.2" });
+            Bom bom = new() { Components = components };
+
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            cycloneDXBomParser.Setup(x => x.ParseCycloneDXBom(It.IsAny<string>())).Returns(bom);
+
+            _alpineProcessor = new AlpineProcessor(cycloneDXBomParser.Object);
+        }
+
         [Test]
         public void ParsePackageConfig_GivenAMultipleInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 4;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
+                        
             string[] Includes = { "*_Alpine.cdx.json" };
             CommonAppSettings appSettings = new CommonAppSettings()
             {
@@ -34,10 +52,11 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _alpineProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
+            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count),
+                "Checks for no of components");
         }
 
 
@@ -45,10 +64,9 @@ namespace LCT.PackageIdentifier.UTest
         public void ParsePackageConfig_GivenAInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 4;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
             string[] Includes = { "CycloneDX_Alpine.cdx.json" };
             CommonAppSettings appSettings = new CommonAppSettings()
             {
@@ -59,20 +77,21 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _alpineProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
+            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), 
+                "Checks for no of components");
         }
 
         [Test]
         public void ParsePackageConfig_GivenMultipleInputFiles_ReturnsCountOfDuplicates()
         {
             //Arrange
-            int duplicateComponents = 4;
+            int duplicateComponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
+  
             string[] Includes = { "*_Alpine.cdx.json" };
 
             CommonAppSettings appSettings = new CommonAppSettings()
@@ -84,20 +103,20 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            alpineProcessor.ParsePackageFile(appSettings);
+            _alpineProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(duplicateComponents, Is.EqualTo(BomCreator.bomKpiData.DuplicateComponents), "Checks for no of duplicate components");
+            Assert.That(duplicateComponents, Is.EqualTo(BomCreator.bomKpiData.DuplicateComponents),
+                "Checks for no of duplicate components");
         }
 
         [Test]
         public void ParsePackageConfig_GivenAInputFilePath_ReturnsSourceDetails()
         {
             //Arrange
-            string sourceName = "alpine-baselayout" + "_" + "3.4.3-r1";
+            string sourceName =@"apk-tools_2.12.9-r3";
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
             string[] Includes = { "AlpineSourceDetails_Cyclonedx.cdx.json" };
 
             CommonAppSettings appSettings = new CommonAppSettings()
@@ -109,20 +128,20 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _alpineProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.AreEqual(sourceName, listofcomponents.Components[0].Name + "_" + listofcomponents.Components[0].Version, "Checks component name and version");
+            Assert.AreEqual(sourceName, listofcomponents.Components[0].Name + "_" +
+                listofcomponents.Components[0].Version, "Checks component name and version");
         }
 
         [Test]
         public void ParsePackageConfig_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 5;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
             string[] Includes = { "CycloneDX_Alpine.cdx.json", "SBOMTemplate_Alpine.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 
@@ -136,10 +155,11 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _alpineProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
+            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count),
+                "Checks for no of components");
         }
 
         [Test]
@@ -148,7 +168,6 @@ namespace LCT.PackageIdentifier.UTest
             //Arrange
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            AlpineProcessor alpineProcessor = new AlpineProcessor();
             string[] Includes = { "CycloneDX_Alpine.cdx.json", "SBOMTemplate_Alpine.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 
@@ -162,8 +181,10 @@ namespace LCT.PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings);
-            bool isUpdated = listofcomponents.Components.Exists(x => x.Properties != null && x.Properties.Exists(x => x.Name == Dataconstant.Cdx_IdentifierType && x.Value == Dataconstant.Discovered));
+            Bom listofcomponents = _alpineProcessor.ParsePackageFile(appSettings);
+            bool isUpdated = listofcomponents.Components.Exists(x => x.Properties != null
+            && x.Properties.Exists(x => x.Name == Dataconstant.Cdx_IdentifierType 
+            && x.Value == Dataconstant.Discovered));
 
             //Assert
             Assert.IsTrue(isUpdated, "Checks For Updated Property In List ");

--- a/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
@@ -60,8 +60,9 @@ namespace PackageIdentifier.UTest
                 }
             };
             mockIProcessor.Setup(x => x.GetJfrogArtifactoryRepoInfo(It.IsAny<CommonAppSettings>(), It.IsAny<ArtifactoryCredentials>(), It.IsAny<Component>(), It.IsAny<string>())).ReturnsAsync(lstComponentForBOM);
-    
-            IParser parser = new DebianProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+
+            IParser parser = new DebianProcessor(cycloneDXBomParser.Object);
             Mock<IJFrogService> jFrogService = new Mock<IJFrogService>();
             Mock<IBomHelper> bomHelper = new Mock<IBomHelper>();
             bomHelper.Setup(x => x.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>())).ReturnsAsync(aqlResultList);

--- a/src/LCT.PackageIdentifier.UTest/ConanParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/ConanParserTests.cs
@@ -44,9 +44,10 @@ namespace PackageIdentifier.UTest
                 PackageFilePath = packagefilepath,
                 Conan = config
             };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new ConanProcessor().ParsePackageFile(appSettings);
+            Bom listofcomponents = new ConanProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectedNoOfcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -73,9 +74,10 @@ namespace PackageIdentifier.UTest
                 PackageFilePath = packagefilepath,
                 Conan = config
             };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new ConanProcessor().ParsePackageFile(appSettings);
+            Bom listofcomponents = new ConanProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
             var IsDevDependency = listofcomponents.Components.Find(a => a.Name == "googletest")
                 .Properties.First(x => x.Name == "internal:siemens:clearing:development").Value;
 
@@ -105,9 +107,10 @@ namespace PackageIdentifier.UTest
                 PackageFilePath = packagefilepath,
                 Conan = config
             };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new ConanProcessor().ParsePackageFile(appSettings);
+            Bom listofcomponents = new ConanProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(totalComponentsAfterExclusion, Is.EqualTo(listofcomponents.Components.Count), "Checks if the excluded components have been removed");
@@ -156,9 +159,10 @@ namespace PackageIdentifier.UTest
             Mock<IBomHelper> mockBomHelper = new Mock<IBomHelper>();
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            ConanProcessor conanProcessor = new ConanProcessor();
+            ConanProcessor conanProcessor = new ConanProcessor(cycloneDXBomParser.Object);
             var actual = await conanProcessor.IdentificationOfInternalComponents(componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -193,9 +197,10 @@ namespace PackageIdentifier.UTest
             Mock<IBomHelper> mockBomHelper = new Mock<IBomHelper>();
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            ConanProcessor conanProcessor = new ConanProcessor();
+            ConanProcessor conanProcessor = new ConanProcessor(cycloneDXBomParser.Object);
             var actual = await conanProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
             var reponameActual = actual.First(x => x.Properties[0].Name == "internal:siemens:clearing:repo-name").Properties[0].Value;
@@ -233,9 +238,10 @@ namespace PackageIdentifier.UTest
             Mock<IBomHelper> mockBomHelper = new Mock<IBomHelper>();
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            ConanProcessor conanProcessor = new ConanProcessor();
+            ConanProcessor conanProcessor = new ConanProcessor(cycloneDXBomParser.Object);
             var actual = await conanProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -248,10 +254,12 @@ namespace PackageIdentifier.UTest
         public void ParsePackageConfig_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 1;
+            int expectednoofcomponents = 0;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            ConanProcessor conanProcessor = new ConanProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+
+            ConanProcessor conanProcessor = new ConanProcessor(cycloneDXBomParser.Object);
             string[] Includes = { "SBOM_ConanCATemplate.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 

--- a/src/LCT.PackageIdentifier.UTest/DebianParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/DebianParserTests.cs
@@ -11,20 +11,36 @@ using System.IO;
 using LCT.Common;
 using LCT.Common.Model;
 using LCT.Common.Constants;
+using Moq;
+using System.Collections.Generic;
 
 namespace PackageIdentifier.UTest
 {
     [TestFixture]
-    class DebianParserTests
+    public class DebianParserTests
     {
+        readonly DebianProcessor _debianProcessor;
+
+        public DebianParserTests()
+        {
+            List<Component> components = new List<Component>();
+            components.Add(new Component() { Name = "adduser", Version = "3.118", Purl = "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10" });
+            components.Add(new Component() { Name = "base-files", Version = "10.3+deb10u10", Purl = "pkg:deb/debian/base-files@10.3+deb10u10?arch=amd64\u0026distro=debian-10" });
+            Bom bom = new() { Components = components };
+
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            cycloneDXBomParser.Setup(x => x.ParseCycloneDXBom(It.IsAny<string>())).Returns(bom);
+
+            _debianProcessor = new DebianProcessor(cycloneDXBomParser.Object);
+        }
+
         [Test]
         public void ParsePackageConfig_GivenAMultipleInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 8;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "*_Debian.cdx.json" };
             CommonAppSettings appSettings = new CommonAppSettings()
             {
@@ -35,10 +51,11 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = DebianProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _debianProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
+            Assert.That(expectednoofcomponents, 
+                Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
         }
 
 
@@ -46,10 +63,10 @@ namespace PackageIdentifier.UTest
         public void ParsePackageConfig_GivenAInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 4;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "CycloneDX_Debian.cdx.json" };
             CommonAppSettings appSettings = new CommonAppSettings()
             {
@@ -60,7 +77,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = DebianProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _debianProcessor.ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -70,10 +87,9 @@ namespace PackageIdentifier.UTest
         public void ParsePackageConfig_GivenMultipleInputFiles_ReturnsCountOfDuplicates()
         {
             //Arrange
-            int duplicateComponents = 1;
+            int duplicateComponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "*_Debian.cdx.json" };
 
             CommonAppSettings appSettings = new CommonAppSettings()
@@ -85,7 +101,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            DebianProcessor.ParsePackageFile(appSettings);
+            _debianProcessor.ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(duplicateComponents, Is.EqualTo(BomCreator.bomKpiData.DuplicateComponents), "Checks for no of duplicate components");
@@ -98,7 +114,6 @@ namespace PackageIdentifier.UTest
             string sourceName = "adduser" + "_" + "3.118";
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "SourceDetails_Cyclonedx.cdx.json" };
 
             CommonAppSettings appSettings = new CommonAppSettings()
@@ -110,7 +125,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = DebianProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _debianProcessor.ParsePackageFile(appSettings);
 
             //Assert
             Assert.AreEqual(sourceName, listofcomponents.Components[0].Name + "_" + listofcomponents.Components[0].Version, "Checks component name and version");
@@ -120,10 +135,9 @@ namespace PackageIdentifier.UTest
         public void ParsePackageConfig_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 5;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "CycloneDX_Debian.cdx.json", "SBOMTemplate_Debian.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 
@@ -137,7 +151,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = DebianProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _debianProcessor.ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -149,7 +163,6 @@ namespace PackageIdentifier.UTest
             //Arrange
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            DebianProcessor DebianProcessor = new DebianProcessor();
             string[] Includes = { "CycloneDX_Debian.cdx.json", "SBOMTemplate_Debian.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 
@@ -163,7 +176,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            Bom listofcomponents = DebianProcessor.ParsePackageFile(appSettings);
+            Bom listofcomponents = _debianProcessor.ParsePackageFile(appSettings);
             bool isUpdated = listofcomponents.Components.Exists(x => x.Properties != null && x.Properties.Exists(x => x.Name == Dataconstant.Cdx_IdentifierType && x.Value == Dataconstant.Discovered));
 
             //Assert

--- a/src/LCT.PackageIdentifier.UTest/MavenParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/MavenParserTests.cs
@@ -39,8 +39,8 @@ namespace LCT.PackageIdentifier.UTest
                 RemoveDevDependency = true,
                 Maven = new Config() { Include = Includes, Exclude = Excludes }
             };
-
-            MavenProcessor MavenProcessor = new MavenProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            MavenProcessor MavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
 
             //Act
             Bom bom = MavenProcessor.ParsePackageFile(appSettings);
@@ -78,9 +78,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("junit");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            MavenProcessor mavenProcessor = new MavenProcessor();
+            MavenProcessor mavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
             var actual = await mavenProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -114,9 +115,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("junit");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            MavenProcessor mavenProcessor = new MavenProcessor();
+            MavenProcessor mavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
             var actual = await mavenProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -136,7 +138,7 @@ namespace LCT.PackageIdentifier.UTest
             };
             var components = new List<Component>() { component1 };
             ComponentIdentification componentIdentification = new() { comparisonBOMData = components };
-            string[] reooListArr = {"internalrepo1", "internalrepo2" };
+            string[] reooListArr = { "internalrepo1", "internalrepo2" };
             CommonAppSettings appSettings = new() { InternalRepoList = reooListArr };
 
             AqlResult aqlResult = new()
@@ -152,9 +154,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("junit/junit");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            MavenProcessor mavenProcessor = new MavenProcessor();
+            MavenProcessor mavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
             var actual = await mavenProcessor.IdentificationOfInternalComponents(
                 componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -191,9 +194,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("junit/junit");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            MavenProcessor mavenProcessor = new MavenProcessor();
+            MavenProcessor mavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
             var actual = await mavenProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -230,9 +234,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("junit");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            MavenProcessor mavenProcessor = new MavenProcessor();
+            MavenProcessor mavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
             var actual = await mavenProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -257,8 +262,8 @@ namespace LCT.PackageIdentifier.UTest
                 RemoveDevDependency = true,
                 Maven = new Config() { Include = Includes, Exclude = Excludes }
             };
-
-            MavenProcessor MavenProcessor = new MavenProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            MavenProcessor MavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
 
             //Act
             MavenProcessor.ParsePackageFile(appSettings);
@@ -284,8 +289,8 @@ namespace LCT.PackageIdentifier.UTest
                 RemoveDevDependency = true,
                 Maven = new Config() { Include = Includes, Exclude = Excludes }
             };
-
-            MavenProcessor MavenProcessor = new MavenProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            MavenProcessor MavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
 
             //Act
             Bom bom = MavenProcessor.ParsePackageFile(appSettings);
@@ -299,7 +304,7 @@ namespace LCT.PackageIdentifier.UTest
         public void ParsePackageFile_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 2;
+            int expectednoofcomponents = 1;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string outFolder = Path.GetDirectoryName(exePath);
             string filepath = outFolder + @"\PackageIdentifierUTTestFiles";
@@ -314,8 +319,8 @@ namespace LCT.PackageIdentifier.UTest
                 Maven = new Config() { Include = Includes, Exclude = Excludes },
                 CycloneDxSBomTemplatePath = filepath + "\\SBOMTemplates\\SBOM_MavenCATemplate.cdx.json"
             };
-
-            MavenProcessor MavenProcessor = new MavenProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            MavenProcessor MavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
 
             //Act
             Bom bom = MavenProcessor.ParsePackageFile(appSettings);
@@ -343,8 +348,8 @@ namespace LCT.PackageIdentifier.UTest
                 Maven = new Config() { Include = Includes, Exclude = Excludes },
                 CycloneDxSBomTemplatePath = filepath + "\\SBOMTemplates\\SBOMTemplate_Maven.cdx.json"
             };
-
-            MavenProcessor MavenProcessor = new MavenProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            MavenProcessor MavenProcessor = new MavenProcessor(cycloneDXBomParser.Object);
 
             //Act
             Bom bom = MavenProcessor.ParsePackageFile(appSettings);

--- a/src/LCT.PackageIdentifier.UTest/NPMParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/NPMParserTests.cs
@@ -12,6 +12,7 @@ using LCT.Common.Model;
 using System.Collections.Generic;
 using CycloneDX.Models;
 using LCT.Common.Constants;
+using Moq;
 
 namespace LCT.PackageIdentifier.UTest
 {
@@ -37,7 +38,8 @@ namespace LCT.PackageIdentifier.UTest
                 Npm = new Config() { Include = Includes, Exclude = Excludes }
             };
 
-            NpmProcessor NpmProcessor = new NpmProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor NpmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
 
             //Act
             NpmProcessor.ParsePackageFile(appSettings);
@@ -63,8 +65,8 @@ namespace LCT.PackageIdentifier.UTest
                 RemoveDevDependency = true,
                 Npm = new Config() { Include = Includes, Exclude = Excludes }
             };
-
-            NpmProcessor NpmProcessor = new NpmProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor NpmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
 
             //Act
             Bom bom=NpmProcessor.ParsePackageFile(appSettings);
@@ -94,7 +96,9 @@ namespace LCT.PackageIdentifier.UTest
 
 
             };
-            NpmProcessor NpmProcessor = new NpmProcessor();
+
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor NpmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
 
             //Act
             NpmProcessor.ParsePackageFile(appSettings);
@@ -110,7 +114,8 @@ namespace LCT.PackageIdentifier.UTest
             int expectednoofcomponents = 5;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            NpmProcessor npmProcessor = new NpmProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             string[] Includes = { "*_NPM.cdx.json" };
             CommonAppSettings appSettings = new CommonAppSettings()
             {
@@ -131,10 +136,11 @@ namespace LCT.PackageIdentifier.UTest
         public void ParseCycloneDXFile_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 4;
+            int expectednoofcomponents = 3;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            NpmProcessor npmProcessor = new NpmProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             string[] Includes = { "CycloneDX2_NPM.cdx.json", "SBOMTemplate_Npm.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 
@@ -160,7 +166,8 @@ namespace LCT.PackageIdentifier.UTest
             //Arrange
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
-            NpmProcessor npmProcessor = new NpmProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             string[] Includes = { "CycloneDX2_NPM.cdx.json" };
             string packagefilepath = OutFolder + @"\PackageIdentifierUTTestFiles";
 

--- a/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
+++ b/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
@@ -47,9 +47,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NpmProcessor npmProcessor = new NpmProcessor();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             var actual = await npmProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -83,9 +84,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NpmProcessor npmProcessor = new NpmProcessor();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             var actual = await npmProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -121,9 +123,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations/common");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NpmProcessor npmProcessor = new NpmProcessor();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             var actual = await npmProcessor.IdentificationOfInternalComponents(
                 componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -160,9 +163,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations/common");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NpmProcessor npmProcessor = new NpmProcessor();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             var actual = await npmProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -199,9 +203,10 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NpmProcessor npmProcessor = new NpmProcessor();
+            NpmProcessor npmProcessor = new NpmProcessor(cycloneDXBomParser.Object);
             var actual = await npmProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 

--- a/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
@@ -179,8 +179,8 @@ namespace PackageIdentifier.UTest
             string csprojfilepath = outFolder + @"\PackageIdentifierUTTestFiles";
             string[] Excludes = null;
 
-            CycloneDX.Models.Bom bom = new CycloneDX.Models.Bom();
-            bom.Components = new List<CycloneDX.Models.Component>();
+            Bom bom = new Bom();
+            bom.Components = new List<Component>();
             CommonAppSettings CommonAppSettings = new CommonAppSettings()
             {
                 PackageFilePath = csprojfilepath,
@@ -188,7 +188,7 @@ namespace PackageIdentifier.UTest
             };
 
             //Act
-            CycloneDX.Models.Bom updatedBom = NugetProcessor.RemoveExcludedComponents(CommonAppSettings, bom);
+            Bom updatedBom = NugetProcessor.RemoveExcludedComponents(CommonAppSettings, bom);
 
             //Assert
             Assert.AreEqual(0, updatedBom.Components.Count, "Zero component exculded");
@@ -222,9 +222,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -261,7 +262,8 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -298,9 +300,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations/common");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -322,7 +325,7 @@ namespace PackageIdentifier.UTest
             var components = new List<Component>() { component1 };
             string[] reooListArr = { "internalrepo1", "internalrepo2" };
             CommonAppSettings appSettings = new();
-            appSettings.Nuget = new LCT.Common.Model.Config() { JfrogNugetRepoList = reooListArr };
+            appSettings.Nuget = new Config() { JfrogNugetRepoList = reooListArr };
             AqlResult aqlResult = new()
             {
                 Name = "animations-common-1.0.0.nupkg",
@@ -337,9 +340,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations/common");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -376,9 +380,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -415,9 +420,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -454,9 +460,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -493,9 +500,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -533,9 +541,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor();
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -564,9 +573,10 @@ namespace PackageIdentifier.UTest
                 PackageFilePath = packagefilepath,
                 Nuget = config
             };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new NugetProcessor().ParsePackageFile(appSettings);
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -593,11 +603,14 @@ namespace PackageIdentifier.UTest
                 PackageFilePath = packagefilepath,
                 Nuget = config
             };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+
 
             //Act
-            Bom listofcomponents = new NugetProcessor().ParsePackageFile(appSettings);
-
-            var IsDevDependency = listofcomponents.Components.Find(a => a.Name == "SonarAnalyzer.CSharp").Properties[0].Value;
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
+            var IsDevDependency = 
+                listofcomponents.Components.Find(a => a.Name == "SonarAnalyzer.CSharp")
+                .Properties[0].Value;
 
             //Assert
             Assert.That(IsDev, Is.EqualTo(IsDevDependency), "Checks if Dev Dependency Component or not");

--- a/src/LCT.PackageIdentifier.UTest/PythonParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/PythonParserTests.cs
@@ -27,13 +27,21 @@ namespace PackageIdentifier.UTest
         readonly PythonProcessor pythonProcessor;
         public PythonParserTests()
         {
-            pythonProcessor = new PythonProcessor();
+
+            List<Component> components = new List<Component>();
+            components.Add(new Component() { Name = "virtualenv", Version = "20.16.5", Purl = "pkg:pypi/virtualenv@20.16.5" });
+            components.Add(new Component() { Name = "virtualenv", Version = "20.19.0", Purl = "pkg:pypi/virtualenv@20.19.0" });
+            Bom bom = new() { Components = components };
+
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            cycloneDXBomParser.Setup(x => x.ParseCycloneDXBom(It.IsAny<string>())).Returns(bom);
+            pythonProcessor = new PythonProcessor(cycloneDXBomParser.Object);
         }
         [Test]
         public void ParseCycloneDXFile_GivenAMultipleInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 9;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
             string[] Includes = { "*_Python.cdx.json" };
@@ -57,7 +65,7 @@ namespace PackageIdentifier.UTest
         public void ParseCycloneDXFile_GivenAInputFilePath_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 4;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
             string[] Includes = { "CycloneDX_Python.cdx.json" };
@@ -73,13 +81,14 @@ namespace PackageIdentifier.UTest
             Bom listofcomponents = pythonProcessor.ParsePackageFile(appSettings);
 
             //Assert
-            Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
+            Assert.That(expectednoofcomponents,
+                Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
         }
         [Test]
         public void ParseCycloneDXFile_GivenAInputFilePathExcludeOneComponent_ReturnsCounts()
         {
             //Arrange
-            int expectednoofcomponents = 3;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
             string[] Includes = { "CycloneDX_Python.cdx.json" };
@@ -110,7 +119,7 @@ namespace PackageIdentifier.UTest
         public void ParseCycloneDXFile_GivenMultipleInputFiles_ReturnsCountOfDuplicates()
         {
             //Arrange
-            int duplicateComponents = 1;
+            int duplicateComponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
             string[] Includes = { "*_Python.cdx.json" };
@@ -133,7 +142,7 @@ namespace PackageIdentifier.UTest
         public void ParseCycloneDXFile_GivenAInputFilePathAlongWithSBOMTemplate_ReturnTotalComponentsList()
         {
             //Arrange
-            int expectednoofcomponents = 5;
+            int expectednoofcomponents = 2;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string OutFolder = Path.GetDirectoryName(exePath);
             string[] Includes = { "CycloneDX_Python.cdx.json", "SBOMTemplate_Python.cdx.json" };
@@ -211,7 +220,8 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("cachy");
 
             // Act
-            PythonProcessor pyProcessor = new PythonProcessor();
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            PythonProcessor pyProcessor = new PythonProcessor(cycloneDXBomParser.Object);
             var actual = await pyProcessor.IdentificationOfInternalComponents(
                 component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -246,9 +256,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("cachy");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            PythonProcessor pyProcessor = new PythonProcessor();
+            PythonProcessor pyProcessor = new PythonProcessor(cycloneDXBomParser.Object);
             var actual = await pyProcessor.IdentificationOfInternalComponents(
                 component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -284,9 +295,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("html5lib");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            PythonProcessor pyProcessor = new PythonProcessor();
+            PythonProcessor pyProcessor = new PythonProcessor(cycloneDXBomParser.Object);
             var actual = await pyProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -322,9 +334,10 @@ namespace PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>()))
                 .ReturnsAsync(results);
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("html5lib");
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            PythonProcessor pyProcessor = new PythonProcessor();
+            PythonProcessor pyProcessor = new PythonProcessor(cycloneDXBomParser.Object);
             var actual = await pyProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 

--- a/src/LCT.PackageIdentifier/AlpineProcesser.cs
+++ b/src/LCT.PackageIdentifier/AlpineProcesser.cs
@@ -11,14 +11,12 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using log4net;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Xml;
 
 namespace LCT.PackageIdentifier
 {
@@ -28,11 +26,11 @@ namespace LCT.PackageIdentifier
     public class AlpineProcessor : IParser
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
 
-        public AlpineProcessor()
+        public AlpineProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            cycloneDXBomParser = new CycloneDXBomParser();
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         #region public method
@@ -64,7 +62,7 @@ namespace LCT.PackageIdentifier
             if (File.Exists(appSettings.CycloneDxSBomTemplatePath) && appSettings.CycloneDxSBomTemplatePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
             {
                 Bom templateDetails;
-                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CycloneDXBomParser.CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 //Adding Template Component Details & MetaData
                 SbomTemplate.AddComponentDetails(bom.Components, templateDetails);
@@ -122,7 +120,7 @@ namespace LCT.PackageIdentifier
 
         private void ExtractDetailsForJson(string filePath, ref List<AlpinePackage> alpinePackages, List<Dependency> dependenciesForBOM)
         {
-            Bom bom = cycloneDXBomParser.ParseCycloneDXBom(filePath);
+            Bom bom = _cycloneDXBomParser.ParseCycloneDXBom(filePath);
             foreach (var componentsInfo in bom.Components)
             {
                 BomCreator.bomKpiData.ComponentsinPackageLockJsonFile++;

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -30,9 +30,15 @@ namespace LCT.PackageIdentifier
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         public static readonly BomKpiData bomKpiData = new();
         ComponentIdentification componentData;
+        private readonly ICycloneDXBomParser CycloneDXBomParser;
 
         public IJFrogService JFrogService { get; set; }
         public IBomHelper BomHelper { get; set; }
+
+        public BomCreator(ICycloneDXBomParser cycloneDXBomParser)
+        {
+            CycloneDXBomParser = cycloneDXBomParser;
+        }
 
         public async Task GenerateBom(CommonAppSettings appSettings, IBomHelper bomHelper, IFileOperations fileOperations)
         {
@@ -102,29 +108,28 @@ namespace LCT.PackageIdentifier
         {
             IParser parser;
 
-
             switch (appSettings.ProjectType.ToUpperInvariant())
             {
                 case "NPM":
-                    parser = new NpmProcessor();
+                    parser = new NpmProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "NUGET":
-                    parser = new NugetProcessor();
+                    parser = new NugetProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "MAVEN":
-                    parser = new MavenProcessor();
+                    parser = new MavenProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "DEBIAN":
-                    parser = new DebianProcessor();
+                    parser = new DebianProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "ALPINE":
-                    parser = new AlpineProcessor();
+                    parser = new AlpineProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "PYTHON":
-                    parser = new PythonProcessor();
+                    parser = new PythonProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "CONAN":
-                    parser = new ConanProcessor();
+                    parser = new ConanProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 default:
                     Logger.Error($"GenerateBom():Invalid ProjectType - {appSettings.ProjectType}");

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -185,6 +185,10 @@ namespace LCT.PackageIdentifier
                 {
                     Logger.Logger.Log(null, Level.Error, $"Check the provided JFrog server details..", null);
                 }
+                else
+                {
+                    Logger.Logger.Log(null, Level.Error, $"JFrog Connection was not successfull check the server status.", null);
+                }
             }
             return false;
         }

--- a/src/LCT.PackageIdentifier/ConanProcessor.cs
+++ b/src/LCT.PackageIdentifier/ConanProcessor.cs
@@ -33,16 +33,13 @@ namespace LCT.PackageIdentifier
     {
         #region fields
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
         #endregion
 
         #region constructor
-        public ConanProcessor()
+        public ConanProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            if (cycloneDXBomParser == null)
-            {
-                cycloneDXBomParser = new CycloneDXBomParser();
-            }
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
         #endregion
 
@@ -182,7 +179,7 @@ namespace LCT.PackageIdentifier
                 else if (filepath.EndsWith(FileConstant.CycloneDXFileExtension) && !filepath.EndsWith(FileConstant.SBOMTemplateFileExtension))
                 {
                     Logger.Debug($"ParsingInputFileForBOM():Found as CycloneDXFile");
-                    bom = cycloneDXBomParser.ParseCycloneDXBom(filepath);
+                    bom = _cycloneDXBomParser.ParseCycloneDXBom(filepath);
                     CheckValidComponentsForProjectType(bom.Components, appSettings.ProjectType);
                     componentsForBOM.AddRange(bom.Components);
                     GetDetailsforManuallyAddedComp(componentsForBOM);
@@ -208,7 +205,7 @@ namespace LCT.PackageIdentifier
             {
                 //Adding Template Component Details
                 Bom templateDetails;
-                templateDetails = ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 SbomTemplate.AddComponentDetails(bom.Components, templateDetails);
             }

--- a/src/LCT.PackageIdentifier/DebianProcessor.cs
+++ b/src/LCT.PackageIdentifier/DebianProcessor.cs
@@ -28,12 +28,12 @@ namespace LCT.PackageIdentifier
     public class DebianProcessor : IParser
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
 
-        public DebianProcessor()
+        public DebianProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            cycloneDXBomParser = new CycloneDXBomParser();
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         #region public method
@@ -66,7 +66,7 @@ namespace LCT.PackageIdentifier
             if (File.Exists(appSettings.CycloneDxSBomTemplatePath) && appSettings.CycloneDxSBomTemplatePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
             {
                 Bom templateDetails;
-                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CycloneDXBomParser.CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 //Adding Template Component Details & MetaData
                 SbomTemplate.AddComponentDetails(bom.Components, templateDetails);
@@ -221,7 +221,7 @@ namespace LCT.PackageIdentifier
 
         private Bom ExtractDetailsForJson(string filePath, ref List<DebianPackage> debianPackages)
         {
-            Bom bom = cycloneDXBomParser.ParseCycloneDXBom(filePath);
+            Bom bom = _cycloneDXBomParser.ParseCycloneDXBom(filePath);
 
             foreach (var componentsInfo in bom.Components)
             {

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -18,11 +18,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="log4net" Version="2.0.15" />
-		<PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime"/>
+		<PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
 		<PackageReference Include="Microsoft.CodeCoverage" Version="17.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="NuGet.Packaging" Version="6.6.1" />
+		<PackageReference Include="NuGet.Packaging" Version="6.7.1" />
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
 	</ItemGroup>

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="NuGet.Packaging" Version="6.7.1" />
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
+		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
 	</ItemGroup>
   
 	<ItemGroup>

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -52,11 +52,11 @@ namespace LCT.PackageIdentifier
 
                     if (componentsForBOM.Count == 0)
                     {
-                        componentsForBOM.AddRange(bomList?.Components);
+                        componentsForBOM.AddRange(bomList.Components);
                     }
                     else
                     {
-                        componentsToBOM.AddRange(bomList?.Components);
+                        componentsToBOM.AddRange(bomList.Components);
                     }
 
                     if (bomList.Dependencies != null)

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -24,11 +24,11 @@ namespace LCT.PackageIdentifier
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
 
-        public MavenProcessor()
+        public MavenProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            cycloneDXBomParser = new CycloneDXBomParser();
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         public Bom ParsePackageFile(CommonAppSettings appSettings)
@@ -70,7 +70,7 @@ namespace LCT.PackageIdentifier
             {
                 //Adding Template Component Details
                 Bom templateDetails;
-                templateDetails = ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 SbomTemplate.AddComponentDetails(componentsForBOM, templateDetails);
             }

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -23,10 +23,8 @@ using System.Reflection;
 using System.Security;
 using System.Threading.Tasks;
 
-
 namespace LCT.PackageIdentifier
 {
-
     /// <summary>
     /// Parses the NPM Packages
     /// </summary>

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -31,7 +31,7 @@ namespace LCT.PackageIdentifier
     public class NpmProcessor : CycloneDXBomParser, IParser
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
         private const string Bundled = "bundled";
         private const string Dependencies = "dependencies";
         private const string Dev = "dev";
@@ -40,12 +40,9 @@ namespace LCT.PackageIdentifier
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
         private const string Requires = "requires";
 
-        public NpmProcessor()
+        public NpmProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            if (cycloneDXBomParser == null)
-            {
-                cycloneDXBomParser = new CycloneDXBomParser();
-            }
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         public Bom ParsePackageFile(CommonAppSettings appSettings)
@@ -381,7 +378,7 @@ namespace LCT.PackageIdentifier
             if (File.Exists(appSettings.CycloneDxSBomTemplatePath) && appSettings.CycloneDxSBomTemplatePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
             {
                 Bom templateDetails;
-                templateDetails = ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 //Adding Template Component Details
                 SbomTemplate.AddComponentDetails(componentsForBOM, templateDetails);

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -104,7 +104,7 @@ namespace LCT.PackageIdentifier
                     var pacakages = jsonDeserialized["packages"];
                     if (pacakages?.Children() != null)
                     {
-                        IEnumerable<JProperty> depencyComponentList = pacakages?.Children().OfType<JProperty>();
+                        IEnumerable<JProperty> depencyComponentList = pacakages.Children().OfType<JProperty>();
                         GetPackagesForBom(filepath, ref bundledComponents, ref lstComponentForBOM,
                             ref noOfDevDependent, depencyComponentList);
                     }
@@ -181,7 +181,7 @@ namespace LCT.PackageIdentifier
 
                 components.Description = folderPath;
                 components.Version = Convert.ToString(properties[Version]);
-                components.Author = prop?.Value[Dependencies]?.ToString();
+                components.Author = prop.Value[Dependencies]?.ToString();
                 components.Purl = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.BomRef = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
 

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -199,7 +199,7 @@ namespace LCT.PackageIdentifier
         }
 
 
-        private void GetComponentsForBom(string filepath, CommonAppSettings appSettings,
+        private static void GetComponentsForBom(string filepath, CommonAppSettings appSettings,
             ref List<BundledComponents> bundledComponents, ref List<Component> lstComponentForBOM,
             ref int noOfDevDependent, IEnumerable<JProperty> depencyComponentList)
         {

--- a/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
+++ b/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
@@ -249,10 +249,9 @@ namespace LCT.PackageIdentifier
                 {
                     depPackage = (existingDependency as NuGetComponent)!;
                 }
-                else
-                {
-                    components.Add(depPackage.Id, depPackage);
-                }
+
+                //Dependencies or not adding as a componenst since it's just a
+                //self-declaration of a component what that main component requires
 
                 if (!component.Dependencies.Contains(depPackage))
                 {

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -412,8 +412,9 @@ namespace LCT.PackageIdentifier
                 CycloneDXBomParser.CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 SbomTemplate.AddComponentDetails(bom.Components, templateDetails);
             }
-
-            bom = RemoveExcludedComponents(appSettings, bom);
+       
+                bom = RemoveExcludedComponents(appSettings, bom);
+            
         }
 
         private static void ConvertToCycloneDXModel(List<Component> listComponentForBOM, List<NugetPackage> listofComponents, List<Dependency> dependencies)
@@ -512,11 +513,6 @@ namespace LCT.PackageIdentifier
 
         private static void CheckForMultipleVersions(CommonAppSettings appSettings, ref List<Component> listComponentForBOM, ref int noOfExcludedComponents, List<Component> componentsWithMultipleVersions)
         {
-            if (appSettings.Nuget.ExcludedComponents != null)
-            {
-                listComponentForBOM = CommonHelper.RemoveExcludedComponents(listComponentForBOM, appSettings.Nuget.ExcludedComponents, ref noOfExcludedComponents);
-                BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
-            }
 
             if (componentsWithMultipleVersions.Count != 0)
             {

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -45,7 +45,6 @@ namespace LCT.PackageIdentifier
             List<Component> listComponentForBOM = new List<Component>();
             Bom bom = new Bom();
             int totalComponentsIdentified = 0;
-            int noOfExcludedComponents = 0;
 
             ParsingInputFileForBOM(appSettings, ref listComponentForBOM, ref bom);
             totalComponentsIdentified = listComponentForBOM.Count;
@@ -59,7 +58,7 @@ namespace LCT.PackageIdentifier
             var componentsWithMultipleVersions = listComponentForBOM.GroupBy(s => s.Name)
                               .Where(g => g.Count() > 1).SelectMany(g => g).ToList();
 
-            CheckForMultipleVersions(appSettings, ref listComponentForBOM, ref noOfExcludedComponents, componentsWithMultipleVersions);
+            CheckForMultipleVersions(appSettings, componentsWithMultipleVersions);
 
             Logger.Debug($"ParsePackageFile():End");
             bom.Components = listComponentForBOM;
@@ -511,7 +510,7 @@ namespace LCT.PackageIdentifier
         }
 
 
-        private static void CheckForMultipleVersions(CommonAppSettings appSettings, ref List<Component> listComponentForBOM, ref int noOfExcludedComponents, List<Component> componentsWithMultipleVersions)
+        private static void CheckForMultipleVersions(CommonAppSettings appSettings, List<Component> componentsWithMultipleVersions)
         {
 
             if (componentsWithMultipleVersions.Count != 0)

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -31,11 +31,11 @@ namespace LCT.PackageIdentifier
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
 
-        public NugetProcessor()
+        public NugetProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            cycloneDXBomParser = new CycloneDXBomParser();
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         #region public methods
@@ -374,7 +374,7 @@ namespace LCT.PackageIdentifier
                     if (!filepath.EndsWith(FileConstant.SBOMTemplateFileExtension))
                     {
                         Logger.Debug($"ParsingInputFileForBOM():Found as CycloneDXFile");
-                        bom = cycloneDXBomParser.ParseCycloneDXBom(filepath);
+                        bom = _cycloneDXBomParser.ParseCycloneDXBom(filepath);
                         CycloneDXBomParser.CheckValidComponentsForProjectType(bom.Components, appSettings.ProjectType);
                         componentsForBOM.AddRange(bom.Components);
                         CommonHelper.GetDetailsforManuallyAdded(componentsForBOM, listComponentForBOM);
@@ -408,7 +408,7 @@ namespace LCT.PackageIdentifier
             {
                 //Adding Template Component Details
                 Bom templateDetails;
-                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CycloneDXBomParser.CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
                 SbomTemplate.AddComponentDetails(bom.Components, templateDetails);
             }

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -80,8 +80,8 @@ namespace LCT.PackageIdentifier
             if (appSettings.IsTestMode)
                 Logger.Logger.Log(null, Level.Notice, $"\tMode\t\t\t --> {appSettings.Mode}\n", null);
 
-
-            IBomCreator bomCreator = new BomCreator();
+            ICycloneDXBomParser cycloneDXBomParser = new CycloneDXBomParser();
+            IBomCreator bomCreator = new BomCreator(cycloneDXBomParser);
             bomCreator.JFrogService = GetJfrogService(appSettings);
             bomCreator.BomHelper = new BomHelper();
 

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -50,6 +50,8 @@ namespace LCT.PackageIdentifier
 
             string FolderPath = LogFolderInitialisation(appSettings);
 
+            settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
+
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package Identifier >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Package Identifier execution: {DateTime.Now}", null);
 

--- a/src/LCT.PackageIdentifier/PythonProcessor.cs
+++ b/src/LCT.PackageIdentifier/PythonProcessor.cs
@@ -15,14 +15,11 @@ using LCT.Services.Interface;
 using log4net;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Tommy;
 using Component = CycloneDX.Models.Component;
 
@@ -33,11 +30,11 @@ namespace LCT.PackageIdentifier
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
 
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        readonly CycloneDXBomParser cycloneDXBomParser;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
 
-        public PythonProcessor()
+        public PythonProcessor(ICycloneDXBomParser cycloneDXBomParser)
         {
-            cycloneDXBomParser = new CycloneDXBomParser();
+            _cycloneDXBomParser = cycloneDXBomParser;
         }
 
         public Bom ParsePackageFile(CommonAppSettings appSettings)
@@ -61,9 +58,10 @@ namespace LCT.PackageIdentifier
             }
 
             Bom templateDetails = new Bom();
-            if (File.Exists(appSettings.CycloneDxSBomTemplatePath) && appSettings.CycloneDxSBomTemplatePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
+            if (File.Exists(appSettings.CycloneDxSBomTemplatePath) 
+                && appSettings.CycloneDxSBomTemplatePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
             {
-                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
+                templateDetails = CycloneDXBomParser.ExtractSBOMDetailsFromTemplate(_cycloneDXBomParser.ParseCycloneDXBom(appSettings.CycloneDxSBomTemplatePath));
                 CycloneDXBomParser.CheckValidComponentsForProjectType(templateDetails.Components, appSettings.ProjectType);
             }
 
@@ -163,7 +161,7 @@ namespace LCT.PackageIdentifier
         private List<PythonPackage> ExtractDetailsFromJson(string filePath, CommonAppSettings appSettings, ref List<Dependency> dependencies)
         {
             List<PythonPackage> PythonPackages = new List<PythonPackage>();
-            Bom bom = cycloneDXBomParser.ParseCycloneDXBom(filePath);
+            Bom bom = _cycloneDXBomParser.ParseCycloneDXBom(filePath);
             CycloneDXBomParser.CheckValidComponentsForProjectType(bom.Components, appSettings.ProjectType);
 
             foreach (var componentsInfo in bom.Components)
@@ -268,7 +266,8 @@ namespace LCT.PackageIdentifier
             return listComponentForBOM;
         }
 
-        private static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
+        private static Bom RemoveExcludedComponents(CommonAppSettings appSettings,
+            Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
             int noOfExcludedComponents = 0;

--- a/src/LCT.SW360PackageCreator.UTest/PackageDownloaderTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/PackageDownloaderTest.cs
@@ -7,7 +7,6 @@
 using LCT.Common.Model;
 using LCT.SW360PackageCreator;
 using LCT.SW360PackageCreator.Interfaces;
-using Moq;
 using NUnit.Framework;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/LCT.SW360PackageCreator/AlpinePackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/AlpinePackageDownloader.cs
@@ -214,7 +214,9 @@ namespace LCT.SW360PackageCreator
             if (Directory.GetDirectories(localPathforDownload).Length != 0)
             {
 
-                var tempFolder = Directory.CreateDirectory($"{Directory.GetParent(Directory.GetCurrentDirectory())}\\ClearingTool\\DownloadedFiles\\SourceCodeZipped\\{component.Name}\\--{DateTime.Now.ToString("yyyyMMddHHmmss")}\\");
+                var tempFolder = Directory.CreateDirectory($"{Directory.GetParent(Directory.GetCurrentDirectory())}" +
+                    $"\\ClearingTool\\DownloadedFiles\\SourceCodeZipped\\{component.Name}\\--" +
+                    $"{DateTime.Now.ToString("yyyyMMddHHmmss")}\\");
                 tarArchivePath = tempFolder + (component.Name + "_" + component.Version) + ".tar.gz";
                 var InputDirectory = localPathforDownload;
                 var OutputFilename = tarArchivePath;

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -303,7 +303,7 @@ namespace LCT.SW360PackageCreator
         {
             var manuallyLinkedReleases = new List<ReleaseLinked>(alreadyLinkedReleases);
             manuallyLinkedReleases.RemoveAll(x => string.Compare(x.Comment, Dataconstant.LinkedByCATool, StringComparison.OrdinalIgnoreCase) == 0);
-
+            await Task.Yield();
             return manuallyLinkedReleases;
         }
 
@@ -324,6 +324,7 @@ namespace LCT.SW360PackageCreator
                     release.Relation = linkedRelease.Relation;
                 }
             }
+            await Task.Yield();
         }
 
         private async Task CreateComponentAndRealease(ICreatorHelper creatorHelper,

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -363,7 +363,7 @@ namespace LCT.SW360PackageCreator
                 if (!string.IsNullOrEmpty(createdStatus.ReleaseStatus.ReleaseIdToLink))
                     AddReleaseIdToLink(item, createdStatus.ReleaseStatus.ReleaseIdToLink);
 
-                item.ReleaseID = createdStatus?.ReleaseStatus?.ReleaseIdToLink ?? string.Empty;
+                item.ReleaseID = createdStatus.ReleaseStatus?.ReleaseIdToLink ?? string.Empty;
                 if (!(string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
                 {
                     await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
@@ -433,7 +433,7 @@ namespace LCT.SW360PackageCreator
                 if (!string.IsNullOrEmpty(releaseCreateStatus.ReleaseIdToLink))
                     AddReleaseIdToLink(item, releaseCreateStatus.ReleaseIdToLink);
 
-                item.ReleaseID = releaseCreateStatus?.ReleaseIdToLink ?? string.Empty;
+                item.ReleaseID = releaseCreateStatus.ReleaseIdToLink ?? string.Empty;
                 if (!(string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
                 {
                     await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
@@ -457,8 +457,8 @@ namespace LCT.SW360PackageCreator
                 FossTriggerStatus fossResult = await sw360CreatorService.TriggerFossologyProcess(item.ReleaseID, sw360link);
                 if (!string.IsNullOrEmpty(fossResult?.Links?.Self?.Href))
                 {
-                    Logger.Debug($"{fossResult?.Content?.Message}");
-                    uploadId = await CheckFossologyProcessStatus(fossResult?.Links?.Self?.Href, sw360CreatorService);
+                    Logger.Debug($"{fossResult.Content?.Message}");
+                    uploadId = await CheckFossologyProcessStatus(fossResult.Links?.Self?.Href, sw360CreatorService);
                 }
 
             }
@@ -477,7 +477,7 @@ namespace LCT.SW360PackageCreator
                 CheckFossologyProcess fossResult = await sw360CreatorService.CheckFossologyProcessStatus(link);
                 if (!string.IsNullOrEmpty(fossResult?.FossologyProcessInfo?.ExternalTool))
                 {
-                    uploadId = fossResult?.FossologyProcessInfo?.ProcessSteps[0]?.ProcessStepIdInTool;
+                    uploadId = fossResult.FossologyProcessInfo?.ProcessSteps[0]?.ProcessStepIdInTool;
                 }
             }
             catch (AggregateException ex)

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -307,7 +307,7 @@ namespace LCT.SW360PackageCreator
             return manuallyLinkedReleases;
         }
 
-        private async Task<List<ReleaseLinked>> GetAlreadyLinkedReleasesByProjectId(string projectId, ISw360ProjectService sw360ProjectService)
+        private static async Task<List<ReleaseLinked>> GetAlreadyLinkedReleasesByProjectId(string projectId, ISw360ProjectService sw360ProjectService)
         {
             List<ReleaseLinked> alreadyLinkedReleases = await sw360ProjectService.GetAlreadyLinkedReleasesByProjectId(projectId);
             return alreadyLinkedReleases;

--- a/src/LCT.SW360PackageCreator/Model/ConanSources.cs
+++ b/src/LCT.SW360PackageCreator/Model/ConanSources.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using YamlDotNet.Serialization;
 

--- a/src/LCT.SW360PackageCreator/PackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/PackageDownloader.cs
@@ -146,7 +146,7 @@ namespace LCT.SW360PackageCreator
             const int timeOutMs = 200 * 60 * 1000;
             var processResult = ProcessAsyncHelper.RunAsync(p.StartInfo, timeOutMs);
             Result result = processResult?.Result ?? new Result();
-            Logger.Debug($"GetCorrectVersion:{gitCommand}:{result?.ExitCode}, output:{result?.StdOut}, Error:{result?.StdErr}");
+            Logger.Debug($"GetCorrectVersion:{gitCommand}:{result.ExitCode}, output:{result?.StdOut}, Error:{result.StdErr}");
             return result;
         }
 

--- a/src/LCT.SW360PackageCreator/PackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/PackageDownloader.cs
@@ -10,7 +10,6 @@ using LCT.SW360PackageCreator.Interfaces;
 using System;
 using System.Threading.Tasks;
 using log4net;
-using log4net.Core;
 using System.Reflection;
 using LCT.Common.Constants;
 using System.IO;

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -15,7 +15,6 @@ using LCT.Services.Interface;
 using LCT.SW360PackageCreator.Interfaces;
 using log4net;
 using log4net.Core;
-using NuGet.Protocol.Plugins;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -51,6 +51,7 @@ namespace LCT.SW360PackageCreator
             ISw360ProjectService sw360ProjectService= Getsw360ProjectServiceObject(appSettings, out sW360ApicommunicationFacade);
             
             string FolderPath = InitiateLogger(appSettings);
+            settingsManager.CheckRequiredArgsToRun(appSettings, "Creator");
             await CreatorValidator.ValidateAppSettings(appSettings, sw360ProjectService);
 
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package creator >>>>>====================", null);

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -49,9 +49,9 @@ namespace LCT.SW360PackageCreator
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
             ISW360ApicommunicationFacade sW360ApicommunicationFacade;
             ISw360ProjectService sw360ProjectService= Getsw360ProjectServiceObject(appSettings, out sW360ApicommunicationFacade);
-            await CreatorValidator.ValidateAppSettings(appSettings, sw360ProjectService);
-
+            
             string FolderPath = InitiateLogger(appSettings);
+            await CreatorValidator.ValidateAppSettings(appSettings, sw360ProjectService);
 
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package creator >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Package creator execution : {DateTime.Now}", null);

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -55,7 +55,7 @@ namespace LCT.SW360PackageCreator
 
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package creator >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Package creator execution : {DateTime.Now}", null);
-            if (appSettings.ProjectType.ToUpperInvariant() == "ALPINE")
+            if (appSettings.ProjectType?.ToUpperInvariant() == "ALPINE")
             { 
                 Logger.Error($"\nPlease note that the Alpine feature is currently in preview state. This means it's available for testing and evaluation purposes. While functional, it may not yet include all planned features and could encounter occasional issues. Your feedback during this preview phase is appreciated as we work towards its official release. Thank you for exploring Alpine with us.");
             }

--- a/src/LCT.SW360PackageCreator/Repository.cs
+++ b/src/LCT.SW360PackageCreator/Repository.cs
@@ -10,6 +10,7 @@ using log4net;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Linq;
 
 namespace LCT.SW360PackageCreator
 {
@@ -80,20 +81,18 @@ namespace LCT.SW360PackageCreator
 
         private string GetRepoName(string url)
         {
+            string repoUrl = string.Empty;
             if (string.IsNullOrWhiteSpace(url))
             {
                 return string.Empty;
             }
 
-            foreach (string repoUrl in m_RepoUrlList)
-            {
-                if (url.Contains(repoUrl))
-                {
-                    return repoUrl;
-                }
-            }
+            repoUrl = (from string repoUrl2 in m_RepoUrlList
+                             where url.Contains(repoUrl2)
+                             select repoUrl2).FirstOrDefault();
 
-            return string.Empty;
+
+            return repoUrl;
         }
     }
 }

--- a/src/LCT.SW360PackageCreator/URLHelper.cs
+++ b/src/LCT.SW360PackageCreator/URLHelper.cs
@@ -5,39 +5,28 @@
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Security.Policy;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Xml.Linq;
-using JetBrains.Annotations;
-using LCT.APICommunications.Model.Foss;
 using LCT.Common;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using log4net;
-using Microsoft.PowerShell.Commands;
-using Microsoft.Web.Administration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using YamlDotNet.Core;
-using YamlDotNet.Core.Tokens;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using System.Management.Automation.Runspaces;
-using NuGet.ProjectModel;
 
 namespace LCT.SW360PackageCreator
 {

--- a/src/LCT.Services.UTest/Sw360CreatorServiceTest.cs
+++ b/src/LCT.Services.UTest/Sw360CreatorServiceTest.cs
@@ -140,11 +140,13 @@ namespace LCT.Services.UTest
       // Arrange
       HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError);
       Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
+      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
       ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
 
       // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
+      var releasesToBeLinked = new List<ReleaseLinked> { new ReleaseLinked { Name = "GitVersion.CommandLine", Version = "5.3.6", ReleaseId = "5e71f9fc2bf9438e9f20a94dddcc6a0f", Comment = "Linked by CA Tool", Relation = "UNKNOWN" } };
+      var manuallyLinkedReleases = new List<ReleaseLinked> { new ReleaseLinked { Name = "", Version = "", ReleaseId = "b565b2cc63fd4cff8f4e68fa1b5d5bd3", Comment = "", Relation = "CONTAINED" } };
+      bool isLinked = await sw360CreatorService.LinkReleasesToProject(releasesToBeLinked, manuallyLinkedReleases, "fgjk53657989u09ipoklyiutr");
 
       // Assert
       Assert.That(isLinked, Is.False, "Linking Release failed");
@@ -155,12 +157,14 @@ namespace LCT.Services.UTest
     {
       // Arrange
       Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).Throws<HttpRequestException>();
+      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).Throws<HttpRequestException>();
       ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
 
       // Act
 
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
+      var releasesToBeLinked = new List<ReleaseLinked> { new ReleaseLinked { Name = "GitVersion.CommandLine", Version = "5.3.6", ReleaseId = "5e71f9fc2bf9438e9f20a94dddcc6a0f", Comment = "Linked by CA Tool", Relation = "UNKNOWN" } };
+      var manuallyLinkedReleases = new List<ReleaseLinked> { new ReleaseLinked { Name = "", Version = "", ReleaseId = "b565b2cc63fd4cff8f4e68fa1b5d5bd3", Comment = "", Relation = "CONTAINED" } };
+      bool isLinked = await sw360CreatorService.LinkReleasesToProject(releasesToBeLinked, manuallyLinkedReleases, "fgjk53657989u09ipoklyiutr");
 
       // Assert
       Assert.That(isLinked, Is.False, "Linking Release failed");
@@ -171,11 +175,13 @@ namespace LCT.Services.UTest
     {
       // Arrange
       Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).Throws<AggregateException>();
+      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).Throws<AggregateException>();
       ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
 
       // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
+      var releasesToBeLinked = new List<ReleaseLinked> { new ReleaseLinked { Name = "GitVersion.CommandLine", Version = "5.3.6", ReleaseId = "5e71f9fc2bf9438e9f20a94dddcc6a0f", Comment = "Linked by CA Tool", Relation = "UNKNOWN" } };
+      var manuallyLinkedReleases = new List<ReleaseLinked> { new ReleaseLinked { Name = "", Version = "", ReleaseId = "b565b2cc63fd4cff8f4e68fa1b5d5bd3", Comment = "", Relation = "CONTAINED" } };
+      bool isLinked = await sw360CreatorService.LinkReleasesToProject(releasesToBeLinked, manuallyLinkedReleases, "fgjk53657989u09ipoklyiutr");
 
       // Assert
       Assert.That(isLinked, Is.False, "Linking Release failed");
@@ -187,73 +193,17 @@ namespace LCT.Services.UTest
       // Arrange
       HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
       Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
+      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<HttpContent>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
       sw360ApiCommMock.Setup(x => x.UpdateLinkedRelease(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpdateLinkedRelease>())).ReturnsAsync(httpResponseMessage);
       ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
 
       // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
+      var releasesToBeLinked = new List<ReleaseLinked> { new ReleaseLinked { Name = "GitVersion.CommandLine", Version = "5.3.6", ReleaseId = "5e71f9fc2bf9438e9f20a94dddcc6a0f", Comment = "Linked by CA Tool", Relation = "UNKNOWN" } };
+      var manuallyLinkedReleases = new List<ReleaseLinked> { new ReleaseLinked { Name = "", Version = "", ReleaseId = "b565b2cc63fd4cff8f4e68fa1b5d5bd3", Comment = "", Relation = "CONTAINED" } };
+      bool isLinked = await sw360CreatorService.LinkReleasesToProject(releasesToBeLinked, manuallyLinkedReleases, "fgjk53657989u09ipoklyiutr");
 
       // Assert
       Assert.That(isLinked, Is.True, "Linking Release success");
-    }
-
-
-    [Test]
-    public async Task LinkReleasesToProject_InputParamsValidation_Success()
-    {
-      // Arrange
-      string[] totalReleasesToBeLinked = new string[] { "1000000", "2000000" };
-      string linkToProjectId = "fgjk53657989u09ipoklyiutr";
-      HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-      Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>()))
-          .Callback<string[], string>((newlyLinked, projectId) => { totalReleasesToBeLinked = newlyLinked; linkToProjectId = projectId; })
-          .ReturnsAsync(httpResponseMessage);
-
-      sw360ApiCommMock.Setup(x => x.UpdateLinkedRelease(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpdateLinkedRelease>()))
-          .ReturnsAsync(httpResponseMessage);
-      ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
-
-      // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
-
-      // Assert
-      Assert.That(isLinked, Is.True, "Linking Release success");
-    }
-
-    [Test]
-    public async Task LinkReleasesToProject_HttpRequestException_OnUpdateOfLinkedReleaseComment_LinkingFailed()
-    {
-      // Arrange
-      HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-      Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
-      sw360ApiCommMock.Setup(x => x.UpdateLinkedRelease(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpdateLinkedRelease>())).Throws<HttpRequestException>();
-      ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
-
-      // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
-
-      // Assert
-      Assert.That(isLinked, Is.False, "Linking Release success, comment update is failed");
-    }
-
-    [Test]
-    public async Task LinkReleasesToProject_AggregateException_OnUpdateOfLinkedReleaseComment_Linkingfailed()
-    {
-      // Arrange
-      HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-      Mock<ISW360ApicommunicationFacade> sw360ApiCommMock = new Mock<ISW360ApicommunicationFacade>();
-      sw360ApiCommMock.Setup(x => x.LinkReleasesToProject(It.IsAny<string[]>(), It.IsAny<string>())).ReturnsAsync(httpResponseMessage);
-      sw360ApiCommMock.Setup(x => x.UpdateLinkedRelease(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpdateLinkedRelease>())).Throws<AggregateException>();
-      ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
-
-      // Act
-      bool isLinked = await sw360CreatorService.LinkReleasesToProject(new List<string> { "1000000" }, new List<string> { "2000000" }, "fgjk53657989u09ipoklyiutr");
-
-      // Assert
-      Assert.That(isLinked, Is.False, "Linking Release failed");
     }
 
     [TestCase]

--- a/src/LCT.Services/Interface/ISW360CreatorService.cs
+++ b/src/LCT.Services/Interface/ISW360CreatorService.cs
@@ -24,7 +24,7 @@ namespace LCT.Services.Interface
         Task<ReleaseCreateStatus> CreateReleaseForComponent(
             ComparisonBomData componentInfo, string componentId, Dictionary<string, string> attachmentUrlList);
 
-        Task<bool> LinkReleasesToProject(List<string> releasesTobeLinked, List<string> manuallyLinkedReleases, string sw360ProjectId);
+        Task<bool> LinkReleasesToProject(List<ReleaseLinked> releasesTobeLinked, List<ReleaseLinked> manuallyLinkedReleases, string sw360ProjectId);
 
         Task<string> GetReleaseIDofComponent(string componentName, string componentVersion, string componentid);
 

--- a/src/LCT.Services/JFrogService.cs
+++ b/src/LCT.Services/JFrogService.cs
@@ -15,7 +15,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 
 namespace LCT.Services
 {

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -350,19 +350,6 @@ namespace LCT.Services
             return releaseid ?? string.Empty;
         }
 
-        private async Task UpdateLinkedReleaseComment(string projectId, List<string> releaseIDList)
-        {
-            UpdateLinkedRelease updateLinkedRelease = new UpdateLinkedRelease() { Comment = Dataconstant.LinkedByCATool };
-            foreach (string releaseId in releaseIDList)
-            {
-                var updateResponse = await m_SW360ApiCommunicationFacade.UpdateLinkedRelease(projectId, releaseId, updateLinkedRelease);
-                if (!updateResponse.IsSuccessStatusCode)
-                {
-                    Logger.Debug($"UpdateLinkedReleaseComment() : Updating comment to linked release id -{releaseId} of preoject - {projectId} is failed.");
-                }
-            }
-        }
-
         private static string GetReleaseIdFromResponse(string componentName, string componentVersion, string releaseid, string responseBody)
         {
             var responseData = JsonConvert.DeserializeObject<ReleaseIdOfComponent>(responseBody);

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -117,7 +117,7 @@ namespace LCT.Services
             }
             catch (HttpRequestException ex)
             {
-                Logger.Logger.Log(null, Level.Error, $"\tTriggering the FossologyProcess is failed due to {ex.StatusCode} : {ex.Message}", null);
+                ExceptionHandling.FossologyException(ex);             
 
             }
 

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -230,7 +230,7 @@ namespace LCT.Services
 
             if (response.Content != null)
             {
-                string responseString = response?.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
+                string responseString = response.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
                 var responseData = JsonConvert.DeserializeObject<Releases>(responseString);
                 string href = responseData?.Links?.Self?.Href ?? string.Empty;
                 releaseId = CommonHelper.GetSubstringOfLastOccurance(href, "/");

--- a/src/LCT.Services/Sw360ProjectService.cs
+++ b/src/LCT.Services/Sw360ProjectService.cs
@@ -56,19 +56,20 @@ namespace LCT.Services
                 {
                     var projectInfo = JsonConvert.DeserializeObject<ProjectReleases>(result);
                     sw360ProjectName = projectInfo?.Name;
+
                 }
             }
             catch (HttpRequestException ex)
             {
-                Environment.ExitCode = -1;
                 Logger.Error($"Failed to connect SW360 : {ex.Message}");
                 Logger.Debug($"GetProjectNameByProjectIDFromSW360()", ex);
+                Environment.ExitCode = -1;
             }
             catch (AggregateException ex)
             {
-                Environment.ExitCode = -1;
                 Logger.Error($"Failed to connect SW360 : {ex.Message}");
                 Logger.Debug($"GetProjectNameByProjectIDFromSW360()", ex);
+                Environment.ExitCode = -1;
             }
 
             return sw360ProjectName;
@@ -99,7 +100,7 @@ namespace LCT.Services
                     {
                         Comment = sw360Release.Comment,
                         ReleaseId = CommonHelper.GetSubstringOfLastOccurance(releaseUrl, "/"),
-                        Relation= sw360Release.Relation
+                        Relation = sw360Release.Relation
                     };
                     alreadyLinkedReleases.Add(releaseLinked);
                 }

--- a/src/LCT.Services/Sw360ProjectService.cs
+++ b/src/LCT.Services/Sw360ProjectService.cs
@@ -89,7 +89,7 @@ namespace LCT.Services
                 Logger.Debug($"GetProjectReleasesByProjectIdFromSw360():Success StatusCode:{projectResponsebyId.StatusCode} " +
               $"& ReasonPhrase :{projectResponsebyId.ReasonPhrase}");
 
-                string result = projectResponsebyId?.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
+                string result = projectResponsebyId.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
                 var projectReleases = JsonConvert.DeserializeObject<ProjectReleases>(result);
                 var sw360LinkedReleases = projectReleases?.LinkedReleases ?? new List<Sw360LinkedRelease>();
                 foreach (Sw360LinkedRelease sw360Release in sw360LinkedReleases)

--- a/src/LCT.Services/Sw360ProjectService.cs
+++ b/src/LCT.Services/Sw360ProjectService.cs
@@ -98,7 +98,8 @@ namespace LCT.Services
                     ReleaseLinked releaseLinked = new ReleaseLinked
                     {
                         Comment = sw360Release.Comment,
-                        ReleaseId = CommonHelper.GetSubstringOfLastOccurance(releaseUrl, "/")
+                        ReleaseId = CommonHelper.GetSubstringOfLastOccurance(releaseUrl, "/"),
+                        Relation= sw360Release.Relation
                     };
                     alreadyLinkedReleases.Add(releaseLinked);
                 }

--- a/src/LCT.Services/Sw360Service.cs
+++ b/src/LCT.Services/Sw360Service.cs
@@ -59,6 +59,14 @@ namespace LCT.Services
             {
                 Sw360ServiceStopWatch.Start();
                 string responseBody = await m_SW360ApiCommunicationFacade.GetReleases();
+
+                if(string.IsNullOrWhiteSpace(responseBody))
+                {
+                    Logger.Debug($"GetAvailableReleasesInSw360():");
+                    Logger.Error("SW360 server is not accessible,Please wait for sometime and re run the pipeline again");
+                    Environment.ExitCode = -1;
+                }
+
                 Sw360ServiceStopWatch.Stop();
                 Logger.Debug($"GetAvailableReleasesInSw360():Time taken to in GetReleases() call" +
                     $"-{TimeSpan.FromMilliseconds(Sw360ServiceStopWatch.ElapsedMilliseconds).TotalSeconds}");
@@ -72,8 +80,15 @@ namespace LCT.Services
             }
             catch (HttpRequestException ex)
             {
+                Logger.Debug($"GetAvailableReleasesInSw360():", ex);
+                Logger.Error("SW360 server is not accessible,Please wait for sometime and re run the pipeline again");
                 Environment.ExitCode = -1;
-                Logger.Error($"GetAvailableReleasesInSw360():", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logger.Debug($"GetAvailableReleasesInSw360():", ex);
+                Logger.Error("SW360 server is not accessible,Please wait for sometime and re run the pipeline again");
+                Environment.ExitCode = -1;
             }
 
             return availableComponentsList;

--- a/src/LCT.Services/Sw360Service.cs
+++ b/src/LCT.Services/Sw360Service.cs
@@ -315,14 +315,14 @@ namespace LCT.Services
             //checking for release existance with name and version
             bool isReleaseAvailable = false;
             Sw360Releases sw360Release =
-                sw360Releases.FirstOrDefault(x => x.Name?.Trim()?.ToLowerInvariant() == component?.Name?.Trim()?.ToLowerInvariant()
-                && x.Version?.Trim()?.ToLowerInvariant() == component?.Version?.Trim()?.ToLowerInvariant());
+                sw360Releases.FirstOrDefault(x => x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
+                && x.Version?.Trim().ToLowerInvariant() == component?.Version?.Trim().ToLowerInvariant());
 
             if (sw360Release == null && component.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["DEBIAN"]))
             {
-                string debianVersion = $"{component?.Version?.Trim()?.ToLowerInvariant() ?? string.Empty}.debian";
-                sw360Release = sw360Releases.FirstOrDefault(x => x.Name?.Trim()?.ToLowerInvariant() == component?.Name?.Trim()?.ToLowerInvariant()
-                && x.Version?.Trim()?.ToLowerInvariant() == debianVersion);
+                string debianVersion = $"{component?.Version?.Trim().ToLowerInvariant() ?? string.Empty}.debian";
+                sw360Release = sw360Releases.FirstOrDefault(x => x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
+                && x.Version?.Trim().ToLowerInvariant() == debianVersion);
             }
 
             if (sw360Release != null)
@@ -362,7 +362,7 @@ namespace LCT.Services
             //checking for component existance with name 
             bool isComponentAvailable = false;
             Sw360Components sw360Component =
-                sw360Components.FirstOrDefault(x => x.Name?.Trim()?.ToLowerInvariant() == component?.Name?.Trim()?.ToLowerInvariant());
+                sw360Components.FirstOrDefault(x => x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant());
             if (sw360Component != null)
             {
                 availableComponentList.Add(new Components()

--- a/src/TestUtilities/JsonManager.cs
+++ b/src/TestUtilities/JsonManager.cs
@@ -2,12 +2,10 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using CycloneDX.Models;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/TestUtilities/TestConstant.cs
+++ b/src/TestUtilities/TestConstant.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestUtilities/TestHelper.cs
+++ b/src/TestUtilities/TestHelper.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using System;

--- a/src/TestUtilities/TestParam.cs
+++ b/src/TestUtilities/TestParam.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using Microsoft.Extensions.Configuration;

--- a/src/TestUtilities/TestParamAlpine.cs
+++ b/src/TestUtilities/TestParamAlpine.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using Microsoft.Extensions.Configuration;

--- a/src/TestUtilities/TestParamConan.cs
+++ b/src/TestUtilities/TestParamConan.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using Microsoft.Extensions.Configuration;
 
 namespace TestUtilities
 {

--- a/src/TestUtilities/TestParamDebian.cs
+++ b/src/TestUtilities/TestParamDebian.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
-
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using Microsoft.Extensions.Configuration;

--- a/src/TestUtilities/TestParamMaven.cs
+++ b/src/TestUtilities/TestParamMaven.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using Microsoft.Extensions.Configuration;
 
 namespace TestUtilities
 {


### PR DESCRIPTION
Package Creator creates new links to the SW360 project with the relation as UNKNOWN
Package Creator retains the relation of the release links when changed manually.
Comment "Linked by CA Tool" is now added when the link is being created for the release to the project, preventing an un-necessary number of API calls to SW360.
Exception handling while calling the APIs
Exception handling while incase of arguments not provided
Nuget Dependency components logic change
Package Creator error handling while checking for releases from SW360