### PR TITLE
refactor(core): streamline retry logic and cleanup codebase

### DIFF
--- a/src/LCT.APICommunications/RetryHttpClientHandler.cs
+++ b/src/LCT.APICommunications/RetryHttpClientHandler.cs
@@ -28,40 +28,32 @@ namespace LCT.APICommunications
                 .OrResult<HttpResponseMessage>(r =>
                     (r.StatusCode == HttpStatusCode.RequestTimeout
                     || r.StatusCode == HttpStatusCode.NotAcceptable
-                    || r.StatusCode == HttpStatusCode.BadRequest
                     || (int)r.StatusCode >= 500)
                     && r.StatusCode != HttpStatusCode.Unauthorized
                     && r.StatusCode != HttpStatusCode.Forbidden)
                 .WaitAndRetryAsync(ApiConstant.APIRetryIntervals.Count,
-                    GetRetryInterval,
-                    OnRetry);
-        }
+                     GetRetryInterval,
+                    onRetry: (outcome, timespan, attempt, context) =>
+                    {
+                        var httpMethod = context.ContainsKey("HttpMethod") ? context["HttpMethod"] : "Unknown Method";
+                        var requestUri = context.ContainsKey("RequestUri") ? context["RequestUri"] : "Unknown URI";
+                        Logger.Debug($"Retry attempt {attempt} for {httpMethod} method this URL {requestUri} : {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
+                        if (!_initialRetryLogged && context["LogWarnings"] as bool? != false)
+                        {
+                            Logger.Warn($"Retry attempt triggered for this URL {requestUri} due to : {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
+                        }
+                        context["RetryAttempt"] = attempt;
+                        _initialRetryLogged = true;
 
-        private void OnRetry(DelegateResult<HttpResponseMessage> outcome, TimeSpan timespan, int attempt, Context context)
-        {
-            var httpMethod = context.ContainsKey("HttpMethod") ? context["HttpMethod"] : "Unknown Method";
-            var requestUri = context.ContainsKey("RequestUri") ? context["RequestUri"] : "Unknown URI";
-            var operationInfo = context.ContainsKey("OperationInfo") ? context["OperationInfo"] : requestUri;
-            
-
-            Logger.Debug($"Retry attempt {attempt} for {httpMethod} method this URL {requestUri} : {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
-
-            if (!_initialRetryLogged && context["LogWarnings"] as bool? != false)
-            {
-                Logger.Warn($"Retry attempt triggered for {operationInfo}: {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
-            }
-
-            context["RetryAttempt"] = attempt;
-            _initialRetryLogged = true;
+                    });
         }
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
         {
             var context = new Context
             {
-                ["LogWarnings"] = request.Headers.TryGetValues("LogWarnings", out var logWarningsValues) && bool.TryParse(logWarningsValues.FirstOrDefault(), out var logWarnings) ? logWarnings : default,
+                ["LogWarnings"] = !request.Headers.TryGetValues("LogWarnings", out var logWarningsValues) || !bool.TryParse(logWarningsValues.FirstOrDefault(), out var logWarnings) || logWarnings,
                 ["HttpMethod"] = request.Method.ToString(),
-                ["RequestUri"] = request.RequestUri?.ToString(),
-                ["OperationInfo"] = request.Headers.TryGetValues("urlInfo", out var operationInfoValues) ? operationInfoValues.FirstOrDefault() : ""
+                ["RequestUri"] = request.RequestUri?.ToString()
             };
 
             var response = await _retryPolicy.ExecuteAsync(async (ctx) =>

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -24,13 +24,9 @@ namespace LCT.APICommunications
 {
     public static class HttpClientExtensions
     {
-        public static void SetLogWarnings(this HttpClient client, bool logWarnings,string urlInformation)
+        public static void SetLogWarnings(this HttpClient client, bool logWarnings)
         {
-            client.DefaultRequestHeaders.Remove("LogWarnings");
-            client.DefaultRequestHeaders.Remove("urlInfo");
-
             client.DefaultRequestHeaders.Add("LogWarnings", logWarnings.ToString());
-            client.DefaultRequestHeaders.Add("urlInfo", urlInformation);
         }
     }
     /// <summary>
@@ -74,7 +70,6 @@ namespace LCT.APICommunications
         public async Task<string> GetProjects()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get project details");
             var result = string.Empty;
             try
             {
@@ -92,14 +87,12 @@ namespace LCT.APICommunications
         public async Task<string> GetSw360Users()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get Sw360 users");
             return await httpClient.GetStringAsync(sw360UsersApi);
         }
 
         public async Task<string> GetProjectsByName(string projectName)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get projects by name");
             string projectNameApiUrl = $"{sw360ProjectsApi}{ApiConstant.ComponentNameUrl}{projectName}";
             return await httpClient.GetStringAsync(projectNameApiUrl);
         }
@@ -107,7 +100,6 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetProjectsByTag(string projectTag)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get projects by tag");
             string projectsByTagUrl = $"{sw360ProjectByTagApi}{projectTag}";
             return await httpClient.GetAsync(projectsByTagUrl);
         }
@@ -115,7 +107,6 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetProjectById(string projectId)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get project details by project id");
             HttpResponseMessage obj = new HttpResponseMessage();
             var result = obj;
             string projectsByTagUrl = $"{sw360ProjectsApi}/{projectId}";
@@ -142,7 +133,6 @@ namespace LCT.APICommunications
         public async Task<string> GetReleases()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get releases");
             var result = string.Empty;
             try
             {
@@ -181,7 +171,7 @@ namespace LCT.APICommunications
         public async Task<string> TriggerFossologyProcess(string releaseId, string sw360link)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to trigger fossology process");
+            httpClient.SetLogWarnings(false);
             string url = $"{sw360ReleaseApi}/{releaseId}{ApiConstant.FossTriggerAPIPrefix}{sw360link}{ApiConstant.FossTriggerAPISuffix}";
             try
             {
@@ -205,20 +195,18 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> CheckFossologyProcessStatus(string link)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to check fossology process status");
+            httpClient.SetLogWarnings(false);
             return await httpClient.GetAsync(link);
         }
         public async Task<string> GetComponents()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get components details");
             return await httpClient.GetStringAsync(sw360ComponentApi);
         }
 
         public async Task<HttpResponseMessage> GetReleaseByExternalId(string purlId, string externalIdKey = "")
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get release details by externalid");
             string releaseByExternalIdUrl = $"{sw360ReleaseByExternalId}{externalIdKey}{purlId}";
             return await httpClient.GetAsync(releaseByExternalIdUrl);
         }
@@ -226,7 +214,7 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetComponentByExternalId(string purlId, string externalIdKey = "")
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get component details by externalid");
+            httpClient.SetLogWarnings(false);
             string componentByExternalIdUrl = $"{sw360ComponentByExternalId}{externalIdKey}{purlId}";
             return await httpClient.GetAsync(componentByExternalIdUrl);
         }
@@ -234,7 +222,7 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetReleaseById(string releaseId)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get release details by releaseid");
+            httpClient.SetLogWarnings(false);
             string url = $"{sw360ReleaseApi}/{releaseId}";
             return await httpClient.GetAsync(url);
         }
@@ -242,14 +230,12 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetReleaseByLink(string releaseLink)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get release details by releaselink");
             return await httpClient.GetAsync(releaseLink);
         }
 
         public async Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to link releases to the project");
             string url = $"{sw360ProjectsApi}/{sw360ProjectId}/{ApiConstant.Releases}";
             return await httpClient.PostAsync(url, httpContent);
         }
@@ -257,7 +243,6 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> UpdateLinkedRelease(string projectId, string releaseId, UpdateLinkedRelease updateLinkedRelease)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to update linked releases");
             string updateUri = $"{sw360ProjectsApi}/{projectId}/{ApiConstant.Release}/{releaseId}";
             string updateContent = JsonConvert.SerializeObject(updateLinkedRelease);
             HttpContent content = new StringContent(updateContent, Encoding.UTF8, "application/json");
@@ -268,21 +253,21 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> CreateComponent(CreateComponent createComponentContent)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false,"unable to create component");
+            httpClient.SetLogWarnings(false);
             return await httpClient.PostAsJsonAsync(sw360ComponentApi, createComponentContent);
         }
 
         public async Task<HttpResponseMessage> CreateRelease(Releases createReleaseContent)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to create release");
+            httpClient.SetLogWarnings(false);
             return await httpClient.PostAsJsonAsync(sw360ReleaseApi, createReleaseContent);
         }
 
         public async Task<string> GetReleaseOfComponentById(string componentId)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get release data by component id");
+            httpClient.SetLogWarnings(false);
             string componentUrl = $"{sw360ComponentApi}/{componentId}";
             return await httpClient.GetStringAsync(componentUrl);
         }
@@ -290,14 +275,12 @@ namespace LCT.APICommunications
         public async Task<string> GetReleaseAttachments(string releaseAttachmentsUrl)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get release attachments");
             return await httpClient.GetStringAsync(releaseAttachmentsUrl);
         }
 
         public async Task<string> GetAttachmentInfo(string attachmentUrl)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get attachment information");
             return await httpClient.GetStringAsync(attachmentUrl);
         }
 
@@ -315,7 +298,7 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> UpdateRelease(string releaseId, HttpContent httpContent)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false,"unable to update the release data");
+            httpClient.SetLogWarnings(false);
             string releaseApi = $"{sw360ReleaseApi}/{releaseId}";
             return await httpClient.PatchAsync(releaseApi, httpContent);
         }
@@ -323,7 +306,6 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> UpdateComponent(string componentId, HttpContent httpContent)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to update the component data");
             string componentApi = $"{sw360ComponentApi}/{componentId}";
             return await httpClient.PatchAsync(componentApi, httpContent);
         }
@@ -339,7 +321,6 @@ namespace LCT.APICommunications
         public async Task<string> GetReleaseByCompoenentName(string componentName)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get release data by component name");
             string url = $"{sw360ReleaseNameApi}{componentName}";
             return await httpClient.GetStringAsync(url);
         }
@@ -347,28 +328,26 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetComponentDetailsByUrl(string componentLink)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get component details by component link");
             return await httpClient.GetAsync(componentLink);
         }
 
         public async Task<string> GetComponentByName(string componentName)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get component details by component name");
+            httpClient.SetLogWarnings(false);
             string url = $"{sw360ComponentApi}{ApiConstant.ComponentNameUrl}{componentName}";
             return await httpClient.GetStringAsync(url);
         }
         public async Task<HttpResponseMessage> GetComponentUsingName(string componentName)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(false, "unable to get component details by component name");
+            httpClient.SetLogWarnings(false);
             string url = $"{sw360ComponentApi}{ApiConstant.ComponentNameUrl}{componentName}";
             return await httpClient.GetAsync(url);
         }
         public async Task<HttpResponseMessage> GetAllReleasesWithAllData(int page, int pageEntries)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get all releases details");
             string url = $"{sw360ReleaseApi}?page={page}&allDetails=true&page_entries={pageEntries}";
             return await httpClient.GetAsync(url);
         }

--- a/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
@@ -15,7 +15,6 @@ using LCT.Common.Model;
 using LCT.Facade.Interfaces;
 using LCT.Services;
 using LCT.Services.Interface;
-using LCT.Services.Model;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using Moq;
@@ -68,7 +67,7 @@ namespace LCT.SW360PackageCreator.UTest
                 Name = "TestComponent",
                 Version = "1.0.0",
                 ApprovedStatus = "NEW_CLEARING",
-                ClearingState = Dataconstant.ScanAvailableState
+                ClearingState = Dataconstant.ScanClearingState
             };
 
             // Act
@@ -87,7 +86,7 @@ namespace LCT.SW360PackageCreator.UTest
                 Name = "TestComponent",
                 Version = "1.0.0",
                 ApprovedStatus = "NEW_CLEARING",
-                ClearingState = Dataconstant.ScanAvailableState,
+                ClearingState = Dataconstant.ScanClearingState,
                 FossologyLink = "https://fossology.example.com/upload/12345",
                 FossologyUploadId = "12345"
             };
@@ -109,7 +108,7 @@ namespace LCT.SW360PackageCreator.UTest
                 Name = "TestComponent",
                 Version = "1.0.0",
                 ApprovedStatus = "NEW_CLEARING",
-                ClearingState = Dataconstant.ScanAvailableState
+                ClearingState = Dataconstant.ScanClearingState
             };
 
             _mockSw360CreatorService
@@ -1046,122 +1045,11 @@ namespace LCT.SW360PackageCreator.UTest
             await ComponentCreator.GetUploadIdWhenReleaseExists(item, releasesInfo, appSettings);
 
             // Assert
-            Assert.AreEqual("APPROVED", item.ApprovedStatus, "ClearingState should be set from releasesInfo.");
+            Assert.AreEqual("APPROVED", item.ClearingState, "ClearingState should be set from releasesInfo.");
             Assert.AreEqual("https://fossology.example.com/upload/12345", item.FossologyLink, "FossologyLink should be set from AdditionalData.");
             Assert.AreEqual("12345", item.FossologyUploadId, "FossologyUploadId should be set from ProcessStepIdInTool.");
         }
-        [Test]
-        public async Task ProcessReleaseAlreadyExist_ReleaseAlreadyExists_WithValidReleaseID_ShouldTriggerFossologyUpload()
-        {
-            // Arrange
-            var item = new ComparisonBomData
-            {
-                ReleaseID = "12345",
-                DownloadUrl = "https://example.com/download"
-            };
-            var releaseCreateStatus = new ReleaseCreateStatus
-            {
-                ReleaseAlreadyExist = true
-            };
-            var releasesInfo = new ReleasesInfo
-            {
-                Name = "TestRelease",
-                Embedded = new AttachmentEmbedded
-                {
-                    Sw360attachments = new List<Sw360Attachments>
-                {
-                    new Sw360Attachments { AttachmentType = "SOURCE" }
-                }
-                }
-            };
 
-            _mockSw360CreatorService
-                .Setup(service => service.GetReleaseInfo(item.ReleaseID))
-                .ReturnsAsync(releasesInfo);
-
-            // Act
-            await ComponentCreator.ProcessReleaseAlreadyExist(item, _mockSw360CreatorService.Object, _appSettings, releaseCreateStatus);
-
-            // Assert
-            Assert.AreEqual("TestRelease", item.ParentReleaseName);
-            _mockSw360CreatorService.Verify(service => service.GetReleaseInfo(item.ReleaseID), Times.Once);
-        }
-
-        [Test]
-        public async Task ProcessReleaseAlreadyExist_ReleaseAlreadyExists_WithNoAttachments_ShouldNotTriggerFossologyUpload()
-        {
-            // Arrange
-            var item = new ComparisonBomData
-            {
-                ReleaseID = "12345",
-                DownloadUrl = "https://example.com/download"
-            };
-            var releaseCreateStatus = new ReleaseCreateStatus
-            {
-                ReleaseAlreadyExist = true
-            };
-            var releasesInfo = new ReleasesInfo
-            {
-                Name = "TestRelease",
-                Embedded = new AttachmentEmbedded
-                {
-                    Sw360attachments = new List<Sw360Attachments>() // No attachments
-                }
-            };
-
-            _mockSw360CreatorService
-                .Setup(service => service.GetReleaseInfo(item.ReleaseID))
-                .ReturnsAsync(releasesInfo);
-
-            // Act
-            await ComponentCreator.ProcessReleaseAlreadyExist(item, _mockSw360CreatorService.Object, _appSettings, releaseCreateStatus);
-
-            // Assert
-            Assert.AreEqual("TestRelease", item.ParentReleaseName);
-            _mockSw360CreatorService.Verify(service => service.GetReleaseInfo(item.ReleaseID), Times.Once);
-        }
-
-        [Test]
-        public async Task ProcessReleaseAlreadyExist_ReleaseDoesNotExist_WithValidDownloadUrl_ShouldTriggerFossologyUpload()
-        {
-            // Arrange
-            var item = new ComparisonBomData
-            {
-                ReleaseID = "12345",
-                DownloadUrl = "https://example.com/download"
-            };
-            var releaseCreateStatus = new ReleaseCreateStatus
-            {
-                ReleaseAlreadyExist = false
-            };
-
-            // Act
-            await ComponentCreator.ProcessReleaseAlreadyExist(item, _mockSw360CreatorService.Object, _appSettings, releaseCreateStatus);
-
-            // Assert
-            _mockSw360CreatorService.Verify(service => service.GetReleaseInfo(It.IsAny<string>()), Times.Never);
-        }
-
-        [Test]
-        public async Task ProcessReleaseAlreadyExist_ReleaseDoesNotExist_WithInvalidDownloadUrl_ShouldNotTriggerFossologyUpload()
-        {
-            // Arrange
-            var item = new ComparisonBomData
-            {
-                ReleaseID = "12345",
-                DownloadUrl = Dataconstant.DownloadUrlNotFound
-            };
-            var releaseCreateStatus = new ReleaseCreateStatus
-            {
-                ReleaseAlreadyExist = false
-            };
-
-            // Act
-            await ComponentCreator.ProcessReleaseAlreadyExist(item, _mockSw360CreatorService.Object, _appSettings, releaseCreateStatus);
-
-            // Assert
-            _mockSw360CreatorService.Verify(service => service.GetReleaseInfo(It.IsAny<string>()), Times.Never);
-        }
     }
 }
 

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -368,8 +368,10 @@ namespace LCT.SW360PackageCreator
                     AddReleaseIdToLink(item, createdStatus.ReleaseStatus.ReleaseIdToLink);
 
                 item.ReleaseID = createdStatus.ReleaseStatus?.ReleaseIdToLink ?? string.Empty;
-                await ProcessReleaseAlreadyExist(item, sw360CreatorService, appSettings, createdStatus.ReleaseStatus);
-
+                if (!(string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
+                {
+                    await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
+                }
                 UpdatedCompareBomData.Add(item);
             }
         }
@@ -378,7 +380,7 @@ namespace LCT.SW360PackageCreator
             ISw360CreatorService sw360CreatorService, CommonAppSettings appSettings)
         {
 
-            if (appSettings.SW360.Fossology.EnableTrigger && (item.ApprovedStatus.Equals(Dataconstant.NewClearing) || item.ApprovedStatus.Equals("Not Available") || item.ApprovedStatus.Equals(Dataconstant.SentToClearingState) || item.ApprovedStatus.Equals(Dataconstant.ScanAvailableState) ))
+            if (appSettings.SW360.Fossology.EnableTrigger && (item.ApprovedStatus.Equals("NEW_CLEARING") || item.ApprovedStatus.Equals("Not Available") || item.ClearingState.Equals(Dataconstant.ScanClearingState)))
             {
                 var formattedName = GetFormattedName(item);
                 Logger.Logger.Log(null, Level.Notice, $"\tInitiating FOSSology process for: Release : Name - {formattedName} , version - {item.Version}", null);
@@ -441,7 +443,11 @@ namespace LCT.SW360PackageCreator
                     AddReleaseIdToLink(item, releaseCreateStatus.ReleaseIdToLink);
 
                 item.ReleaseID = releaseCreateStatus.ReleaseIdToLink ?? string.Empty;
-                await ProcessReleaseAlreadyExist(item, sw360CreatorService, appSettings, releaseCreateStatus);
+                if (!(string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
+                {
+                    await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
+                }
+
                 UpdatedCompareBomData.Add(item);
                 await sw360CreatorService.UpdatePurlIdForExistingComponent(item, componentId);
             }
@@ -571,12 +577,11 @@ namespace LCT.SW360PackageCreator
                 {
                     ComponentsNotLinked.Add(new Components() { Name = item.Name, Version = item.Version });
                 }
-                
+                UpdatedCompareBomData.Add(item);
                 ReleasesInfo releasesInfo = await sw360CreatorService.GetReleaseInfo(releaseId);
                 string componentId = CommonHelper.GetSubstringOfLastOccurance(releasesInfo.Links?.Sw360Component?.Href, "/");
                 item.ReleaseID = releaseId;
                 await GetUploadIdWhenReleaseExists(item, releasesInfo, appSettings);
-                UpdatedCompareBomData.Add(item);
                 if (IsReleaseAttachmentExist(releasesInfo))
                 {
                     await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
@@ -594,7 +599,7 @@ namespace LCT.SW360PackageCreator
                 return Task.CompletedTask;
             }
 
-            item.ApprovedStatus = releasesInfo.ClearingState;
+            item.ClearingState = releasesInfo.ClearingState;
 
             var uploadId = releasesInfo.ExternalToolProcesses?
                 .SelectMany(process => process.ProcessSteps)
@@ -615,29 +620,6 @@ namespace LCT.SW360PackageCreator
             item.ParentReleaseName = releasesInfo.Name;
 
             return Task.CompletedTask;
-        }
-        public static async Task ProcessReleaseAlreadyExist(ComparisonBomData item, ISw360CreatorService sw360CreatorService, CommonAppSettings appSettings, ReleaseCreateStatus releaseCreateStatus)
-        {
-            if (releaseCreateStatus.ReleaseAlreadyExist)
-            {
-                if (!string.IsNullOrEmpty(item.ReleaseID))
-                {
-                    ReleasesInfo releasesInfo = await sw360CreatorService.GetReleaseInfo(item.ReleaseID);
-                    item.ParentReleaseName = releasesInfo?.Name ?? string.Empty;
-                    item.ApprovedStatus = releasesInfo?.ClearingState;
-                    if (IsReleaseAttachmentExist(releasesInfo))
-                    {
-                        await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
-                    }
-                }
-            }
-            else
-            {
-                if (!(string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
-                {
-                    await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
-                }
-            }
         }
         public static bool IsReleaseAttachmentExist(ReleasesInfo releasesInfo)
         {

--- a/src/LCT.SW360PackageCreator/CreatorValidator.cs
+++ b/src/LCT.SW360PackageCreator/CreatorValidator.cs
@@ -37,7 +37,21 @@ namespace LCT.SW360PackageCreator
         {
             string sw360ProjectName = await sw360ProjectService.GetProjectNameByProjectIDFromSW360(appSettings.SW360.ProjectID, appSettings.SW360.ProjectName, projectReleases);
 
-            return CommonHelper.ValidateSw360Project(sw360ProjectName, projectReleases?.clearingState,projectReleases?.Name, appSettings);
+            if (string.IsNullOrEmpty(sw360ProjectName))
+            {
+                throw new InvalidDataException($"Invalid Project Id - {appSettings.SW360.ProjectID}");
+            }
+            else if (projectReleases?.clearingState == "CLOSED")
+            {
+                Logger.Error($"Provided Sw360 project is not in active state ,Please make sure you added the correct project details that is in active state..");
+                Logger.Debug($"ValidateAppSettings() : Sw360 project " + projectReleases.Name + " is in " + projectReleases.clearingState + " state.");
+                return -1;
+            }
+            else
+            {
+                appSettings.SW360.ProjectName = sw360ProjectName;
+            }
+            return 0;
         }
         public static async Task TriggerFossologyValidation(CommonAppSettings appSettings, ISW360ApicommunicationFacade sW360ApicommunicationFacade)
         {

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -173,7 +173,6 @@ namespace LCT.Services
                     releaseId = await GetReleaseIdToLinkToProject(componentInfo.Name, componentInfo.Version, componentInfo.ReleaseExternalId, componentId);
                     Logger.Debug($"CreateReleaseForComponent():Release already exists for component -->" +
                         $"{componentInfo.Name} - {componentInfo.Version}. No changes made by tool");
-                    createStatus.ReleaseAlreadyExist = true;
                 }
                 else
                 {
@@ -186,7 +185,7 @@ namespace LCT.Services
                         $"response status code-{response.StatusCode} and reason pharase-{response.ReasonPhrase}");
                 }
 
-                Logger.Debug($"Component Name -{componentInfo.Name},Version :{componentInfo.Version} , Release Id :{releaseId}");
+                Logger.Debug($"Component Name -{componentInfo.Name}{componentInfo.Version} : Release Id :{releaseId}");
                 createStatus.ReleaseIdToLink = releaseId;
             }
             catch (HttpRequestException e)


### PR DESCRIPTION
Refactored retry logic in `RetryHttpClientHandler.cs` to simplify context initialization and improve maintainability. Simplified `SetLogWarnings` method in `SW360Apicommunication.cs` and removed redundant calls. Updated clearing state logic and removed deprecated test cases in `ComponentCreatorTest.cs`. Refactored `ComponentCreator.cs` to integrate `ProcessReleaseAlreadyExist` logic and enhance FOSSology trigger validation. Improved validation in `CreatorValidator.cs` for active SW360 projects. Centralized logging initialization in `Program.cs`. Performed general code cleanup, including removing unused imports and improving log message clarity.

BREAKING CHANGE: Removed `ProcessReleaseAlreadyExist` method in `ComponentCreator.cs` and updated `SetLogWarnings` method signature.