### PR TITLE
Added new property internal:siemens:clearing:sw360:exclude to exclude components from Sw360, but retain them in the SBOM

### DIFF
--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -59,8 +59,7 @@ namespace LCT.Common.UTest
             ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.2", Purl = "pkg:npm/Debian@3.1.2", Properties = new List<Property>() });
             ComponentsForBom.Add(new Component() { Name = "Newton", Version = "3.1.3", Purl = "pkg:npm/Newton@3.1.3", Properties = new List<Property>() });
             ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.4", Purl = "pkg:npm/Log4t@3.1.4", Properties = new List<Property>() });
-            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5",Purl= "pkg:npm/Log4t@3.1.5", Properties = new List<Property>() });
-            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5", Purl = "pkg:npm/Log4t@3.1.5", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5",Purl= "pkg:npm/Log4t@3.1.5", Properties = new List<Property>() });           
             
             int noOfExcludedComponents = 0;
 
@@ -73,11 +72,7 @@ namespace LCT.Common.UTest
             CommonHelper.RemoveExcludedComponents(ComponentsForBom, list, ref noOfExcludedComponents);
 
             //Assert            
-            Assert.That(noOfExcludedComponents, Is.EqualTo(4), "Returns the count of excluded components");
-            Assert.That(ComponentsForBom[0].Purl, Is.EqualTo("pkg:npm/Log4t@3.1.4"), "Checks the component PURL is correct");
-            Assert.That(ComponentsForBom[0].Properties.Count, Is.EqualTo(0), "Checks the component has no property");
-            Assert.That(ComponentsForBom[1].Purl, Is.EqualTo("pkg:npm/Log4t@3.1.5"), "Checks the component PURL is correct");
-            Assert.That(ComponentsForBom[1].Properties.Count, Is.EqualTo(1), "Checks the component has one property");
+            Assert.That(noOfExcludedComponents, Is.EqualTo(5), "Returns the count of excluded components");            
 
         }
 
@@ -273,9 +268,9 @@ namespace LCT.Common.UTest
             // Arrange
             List<Component> componentList = new List<Component>
             {
-                new Component { Name = "Component1", Version = "1.0" },
-                new Component { Name = "Component2", Version = "2.0" },
-                new Component { Name = "Component3", Version = "3.0" }
+                new Component { Name = "Component1", Version = "1.0", Properties = new List<Property>() },
+                new Component { Name = "Component2", Version = "2.0", Properties = new List<Property>() },
+                new Component { Name = "Component3", Version = "3.0", Properties = new List<Property>() }
             };
             List<string> excludedComponents = new List<string> { "Component1:*", "Component2:2.0" };
             int noOfExcludedComponents = 0;
@@ -284,9 +279,7 @@ namespace LCT.Common.UTest
             List<Component> result = CommonHelper.RemoveExcludedComponents(componentList, excludedComponents, ref noOfExcludedComponents);
 
             // Assert
-            Assert.AreEqual(1, result.Count);
-            Assert.IsFalse(result.Any(c => c.Name == "Component1" && c.Version == "1.0"));
-            Assert.IsTrue(result.Any(c => c.Name == "Component3" && c.Version == "3.0"));
+            Assert.AreEqual(3, result.Count);            
             Assert.AreEqual(2, noOfExcludedComponents);
         }
 

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -54,25 +54,30 @@ namespace LCT.Common.UTest
         {
             //Arrange
             List<Component> ComponentsForBom = new List<Component>();
-            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.0" });
-            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.1" });
-            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.2" });
-            ComponentsForBom.Add(new Component() { Name = "Newton", Version = "3.1.3" });
-            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.4" });
-            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5",Purl= "pkg:npm/foobar@12.3.1" });
-            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5", Purl = "pkg:npm/foobar@12.3.2" });
+            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.0", Purl = "pkg:npm/Debian@3.1.0", Properties = new List<Property>()});
+            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.1", Purl = "pkg:npm/Debian@3.1.1", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Debian", Version = "3.1.2", Purl = "pkg:npm/Debian@3.1.2", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Newton", Version = "3.1.3", Purl = "pkg:npm/Newton@3.1.3", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.4", Purl = "pkg:npm/Log4t@3.1.4", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5",Purl= "pkg:npm/Log4t@3.1.5", Properties = new List<Property>() });
+            ComponentsForBom.Add(new Component() { Name = "Log4t", Version = "3.1.5", Purl = "pkg:npm/Log4t@3.1.5", Properties = new List<Property>() });
+            
             int noOfExcludedComponents = 0;
 
             List<string> list = new List<string>();
             list.Add("Debian:*");
             list.Add("Newton:3.1.3");
-            list.Add("pkg:npm/foobar@12.3.1");
+            list.Add("pkg:npm/Log4t@3.1.5");
 
             //Act
             CommonHelper.RemoveExcludedComponents(ComponentsForBom, list, ref noOfExcludedComponents);
 
             //Assert            
-            Assert.That(noOfExcludedComponents, Is.EqualTo(5), "Returns the count of excluded components");
+            Assert.That(noOfExcludedComponents, Is.EqualTo(4), "Returns the count of excluded components");
+            Assert.That(ComponentsForBom[0].Purl, Is.EqualTo("pkg:npm/Log4t@3.1.4"), "Checks the component PURL is correct");
+            Assert.That(ComponentsForBom[0].Properties.Count, Is.EqualTo(0), "Checks the component has no property");
+            Assert.That(ComponentsForBom[1].Purl, Is.EqualTo("pkg:npm/Log4t@3.1.5"), "Checks the component PURL is correct");
+            Assert.That(ComponentsForBom[1].Properties.Count, Is.EqualTo(1), "Checks the component has one property");
 
         }
 

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -44,9 +44,8 @@ namespace LCT.Common
             List<string> ExcludedComponentsFromPurl = ExcludedComponents?.Where(ec => ec.StartsWith("pkg:")).ToList();
             List<string> otherExcludedComponents = ExcludedComponents?.Where(ec => !ec.StartsWith("pkg:")).ToList();
 
-            ValidateExcludedComponentsFromPurl(ComponentList, ExcludedComponentsFromPurl, ref noOfExcludedComponents);
-            ExcludedList.AddRange(RemoveOtherExcludedComponents(ComponentList, otherExcludedComponents, ref noOfExcludedComponents));
-            ComponentList.RemoveAll(item => ExcludedList.Contains(item));
+            AddExcludedComponentsPropertyFromPurl(ComponentList, ExcludedComponentsFromPurl, ref noOfExcludedComponents);
+            AddExcludedComponentsPropertyFromNameAndVersion(ComponentList, otherExcludedComponents, ref noOfExcludedComponents);            
             return ComponentList;
         }
 
@@ -297,7 +296,7 @@ namespace LCT.Common
             return sw360URL;
         }
 
-        private static List<Component> ValidateExcludedComponentsFromPurl(List<Component> ComponentList, List<string> ExcludedComponentsFromPurl, ref int noOfExcludedComponents)
+        private static List<Component> AddExcludedComponentsPropertyFromPurl(List<Component> ComponentList, List<string> ExcludedComponentsFromPurl, ref int noOfExcludedComponents)
         {
 
 
@@ -310,6 +309,7 @@ namespace LCT.Common
                     if (component.Purl != null && componentPurl.Equals(excludedComponent, StringComparison.OrdinalIgnoreCase))
                     {
                         component.Properties.Add(excludeProperty);
+                        noOfExcludedComponents++;
                     }
                 }
             }
@@ -323,10 +323,10 @@ namespace LCT.Common
             }
             return purl;
         }
-        private static List<Component> RemoveOtherExcludedComponents(List<Component> ComponentList, List<string> otherExcludedComponents, ref int noOfExcludedComponents)
+        private static List<Component> AddExcludedComponentsPropertyFromNameAndVersion(List<Component> ComponentList, List<string> otherExcludedComponents, ref int noOfExcludedComponents)
         {
-            List<Component> ExcludedList = new List<Component>();
 
+            Property excludeProperty = new() { Name = Dataconstant.Cdx_ExcludeComponent, Value = "true" };
             foreach (string excludedComponent in otherExcludedComponents)
             {
                 string[] excludedcomponent = excludedComponent.ToLower().Split(':');
@@ -341,12 +341,12 @@ namespace LCT.Common
                         (component.Version.ToLowerInvariant().Contains(excludedcomponent[1].ToLowerInvariant()) || excludedcomponent[1].ToLowerInvariant() == "*"))
                     {
                         noOfExcludedComponents++;
-                        ExcludedList.Add(component);
+                        component.Properties.Add(excludeProperty);
                     }
                 }
             }
 
-            return ExcludedList;
+            return ComponentList;
         }
         #endregion
     }

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -67,6 +67,7 @@ namespace LCT.Common.Constants
         public const string Cdx_JfrogRepoPath = "internal:siemens:clearing:jfrog-repo-path";
         public const string Cdx_Siemensfilename = "internal:siemens:clearing:siemens:filename";
         public const string Cdx_SiemensDirect = "internal:siemens:clearing:siemens:direct";
+        public const string Cdx_ExcludeComponent = "internal:siemens:clearing:sw360:exclude";
 
         public static Dictionary<string, string> PurlCheck()
         {

--- a/src/LCT.Common/Model/Components.cs
+++ b/src/LCT.Common/Model/Components.cs
@@ -61,6 +61,8 @@ namespace LCT.Common.Model
 
         [JsonIgnore]
         public string IsDev { get; set; }
-        
+        [JsonIgnore]
+        public string ExcludeComponent { get; set; }
+
     }
 }

--- a/src/LCT.PackageIdentifier.UTest/ConanParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/ConanParserTests.cs
@@ -95,7 +95,7 @@ namespace LCT.PackageIdentifier.UTest
         public void ParseLockFile_GivenAInputFilePathExcludeComponent_ReturnComponentCount()
         {
             //Arrange
-            int totalComponentsAfterExclusion = 15;
+            int totalComponentsAfterExclusion = 17;
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string outFolder = Path.GetDirectoryName(exePath);
             string packagefilepath = outFolder + @"\PackageIdentifierUTTestFiles";

--- a/src/LCT.PackageIdentifier/Model/BomKpiData.cs
+++ b/src/LCT.PackageIdentifier/Model/BomKpiData.cs
@@ -46,7 +46,7 @@ namespace LCT.PackageIdentifier.Model
         public int UnofficialComponents { get; set; }
 
 
-        [DisplayName(@"Total Components Excluded")]
+        [DisplayName(@"Total Components Excluded SW360")]
         public int ComponentsExcluded { get; set; }
 
         [DisplayName(@"Components With SourceURL")]

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -73,7 +73,7 @@ namespace LCT.SW360PackageCreator
                 {
                     Logger.Debug($"{item.Name}-{item.Version} found as internal component. ");
                 }
-                else if (componentsData.IsDev == "true" && appSettings.SW360.IgnoreDevDependency)
+                else if ((componentsData.IsDev == "true" && appSettings.SW360.IgnoreDevDependency)||componentsData.ExcludeComponent == "true")
                 {
                     //do nothing
                 }
@@ -148,14 +148,13 @@ namespace LCT.SW360PackageCreator
         private static bool GetPackageType(Component package, ref Components componentsData)
         {
             bool isInternalComponent = false;
-
+            
             foreach (var property in package.Properties)
             {
                 if (property.Name?.ToLower() == Dataconstant.Cdx_ProjectType.ToLower())
                 {
                     componentsData.ProjectType = property.Value;
                 }
-
                 if (property.Name?.ToLower() == Dataconstant.Cdx_IsInternal.ToLower())
                 {
                     _ = bool.TryParse(property.Value, out isInternalComponent);
@@ -163,6 +162,10 @@ namespace LCT.SW360PackageCreator
                 if (property.Name?.ToLower() == Dataconstant.Cdx_IsDevelopment.ToLower())
                 {
                     componentsData.IsDev = property.Value;
+                }
+                if (property.Name?.ToLower() == Dataconstant.Cdx_ExcludeComponent.ToLower())
+                {
+                    componentsData.ExcludeComponent = property.Value;
                 }
             }
 


### PR DESCRIPTION
Added logic to handle Purl exclusion for components in appsettings.
Introduced a new property, internal:siemens:clearing:sw360:exclude, to exclude components from SW360 while retaining them in the SBOM.
Updated test cases accordingly.