### PR TITLE
Feat: Integrating Microsoft's internal component detection tool logic 

### DIFF
--- a/src/LCT.Common/Constants/FileConstant.cs
+++ b/src/LCT.Common/Constants/FileConstant.cs
@@ -51,6 +51,8 @@ namespace LCT.Common.Constants
         public const string CycloneDXFileExtension = ".cdx.json";
         public const string SBOMTemplateFileExtension = "CATemplate.cdx.json";
         public const string NugetAssetFile = "project.assets.json";
+        public static string[] Nuget_DeploymentType_DetectionExt = { "*.csproj" };
+        public static string[] Nuget_DeploymentType_DetectionTags = { "SelfContained", "PublishSingleFile" };
         public const string multipleversionsFileName = "Multipleversions.json";
         public const string artifactoryReportNotApproved = "ReportNotApproved.json";
         public const string basicSBOMName = "ContinuousClearing";

--- a/src/LCT.Common/Constants/FileConstant.cs
+++ b/src/LCT.Common/Constants/FileConstant.cs
@@ -51,7 +51,7 @@ namespace LCT.Common.Constants
         public const string CycloneDXFileExtension = ".cdx.json";
         public const string SBOMTemplateFileExtension = "CATemplate.cdx.json";
         public const string NugetAssetFile = "project.assets.json";
-        public static string[] Nuget_DeploymentType_DetectionExt = { "*.csproj" };
+        public static string[] Nuget_DeploymentType_DetectionExt = { "*.csproj","*.Build.props" };
         public static string[] Nuget_DeploymentType_DetectionTags = { "SelfContained", "PublishSingleFile" };
         public const string multipleversionsFileName = "Multipleversions.json";
         public const string artifactoryReportNotApproved = "ReportNotApproved.json";

--- a/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
@@ -338,8 +338,9 @@ namespace LCT.PackageIdentifier.UTest
             };
             mockIProcessor.Setup(x => x.GetJfrogArtifactoryRepoInfo(It.IsAny<CommonAppSettings>(), It.IsAny<ArtifactoryCredentials>(), It.IsAny<Component>(), It.IsAny<string>())).ReturnsAsync(lstComponentForBOM);
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            Mock<IFrameworkPackages> frameworkPackages = new Mock<IFrameworkPackages>();
 
-            IParser parser = new NugetProcessor(cycloneDXBomParser.Object);
+            IParser parser = new NugetProcessor(cycloneDXBomParser.Object, frameworkPackages.Object);
             Mock<IJFrogService> jFrogService = new Mock<IJFrogService>();
             Mock<IBomHelper> bomHelper = new Mock<IBomHelper>();
             bomHelper.Setup(x => x.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>())).ReturnsAsync(aqlResultList);

--- a/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
@@ -29,12 +29,15 @@ namespace LCT.PackageIdentifier.UTest
         private Mock<IBomHelper> _mockBomHelper;
         private NugetProcessor _nugetProcessor;
         private ICycloneDXBomParser _cycloneDXBomParser;
+        private IFrameworkPackages _frameworkPackages;
         [SetUp]
         public void Setup()
         {
             _mockBomHelper = new Mock<IBomHelper>();
             _cycloneDXBomParser = new Mock<ICycloneDXBomParser>().Object;
-            _nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
+            _frameworkPackages = new Mock<IFrameworkPackages>().Object;
+
+            _nugetProcessor = new NugetProcessor(_cycloneDXBomParser, _frameworkPackages);
         }
 
         [Test]
@@ -47,7 +50,7 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = ""
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
+            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser, _frameworkPackages);
 
             // Act
             var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
@@ -66,7 +69,7 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = "."
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
+            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser, _frameworkPackages);
 
             // Act
             var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
@@ -85,7 +88,7 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = "my-folder"
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
+            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser, _frameworkPackages);
 
             // Act
             var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
@@ -237,7 +240,7 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
 
             // Act
             nugetProcessor.AddSiemensDirectProperty(ref bom);
@@ -294,7 +297,7 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
 
             // Act
             nugetProcessor.AddSiemensDirectProperty(ref bom);
@@ -381,7 +384,7 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
 
             // Act
             nugetProcessor.AddSiemensDirectProperty(ref bom);
@@ -622,7 +625,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -672,7 +675,7 @@ namespace LCT.PackageIdentifier.UTest
 
             // Act
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -724,7 +727,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -777,7 +780,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -829,7 +832,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -881,7 +884,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -933,7 +936,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -985,7 +988,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -1038,7 +1041,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -1071,7 +1074,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages).ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -1104,7 +1107,7 @@ namespace LCT.PackageIdentifier.UTest
 
 
             //Act
-            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages).ParsePackageFile(appSettings);
             var IsDevDependency =
                 listofcomponents.Components.Find(a => a.Name == "SonarAnalyzer.CSharp")
                 .Properties[0].Value;

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -38,14 +38,16 @@ namespace LCT.PackageIdentifier
         public static readonly BomKpiData bomKpiData = new();
         ComponentIdentification componentData;
         private readonly ICycloneDXBomParser CycloneDXBomParser;
+        private readonly IFrameworkPackages _frameworkPackages;
         public IJFrogService JFrogService { get; set; }
         public IBomHelper BomHelper { get; set; }
 
         public static Jfrog jfrog { get; set; } = new Jfrog();
         public static SW360 sw360 { get; set; } = new SW360();
-        public BomCreator(ICycloneDXBomParser cycloneDXBomParser)
+        public BomCreator(ICycloneDXBomParser cycloneDXBomParser, IFrameworkPackages frameworkPackages)
         {
             CycloneDXBomParser = cycloneDXBomParser;
+            _frameworkPackages = frameworkPackages;
         }
 
         public async Task GenerateBom(CommonAppSettings appSettings,
@@ -147,7 +149,7 @@ namespace LCT.PackageIdentifier
                     parser = new NpmProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "NUGET":
-                    parser = new NugetProcessor(CycloneDXBomParser);
+                    parser = new NugetProcessor(CycloneDXBomParser, _frameworkPackages);
                     return await ComponentIdentification(appSettings, parser);
                 case "MAVEN":
                     parser = new MavenProcessor(CycloneDXBomParser);

--- a/src/LCT.PackageIdentifier/FrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/FrameworkPackages.cs
@@ -1,0 +1,139 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using LCT.PackageIdentifier.Interface;
+using log4net;
+using log4net.Core;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace LCT.PackageIdentifier
+{
+    public class FrameworkPackages : IFrameworkPackages
+    {
+        Dictionary<string, Dictionary<string, NuGetVersion>> _foundFrameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>();
+        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        #region public methods
+        public Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths)
+        {
+            try
+            {
+                var uniqueTargets = new Dictionary<NuGetFramework, HashSet<string>>();
+
+                foreach (var lockFilePath in lockFilePaths)
+                {
+                    var lockFile = new LockFileFormat().Read(lockFilePath);
+                    foreach (var target in lockFile.Targets)
+                    {
+                        var frameworkReferences = GetFrameworkReferences(lockFile, target);
+                        if (!uniqueTargets.ContainsKey(target.TargetFramework))
+                        {
+                            uniqueTargets[target.TargetFramework] = new HashSet<string>();
+                        }
+                        foreach (var reference in frameworkReferences)
+                        {
+                            uniqueTargets[target.TargetFramework].Add(reference);
+                        }
+                    }
+                }
+
+                var frameworkPackagesType = LoadAssembly();
+
+                if (frameworkPackagesType == null)
+                {
+                    Logger.Warn("Assembly type 'Microsoft.ComponentDetection.Detectors.NuGet.FrameworkPackages' could not be found.");
+                }
+
+                var getFrameworkPackagesMethod = GetFrameworkPackagesMethod(frameworkPackagesType);
+
+                if (getFrameworkPackagesMethod == null)
+                {
+                    Logger.Logger.Log(null, Level.Notice, $"Method 'GetFrameworkPackages' not found.", null);
+                    return _foundFrameworkPackages;
+                }
+
+                foreach (var target in uniqueTargets)
+                {
+                    InvokeGetFrameworkPackagesMethod(getFrameworkPackagesMethod, target.Key, target.Value.ToArray(), null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug($"Error occurred while GetFrameworkPackages: {ex.Message}");
+            }
+
+            return _foundFrameworkPackages;
+        }
+
+        public string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target)
+        {
+            var frameworkInformation = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(x => x.FrameworkName.Equals(target.TargetFramework));
+
+            if (frameworkInformation == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var results = frameworkInformation.FrameworkReferences.Select(x => x.Name)
+                .Concat(target.Libraries.SelectMany(l => l.FrameworkReferences))
+                .Distinct()
+                .ToArray();
+
+            return results;
+        }
+        #endregion
+
+        #region private methods
+        private static Type? LoadAssembly()
+        {
+            Assembly componentDetectionAssembly = Assembly.Load("Microsoft.ComponentDetection.Detectors");
+            return componentDetectionAssembly.GetType("Microsoft.ComponentDetection.Detectors.NuGet.FrameworkPackages");
+        }
+
+        private MethodInfo? GetFrameworkPackagesMethod(Type frameworkPackagesType)
+        {
+            var methods = frameworkPackagesType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            if (methods != null && methods.Any(m => m.Name == "GetFrameworkPackages"))
+            {
+                return frameworkPackagesType.GetMethod("GetFrameworkPackages", BindingFlags.Static | BindingFlags.Public);
+            }
+            return null;
+        }
+
+        private void InvokeGetFrameworkPackagesMethod(MethodInfo getFrameworkPackagesMethod, NuGetFramework targetFramework, string[] frameworkReferences, LockFileTarget? lockFileTarget)
+        {
+            object[] parameters = { targetFramework, frameworkReferences, lockFileTarget };
+            var result = getFrameworkPackagesMethod.Invoke(null, parameters);
+
+            if (result is Array frameworkPackagesArray)
+            {
+                foreach (var frameworkPackage in frameworkPackagesArray)
+                {
+                    ProcessFrameworkPackage(targetFramework, frameworkPackage);
+                }
+            }
+        }
+
+        private void ProcessFrameworkPackage(NuGetFramework targetFramework, object frameworkPackage)
+        {
+            var frameworkNameProperty = frameworkPackage.GetType().GetProperty("FrameworkName");
+            var packagesProperty = frameworkPackage.GetType().GetProperty("Packages");
+
+            if (frameworkNameProperty != null && packagesProperty != null)
+            {
+                var frameworkName = frameworkNameProperty.GetValue(frameworkPackage)?.ToString() ?? string.Empty;
+                _foundFrameworkPackages[targetFramework + "-" + frameworkName] = packagesProperty.GetValue(frameworkPackage) as Dictionary<string, NuGetVersion> ?? new Dictionary<string, NuGetVersion>();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/LCT.PackageIdentifier/FrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/FrameworkPackages.cs
@@ -93,13 +93,13 @@ namespace LCT.PackageIdentifier
         #endregion
 
         #region private methods
-        private static Type? LoadAssembly()
+        private static Type LoadAssembly()
         {
             Assembly componentDetectionAssembly = Assembly.Load("Microsoft.ComponentDetection.Detectors");
             return componentDetectionAssembly.GetType("Microsoft.ComponentDetection.Detectors.NuGet.FrameworkPackages");
         }
 
-        private MethodInfo? GetFrameworkPackagesMethod(Type frameworkPackagesType)
+        private MethodInfo GetFrameworkPackagesMethod(Type frameworkPackagesType)
         {
             var methods = frameworkPackagesType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
             if (methods != null && methods.Any(m => m.Name == "GetFrameworkPackages"))
@@ -109,7 +109,7 @@ namespace LCT.PackageIdentifier
             return null;
         }
 
-        private void InvokeGetFrameworkPackagesMethod(MethodInfo getFrameworkPackagesMethod, NuGetFramework targetFramework, string[] frameworkReferences, LockFileTarget? lockFileTarget)
+        private void InvokeGetFrameworkPackagesMethod(MethodInfo getFrameworkPackagesMethod, NuGetFramework targetFramework, string[] frameworkReferences, LockFileTarget lockFileTarget)
         {
             object[] parameters = { targetFramework, frameworkReferences, lockFileTarget };
             var result = getFrameworkPackagesMethod.Invoke(null, parameters);

--- a/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System.Collections.Generic;
+
+namespace LCT.PackageIdentifier.Interface
+{
+    public interface IFrameworkPackages
+    {
+        Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths);
+
+        string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target);
+    }
+}

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -22,11 +22,9 @@
 		<PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
 		<PackageReference Include="Microsoft.CodeCoverage" Version="17.1.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="NuGet.Packaging" Version="6.7.1" />
+		<PackageReference Include="Microsoft.ComponentDetection.Detectors" Version="5.2.13" />
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
-		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
 	</ItemGroup>
   

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -18,6 +18,7 @@ using LCT.Services;
 using LCT.Services.Interface;
 using log4net;
 using log4net.Core;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -26,7 +27,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
-
 
 namespace LCT.PackageIdentifier
 {
@@ -41,24 +41,57 @@ namespace LCT.PackageIdentifier
         public static Stopwatch BomStopWatch { get; set; }
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();
+
+        private readonly IFrameworkPackages _frameworkPackages;
+        private readonly ISettingsManager _settingsManager;
+        private readonly ICycloneDXBomParser _cycloneDXBomParser;
+        private readonly IBomCreator _bomCreator;
+
+        public Program(IFrameworkPackages frameworkPackages, ISettingsManager settingsManager, ICycloneDXBomParser cycloneDXBomParser, IBomCreator bomCreator)
+        {
+            _frameworkPackages = frameworkPackages;
+            _settingsManager = settingsManager;
+            _cycloneDXBomParser = cycloneDXBomParser;
+            _bomCreator = bomCreator;
+        }
         protected Program() { }
 
         static async Task Main(string[] args)
+        {
+            var serviceCollection = new ServiceCollection();
+            ConfigureServices(serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var program = serviceProvider.GetService<Program>();
+            await program.Run(args);
+        }
+
+        private static void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IFrameworkPackages, FrameworkPackages>();
+            services.AddTransient<ISettingsManager, SettingsManager>();
+            services.AddTransient<ICycloneDXBomParser, CycloneDXBomParser>();
+            services.AddTransient<IBomCreator, BomCreator>();
+            services.AddTransient<Program>();
+        }
+
+        public async Task Run(string[] args)
         {
             BomStopWatch = new Stopwatch();
             BomStopWatch.Start();
 
             if (!m_Verbose && CommonHelper.IsAzureDevOpsDebugEnabled())
                 m_Verbose = true;
-            ISettingsManager settingsManager = new SettingsManager();
-            CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
+
+            CommonAppSettings appSettings = _settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
             ProjectReleases projectReleases = new ProjectReleases();
             // do not change the order of getting ca tool information
             CatoolInfo caToolInformation = GetCatoolVersionFromProjectfile();
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
             string FolderPath = LogFolderInitialisation(appSettings);
 
-            settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
+            _settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
 
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package Identifier >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Package Identifier execution: {DateTime.Now}", null);
@@ -86,16 +119,13 @@ namespace LCT.PackageIdentifier
             if (appSettings.IsTestMode)
                 Logger.Logger.Log(null, Level.Notice, $"\tMode\t\t\t --> {appSettings.Mode}\n", null);
 
-            ICycloneDXBomParser cycloneDXBomParser = new CycloneDXBomParser();
-            IBomCreator bomCreator = new BomCreator(cycloneDXBomParser);
-            bomCreator.JFrogService = GetJfrogService(appSettings);
-            bomCreator.BomHelper = new BomHelper();
+            _bomCreator.JFrogService = GetJfrogService(appSettings);
+            _bomCreator.BomHelper = new BomHelper();
 
             //Validating JFrog Settings
-            if (await bomCreator.CheckJFrogConnection(appSettings))
+            if (await _bomCreator.CheckJFrogConnection(appSettings))
             {
-                await bomCreator.GenerateBom(appSettings, new BomHelper(), new FileOperations(), projectReleases,
-                                             caToolInformation);
+                await _bomCreator.GenerateBom(appSettings, new BomHelper(), new FileOperations(), projectReleases, caToolInformation);
             }
 
             if (appSettings?.Telemetry?.Enable == true)
@@ -106,7 +136,6 @@ namespace LCT.PackageIdentifier
             Logger.Logger.Log(null, Level.Notice, $"End of Package Identifier execution : {DateTime.Now}\n", null);
             // publish logs and bom file to pipeline artifact
             PipelineArtifactUploader.UploadArtifacts();
-
         }
 
         private static CatoolInfo GetCatoolVersionFromProjectfile()


### PR DESCRIPTION
PR includes,

- Implementation of reflection-based access to the GetFrameworkPackages method of the Microsoft component detection tool
- Using retrieved framework package list into the BOM generation logic of the CCTool, for marked it as Development dependency
- Identifying the solution for self-contained or classical deployment type
- Updated UT cases