### PR TITLE
Error to be displayed when Components are not present in the BOM for MAVEN package type

### DIFF
--- a/CA.nuspec
+++ b/CA.nuspec
@@ -4,7 +4,7 @@
 <package >
   <metadata>
     <id>continuous-clearing</id>
-    <version>6.2.1</version>
+    <version>6.2.2</version>
     <authors>Siemens AG</authors>
     <owners>continuous-clearing contributors</owners>
     <projectUrl>https://github.com/siemens/continuous-clearing</projectUrl>

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -55,7 +55,7 @@ namespace LCT.PackageIdentifier
                     }
                     else
                     {
-                        Logger.Error("No components found in the BOM file : " + filepath);
+                        Logger.Warn("No components found in the BOM file : " + filepath);
                         continue;
                     }
 

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -48,7 +48,16 @@ namespace LCT.PackageIdentifier
                 if (!filepath.EndsWith(FileConstant.SBOMTemplateFileExtension))
                 {
                     Bom bomList = ParseCycloneDXBom(filepath);
-                    CheckValidComponentsForProjectType(bomList.Components, appSettings.ProjectType);
+
+                    if (bomList?.Components != null)
+                    {
+                        CheckValidComponentsForProjectType(bomList.Components, appSettings.ProjectType);
+                    }
+                    else
+                    {
+                        Logger.Error("No components found in the BOM file : " + filepath);
+                        continue;
+                    }
 
                     if (componentsForBOM.Count == 0)
                     {
@@ -86,7 +95,7 @@ namespace LCT.PackageIdentifier
             componentsForBOM = ListOfComponents.Distinct(new ComponentEqualityComparer()).ToList();
 
             BomCreator.bomKpiData.DuplicateComponents = totalComponentsIdentified - componentsForBOM.Count;
-            
+
 
             if (appSettings.Maven.ExcludedComponents != null)
             {


### PR DESCRIPTION
Bug fix: if components are not present in the BOM throw an error message to the user(MAVEN)