### PR TITLE
Bug fix/jfrog identifer dependencies

### DIFF
--- a/src/ArtifactoryUploader/ArtifactoryUploader.cs
+++ b/src/ArtifactoryUploader/ArtifactoryUploader.cs
@@ -33,7 +33,7 @@ namespace LCT.ArtifactoryUploader
         public static async Task<HttpResponseMessage> UploadPackageToRepo(ComponentsToArtifactory component, int timeout, DisplayPackagesInfo displayPackagesInfo)
         {
             Logger.Debug("Starting UploadPackageToArtifactory method");
-            string operationType = component.PackageType == PackageType.ClearedThirdParty
+            string operationType = component.PackageType == PackageType.ClearedThirdParty 
                 || component.PackageType == PackageType.Development ? "copy" : "move";
             string dryRunSuffix = component.DryRun ? " dry-run" : "";
             HttpResponseMessage responsemessage = new HttpResponseMessage();

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -62,6 +62,20 @@ namespace LCT.Common
             return ComponentList;
         }
 
+        public static List<Dependency> RemoveInvalidDependenciesAndReferences(List<Component> components, List<Dependency> dependencies)
+        {
+            var componentBomRefs = new HashSet<string>(components.Select(c => c.BomRef));
+
+            dependencies.RemoveAll(dep => !componentBomRefs.Contains(dep.Ref));
+
+            foreach (var dep in dependencies)
+            {
+                dep.Dependencies?.RemoveAll(refItem => !componentBomRefs.Contains(refItem.Ref));
+            }
+
+            return dependencies;
+        }
+
         public static string GetSubstringOfLastOccurance(string value, string separator)
         {
             string result = string.IsNullOrWhiteSpace(value) ? string.Empty : value;

--- a/src/LCT.PackageIdentifier/AlpineProcesser.cs
+++ b/src/LCT.PackageIdentifier/AlpineProcesser.cs
@@ -75,14 +75,17 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Alpine.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Alpine.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
 
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/AlpineProcesser.cs
+++ b/src/LCT.PackageIdentifier/AlpineProcesser.cs
@@ -75,7 +75,7 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Alpine.ExcludedComponents != null)
             {

--- a/src/LCT.PackageIdentifier/ConanProcessor.cs
+++ b/src/LCT.PackageIdentifier/ConanProcessor.cs
@@ -524,13 +524,16 @@ namespace LCT.PackageIdentifier
         private static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Conan.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Conan.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/ConanProcessor.cs
+++ b/src/LCT.PackageIdentifier/ConanProcessor.cs
@@ -524,7 +524,7 @@ namespace LCT.PackageIdentifier
         private static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Conan.ExcludedComponents != null)
             {

--- a/src/LCT.PackageIdentifier/DebianProcessor.cs
+++ b/src/LCT.PackageIdentifier/DebianProcessor.cs
@@ -110,13 +110,16 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Debian.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Debian.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/DebianProcessor.cs
+++ b/src/LCT.PackageIdentifier/DebianProcessor.cs
@@ -110,7 +110,7 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Debian.ExcludedComponents != null)
             {

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -100,6 +100,7 @@ namespace LCT.PackageIdentifier
             if (appSettings.Maven.ExcludedComponents != null)
             {
                 componentsForBOM = CommonHelper.RemoveExcludedComponents(componentsForBOM, appSettings.Maven.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentsForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
             }
 

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -453,14 +453,17 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Npm.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Npm.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
 
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -453,7 +453,7 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Npm.ExcludedComponents != null)
             {

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -390,14 +390,17 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Nuget.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Nuget.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
 
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -390,7 +390,7 @@ namespace LCT.PackageIdentifier
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Nuget.ExcludedComponents != null)
             {

--- a/src/LCT.PackageIdentifier/PythonProcessor.cs
+++ b/src/LCT.PackageIdentifier/PythonProcessor.cs
@@ -300,14 +300,17 @@ namespace LCT.PackageIdentifier
             Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
             int noOfExcludedComponents = 0;
             if (appSettings.Python.ExcludedComponents != null)
             {
                 componentForBOM = CommonHelper.RemoveExcludedComponents(componentForBOM, appSettings.Python.ExcludedComponents, ref noOfExcludedComponents);
+                dependenciesForBOM = CommonHelper.RemoveInvalidDependenciesAndReferences(componentForBOM, dependenciesForBOM);
                 BomCreator.bomKpiData.ComponentsExcluded += noOfExcludedComponents;
 
             }
             cycloneDXBOM.Components = componentForBOM;
+            cycloneDXBOM.Dependencies = dependenciesForBOM;
             return cycloneDXBOM;
         }
 

--- a/src/LCT.PackageIdentifier/PythonProcessor.cs
+++ b/src/LCT.PackageIdentifier/PythonProcessor.cs
@@ -300,7 +300,7 @@ namespace LCT.PackageIdentifier
             Bom cycloneDXBOM)
         {
             List<Component> componentForBOM = cycloneDXBOM.Components.ToList();
-            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies.ToList();
+            List<Dependency> dependenciesForBOM = cycloneDXBOM.Dependencies?.ToList() ?? new List<Dependency>();
             int noOfExcludedComponents = 0;
             if (appSettings.Python.ExcludedComponents != null)
             {


### PR DESCRIPTION
Fixing bugs as reported in these work-items

1. [SBOM - Packages found in the dependency sections are not present in the components section, making the SBOM in-valid](https://dev.azure.com/siemens-energy/Enabler/_sprints/taskboard/BLR/Enabler/FY25/FY25%20%5B05%5D-02.12.24-13.12.24?workitem=386971)
2. [CA tool artifactory uploader mentions internal packages not present even if they are valid in jFrog](https://dev.azure.com/siemens-energy/Enabler/_sprints/taskboard/BLR/Enabler/FY25/FY25%20%5B05%5D-02.12.24-13.12.24?workitem=387580)