### PR TITLE
feat: Upgrade the CA Tool to support the latest CycloneDX SBOM schema (v1.6) with Siemens SBOM Standard version v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To ensure such practises are in place, we need to provide software bill of mater
 
 
 This tool has been  logically split into 3 different executables that enable it to be used as separate modules as per the user's requirement.
-
+**_Note: The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements._**
 **_Note: Continuous Clearing Tool internally uses [Syft](https://github.com/anchore/syft) for component detection for debian/alpine type projects._**
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ To ensure such practises are in place, we need to provide software bill of mater
 
 
 This tool has been  logically split into 3 different executables that enable it to be used as separate modules as per the user's requirement.
+
 **_Note: The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements._**
+
 **_Note: Continuous Clearing Tool internally uses [Syft](https://github.com/anchore/syft) for component detection for debian/alpine type projects._**
 
 

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3e407ffb-8ef0-4b06-bcdb-bdbe12dcd2a7",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:57:03Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -149,5 +143,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:fe6bfc03-6e58-4ee4-bbe3-b1dc8fd73ad5",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T14:06:17Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -382,5 +376,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:383df7b9-7355-4912-98ce-dc0c93573a11",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:12Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -361,5 +355,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
+++ b/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
+++ b/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7b3d78c-3b44-41c4-a7d2-1f4be11916bc",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:54:44Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -409,5 +403,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -138,7 +138,7 @@ Explore these configurations in the [DemoProject](../../DemoProject). These samp
 ### Overview
 The Continuous Clearing Tool comprises three executable DLLs, each playing a crucial role in achieving a comprehensive license clearing process. Execute them sequentially as listed below:
 
-`Note:The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements.`
+**Note** :The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements.
 
 > **1. Package Identifier**
 > - This DLL processes the input file and generates a CycloneDX BOM file. The input can be a package file or a CycloneDX BOM file created using a standard tool. If multiple input files are present, simply provide the path to the directory as an argument.

--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -138,6 +138,8 @@ Explore these configurations in the [DemoProject](../../DemoProject). These samp
 ### Overview
 The Continuous Clearing Tool comprises three executable DLLs, each playing a crucial role in achieving a comprehensive license clearing process. Execute them sequentially as listed below:
 
+`Note:The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements.`
+
 > **1. Package Identifier**
 > - This DLL processes the input file and generates a CycloneDX BOM file. The input can be a package file or a CycloneDX BOM file created using a standard tool. If multiple input files are present, simply provide the path to the directory as an argument.
 

--- a/src/ArtifactoryUploader/PackageUploader.cs
+++ b/src/ArtifactoryUploader/PackageUploader.cs
@@ -12,7 +12,6 @@ using LCT.Common;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/ArtifactoryUploader/PackageUploader.cs
+++ b/src/ArtifactoryUploader/PackageUploader.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Level = log4net.Core.Level;
 
 namespace LCT.ArtifactoryUploader
 {

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -110,7 +110,7 @@ namespace ArtifactoryUploader
             catoolInfo.CatoolVersion = $"{versionFromProj.Major}.{versionFromProj.Minor}.{versionFromProj.Build}";
             catoolInfo.CatoolRunningLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             return catoolInfo;
-        }
+        }        
 
         private static IJFrogService GetJfrogService(CommonAppSettings appSettings)
         {

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -23,8 +23,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ArtifactoryUploader
@@ -112,7 +110,7 @@ namespace ArtifactoryUploader
             catoolInfo.CatoolVersion = $"{versionFromProj.Major}.{versionFromProj.Minor}.{versionFromProj.Build}";
             catoolInfo.CatoolRunningLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             return catoolInfo;
-        }        
+        }
 
         private static IJFrogService GetJfrogService(CommonAppSettings appSettings)
         {

--- a/src/LCT.APICommunications.UTest/AttachmentHelperUTest.cs
+++ b/src/LCT.APICommunications.UTest/AttachmentHelperUTest.cs
@@ -46,7 +46,7 @@ namespace LCT.APICommunications.UTest
             var result = _attachmentHelper.AttachComponentSourceToSW360(attachReport);
 
             // Assert
-            Assert.AreEqual("https://api.mock.com/release/123/attachments", result);
+            Assert.That(result, Is.EqualTo("https://api.mock.com/release/123/attachments"));
         }
 
         [Test]
@@ -66,12 +66,12 @@ namespace LCT.APICommunications.UTest
 
             // Assert
             var jsonFilePath = Path.Combine(folderPath, "Attachment.json");
-            Assert.IsTrue(File.Exists(jsonFilePath));
+            Assert.That(File.Exists(jsonFilePath), Is.True);
 
             // Validate JSON content
             var fileContent = File.ReadAllText(jsonFilePath);
-            Assert.IsTrue(fileContent.Contains("Source"));
-            Assert.IsTrue(fileContent.Contains("Test comment"));
+            Assert.That(fileContent, Does.Contain("Source"));
+            Assert.That(fileContent, Does.Contain("Test comment"));
 
             // Cleanup
             File.Delete(jsonFilePath);

--- a/src/LCT.APICommunications.UTest/NPMJfrogAPICommunicationUTest.cs
+++ b/src/LCT.APICommunications.UTest/NPMJfrogAPICommunicationUTest.cs
@@ -107,13 +107,13 @@ namespace LCT.APICommunications.UTest
             var response = await jfrogApiCommunication.GetPackageInfo(component);
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         // Custom HttpMessageHandler to mock SendAsync
         public class MockHttpMessageHandler : HttpMessageHandler
         {
-            private HttpResponseMessage _response;
+            private HttpResponseMessage? _response;
 
             public void SetResponse(HttpResponseMessage response)
             {
@@ -122,6 +122,10 @@ namespace LCT.APICommunications.UTest
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                if (_response == null)
+                {
+                    throw new InvalidOperationException("Mock response has not been set.");
+                }
                 return Task.FromResult(_response);
             }
         }

--- a/src/LCT.APICommunications.UTest/RetryHttpClientHandlerUTest.cs
+++ b/src/LCT.APICommunications.UTest/RetryHttpClientHandlerUTest.cs
@@ -47,7 +47,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
             handlerMock.Protected().Verify(
                 "SendAsync",
                 Times.Exactly(3), // 2 retries + 1 initial call
@@ -79,7 +79,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
             handlerMock.Protected().Verify(
                 "SendAsync",
                 Times.Once(), // No retries
@@ -113,7 +113,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
         [Test]
         public async Task ExecuteWithRetryAsync_ShouldCompleteSuccessfully_WhenActionSucceedsAfterRetry()
@@ -134,7 +134,7 @@ namespace LCT.APICommunications.UTest
             await RetryHttpClientHandler.ExecuteWithRetryAsync(action);
 
             // Assert
-            Assert.AreEqual(ApiConstant.APIRetryIntervals.Count, attempts, "Action should have been attempted the expected number of times.");
+            Assert.That(attempts, Is.EqualTo(ApiConstant.APIRetryIntervals.Count), "Action should have been attempted the expected number of times.");
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace LCT.APICommunications.UTest
             await RetryHttpClientHandler.ExecuteWithRetryAsync(action);
 
             // Assert
-            Assert.IsTrue(actionExecuted, "Action should have been executed.");
+            Assert.That(actionExecuted, Is.True, "Action should have been executed.");
             _mockLogger.Verify(logger => logger.Debug(It.IsAny<string>()), Times.Never, "Retry should not occur if there is no exception.");
         }
 

--- a/src/LCT.APICommunications/DebianJfrogAPICommunication.cs
+++ b/src/LCT.APICommunications/DebianJfrogAPICommunication.cs
@@ -57,7 +57,7 @@ namespace LCT.APICommunications
 
         public override async Task<HttpResponseMessage> MoveFromRepo(ComponentsToArtifactory component)
         {
-            HttpClient httpClient = GetHttpClient(ArtifactoryCredentials);            
+            HttpClient httpClient = GetHttpClient(ArtifactoryCredentials);
             const HttpContent httpContent = null;
             return await httpClient.PostAsync(component.MovePackageApiUrl, httpContent);
         }

--- a/src/LCT.APICommunications/DebianJfrogAPICommunication.cs
+++ b/src/LCT.APICommunications/DebianJfrogAPICommunication.cs
@@ -57,7 +57,7 @@ namespace LCT.APICommunications
 
         public override async Task<HttpResponseMessage> MoveFromRepo(ComponentsToArtifactory component)
         {
-            HttpClient httpClient = GetHttpClient(ArtifactoryCredentials);
+            HttpClient httpClient = GetHttpClient(ArtifactoryCredentials);            
             const HttpContent httpContent = null;
             return await httpClient.PostAsync(component.MovePackageApiUrl, httpContent);
         }

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -145,7 +145,7 @@ namespace LCT.Common.UTest
             List<Component> listComponentForBOM = new List<Component>();
 
             //Act
-            CommonHelper.GetDetailsforManuallyAdded(componentsForBOM, listComponentForBOM);
+            CommonHelper.GetDetailsForManuallyAdded(componentsForBOM, listComponentForBOM);
 
             //Assert
             Assert.AreEqual(2, listComponentForBOM.Count);

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -502,7 +502,7 @@ namespace LCT.Common.UTest
             string[] result = CommonHelper.MaskSensitiveArguments(args);
 
             // Assert
-            Assert.IsEmpty(result, "Null input should return an empty array.");           
+            Assert.IsEmpty(result, "Null input should return an empty array.");            
         }
         [Test]
         public void DefaultLogFolderInitialisation_SetsDefaultLogPath_Windows()
@@ -512,7 +512,7 @@ namespace LCT.Common.UTest
             string runningLocation=Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             Log4Net.CatoolCurrentDirectory = System.IO.Directory.GetParent(runningLocation).FullName;
             bool m_Verbose = false;
-        
+          
 
             // Act
             CommonHelper.DefaultLogFolderInitialisation(logFileName, m_Verbose);

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -502,17 +502,17 @@ namespace LCT.Common.UTest
             string[] result = CommonHelper.MaskSensitiveArguments(args);
 
             // Assert
-            Assert.IsEmpty(result, "Null input should return an empty array.");
+            Assert.IsEmpty(result, "Null input should return an empty array.");           
         }
         [Test]
         public void DefaultLogFolderInitialisation_SetsDefaultLogPath_Windows()
         {
             // Arrange
             string logFileName = FileConstant.BomCreatorLog;
-            string runningLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string runningLocation=Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             Log4Net.CatoolCurrentDirectory = System.IO.Directory.GetParent(runningLocation).FullName;
             bool m_Verbose = false;
-
+        
 
             // Act
             CommonHelper.DefaultLogFolderInitialisation(logFileName, m_Verbose);
@@ -524,9 +524,9 @@ namespace LCT.Common.UTest
             else
             {
                 Assert.AreEqual("/var/log", CommonHelper.DefaultLogPath);
-            }
-
-        }
+            }               
+            
+        }        
     }
 
     public class TestObject

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -526,7 +526,7 @@ namespace LCT.Common.UTest
                 Assert.AreEqual("/var/log", CommonHelper.DefaultLogPath);
             }               
             
-        }        
+        }       
     }
 
     public class TestObject

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -67,7 +67,7 @@ namespace LCT.Common.UTest
         [Test]
         public void LogFolderInitialisation_WhenLogFolderIsNull_ReturnsDefaultLogPath()
         {
-            Log4Net.CatoolLogPath= "C:\\catool\\fds.log";
+            Log4Net.CatoolLogPath = "C:\\catool\\fds.log";
 
             // Act
             string result = CommonHelper.LogFolderInitialisation(appSettings, "catool.log", false);
@@ -502,17 +502,17 @@ namespace LCT.Common.UTest
             string[] result = CommonHelper.MaskSensitiveArguments(args);
 
             // Assert
-            Assert.IsEmpty(result, "Null input should return an empty array.");            
+            Assert.IsEmpty(result, "Null input should return an empty array.");
         }
         [Test]
         public void DefaultLogFolderInitialisation_SetsDefaultLogPath_Windows()
         {
             // Arrange
             string logFileName = FileConstant.BomCreatorLog;
-            string runningLocation=Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string runningLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             Log4Net.CatoolCurrentDirectory = System.IO.Directory.GetParent(runningLocation).FullName;
             bool m_Verbose = false;
-          
+
 
             // Act
             CommonHelper.DefaultLogFolderInitialisation(logFileName, m_Verbose);
@@ -524,9 +524,9 @@ namespace LCT.Common.UTest
             else
             {
                 Assert.AreEqual("/var/log", CommonHelper.DefaultLogPath);
-            }               
-            
-        }       
+            }
+
+        }
     }
 
     public class TestObject

--- a/src/LCT.Common.UTests/Log4NetTests.cs
+++ b/src/LCT.Common.UTests/Log4NetTests.cs
@@ -196,7 +196,7 @@ namespace LCT.Common.UTest
         {
             // Arrange
             bool verbose = true;
-            string? logPath = null;
+            string logPath = null;
             IAppender[] appenders = [new RollingFileAppender()];
 
             // Act

--- a/src/LCT.Common.UTests/TelemetryHelperTests.cs
+++ b/src/LCT.Common.UTests/TelemetryHelperTests.cs
@@ -6,7 +6,6 @@
 
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace LCT.Common.UTest
 {
@@ -15,7 +14,6 @@ namespace LCT.Common.UTest
     {
         private TelemetryHelper telemetryHelper;
         private CommonAppSettings appSettings;
-        private readonly StringWriter consoleOutput;
         [SetUp]
         public void Setup()
         {

--- a/src/LCT.Common/CommonAppSettings.cs
+++ b/src/LCT.Common/CommonAppSettings.cs
@@ -33,7 +33,6 @@ namespace LCT.Common
         public static string AlpineAportsGitURL { get; set; } = $"https://gitlab.alpinelinux.org/alpine/aports.git";
 
         private string m_ProjectType;
-        private string m_LogFolderPath;
         public CommonAppSettings()
         {
             folderAction = new FolderAction();

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -284,7 +284,7 @@ namespace LCT.Common
             }
 
             return Array.Empty<string>();
-        }
+        }        
         public static string LogFolderInitialisation(CommonAppSettings appSettings, string logFileName, bool m_Verbose)
         {
             string FolderPath = DefaultLogPath;
@@ -322,7 +322,7 @@ namespace LCT.Common
                 }
             }
             return FolderPath;
-        }
+        }        
         public static void DefaultLogFolderInitialisation(string logFileName, bool m_Verbose)
         {
             string FolderPath;
@@ -345,7 +345,7 @@ namespace LCT.Common
 
             invalidChars = string.Join(", ", foundInvalidChars.Select(c => $"'{c}'"));
             return foundInvalidChars.Count != 0;
-        }
+        }        
         public static int ValidateSw360Project(string sw360ProjectName, string clearingState, string Name, CommonAppSettings appSettings)
         {
             if (string.IsNullOrEmpty(sw360ProjectName))
@@ -395,12 +395,12 @@ namespace LCT.Common
                     if (i + 1 < args.Length)
                     {
                         maskedArgs[i + 1] = "******";
-                        skipNext = true;
+                        skipNext = true; 
                     }
                 }
                 else
                 {
-                    maskedArgs[i] = args[i];
+                    maskedArgs[i] = args[i]; 
                 }
             }
 

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -249,7 +249,7 @@ namespace LCT.Common
 
         public static string AddSpecificValuesToBOMFormat(Bom listOfComponentsToBom)
         {
-            string guid = Guid.NewGuid().ToString();            
+            string guid = Guid.NewGuid().ToString();
             listOfComponentsToBom.SerialNumber = $"urn:uuid:{guid}";
             listOfComponentsToBom.Version = 1;
             listOfComponentsToBom.Metadata.Timestamp = DateTime.UtcNow;
@@ -284,7 +284,7 @@ namespace LCT.Common
             }
 
             return Array.Empty<string>();
-        }        
+        }
         public static string LogFolderInitialisation(CommonAppSettings appSettings, string logFileName, bool m_Verbose)
         {
             string FolderPath = DefaultLogPath;
@@ -322,7 +322,7 @@ namespace LCT.Common
                 }
             }
             return FolderPath;
-        }        
+        }
         public static void DefaultLogFolderInitialisation(string logFileName, bool m_Verbose)
         {
             string FolderPath;
@@ -345,7 +345,7 @@ namespace LCT.Common
 
             invalidChars = string.Join(", ", foundInvalidChars.Select(c => $"'{c}'"));
             return foundInvalidChars.Count != 0;
-        }        
+        }
         public static int ValidateSw360Project(string sw360ProjectName, string clearingState, string Name, CommonAppSettings appSettings)
         {
             if (string.IsNullOrEmpty(sw360ProjectName))
@@ -395,12 +395,12 @@ namespace LCT.Common
                     if (i + 1 < args.Length)
                     {
                         maskedArgs[i + 1] = "******";
-                        skipNext = true; 
+                        skipNext = true;
                     }
                 }
                 else
                 {
-                    maskedArgs[i] = args[i]; 
+                    maskedArgs[i] = args[i];
                 }
             }
 

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Level = log4net.Core.Level;
 
 namespace LCT.Common
 {
@@ -233,7 +234,7 @@ namespace LCT.Common
             return component.Properties.Exists(x => x.Name == constant);
         }
 
-        public static void GetDetailsforManuallyAdded(List<Component> componentsForBOM, List<Component> listComponentForBOM)
+        public static void GetDetailsForManuallyAdded(List<Component> componentsForBOM, List<Component> listComponentForBOM)
         {
             foreach (var component in componentsForBOM)
             {
@@ -248,13 +249,14 @@ namespace LCT.Common
 
         public static string AddSpecificValuesToBOMFormat(Bom listOfComponentsToBom)
         {
-            string guid = Guid.NewGuid().ToString();
+            string guid = Guid.NewGuid().ToString();            
             listOfComponentsToBom.SerialNumber = $"urn:uuid:{guid}";
             listOfComponentsToBom.Version = 1;
             listOfComponentsToBom.Metadata.Timestamp = DateTime.UtcNow;
-            var formattedString = CycloneDX.Json.Serializer.Serialize(listOfComponentsToBom);
-
-            return formattedString;
+            listOfComponentsToBom.SpecVersion = CycloneDX.SpecificationVersion.v1_6;
+            listOfComponentsToBom.SpecVersionString = "1.6";
+            var serializedBomData = CycloneDX.Json.Serializer.Serialize(listOfComponentsToBom);
+            return serializedBomData;
         }
         public static string[] GetRepoList(CommonAppSettings appSettings)
         {

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -254,7 +254,7 @@ namespace LCT.Common
             listOfComponentsToBom.Version = 1;
             listOfComponentsToBom.Metadata.Timestamp = DateTime.UtcNow;
             listOfComponentsToBom.SpecVersion = CycloneDX.SpecificationVersion.v1_6;
-            listOfComponentsToBom.SpecVersionString = "1.6";
+            listOfComponentsToBom.SpecVersionString = Dataconstant.SbomSpecVersionString;
             var serializedBomData = CycloneDX.Json.Serializer.Serialize(listOfComponentsToBom);
             return serializedBomData;
         }

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -75,6 +75,7 @@ namespace LCT.Common.Constants
         public const string TypeJarSuffix = "?type=jar";
         public const string GithubUrl = "https://github.com/siemens/continuous-clearing";
         public const string StandardSbomUrl = "https://sbom.siemens.io/";
+        public const string SbomSpecVersionString = "1.6";
         public static Dictionary<string, string> PurlCheck()
         {
             return purlids;

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -73,7 +73,8 @@ namespace LCT.Common.Constants
         public const string ScanAvailableState = "SCAN_AVAILABLE";
         public const string SentToClearingState = "SENT_TO_CLEARING_TOOL";
         public const string TypeJarSuffix = "?type=jar";
-
+        public const string GithubUrl = "https://github.com/siemens/continuous-clearing";
+        public const string StandardSbomUrl = "https://sbom.siemens.io/";
         public static Dictionary<string, string> PurlCheck()
         {
             return purlids;

--- a/src/LCT.CycloneDxProcessor/App.config
+++ b/src/LCT.CycloneDxProcessor/App.config
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT-->
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.222.6406" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/LCT.CycloneDxProcessor/App.config
+++ b/src/LCT.CycloneDxProcessor/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--SPDX-FileCopyrightText: 2025 Siemens AG
 SPDX-License-Identifier: MIT-->
-<configuration xmlns="schema url">
+<configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
+++ b/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CycloneDX.Utils" Version="5.2.0" />
+    <PackageReference Include="CycloneDX.Utils" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
@@ -52,10 +52,10 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             //Act
-            int result=await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
+            int result = await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
 
             //Assert
-            Assert.AreEqual(-1,result, "Expected -1 when clearing state is CLOSED.");
+            Assert.AreEqual(-1, result, "Expected -1 when clearing state is CLOSED.");
 
         }
 
@@ -92,6 +92,6 @@ namespace LCT.PackageIdentifier.UTest
             return Task.CompletedTask;
         }
 
-        
+
     }
 }

--- a/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
@@ -55,7 +55,7 @@ namespace LCT.PackageIdentifier.UTest
             int result=await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
 
             //Assert
-            Assert.AreEqual(-1, result, "Expected -1 when clearing state is CLOSED.");
+            Assert.AreEqual(-1,result, "Expected -1 when clearing state is CLOSED.");
 
         }
 

--- a/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
@@ -52,7 +52,7 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             //Act
-            int result = await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
+            int result=await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
 
             //Assert
             Assert.AreEqual(-1, result, "Expected -1 when clearing state is CLOSED.");
@@ -92,6 +92,6 @@ namespace LCT.PackageIdentifier.UTest
             return Task.CompletedTask;
         }
 
-
+        
     }
 }

--- a/src/LCT.PackageIdentifier.UTest/CycloneBomProcessorTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/CycloneBomProcessorTests.cs
@@ -10,7 +10,6 @@ using LCT.Common;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -84,7 +83,7 @@ namespace LCT.PackageIdentifier.UTest
             }
                     }
                 },
-                Definitions=new Definitions() 
+                Definitions = new Definitions()
             };
 
             CommonAppSettings appSettings = new CommonAppSettings()
@@ -92,8 +91,8 @@ namespace LCT.PackageIdentifier.UTest
                 SW360 = new() { ProjectName = "Test" }
             };
             projectReleases.Version = "1.2.3";
-            
-           
+
+
             Component component = new Component
             {
                 Name = appSettings.SW360.ProjectName,

--- a/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
+++ b/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
@@ -441,7 +441,7 @@ namespace LCT.PackageIdentifier.UTest
 
         [Test]
         public void GetdependencyDetailsOfAComponent_ReturnsListOfDependency_SuccessFully()
-        {
+        {            
             // Arrange
             Component component = new Component
             {
@@ -450,8 +450,10 @@ namespace LCT.PackageIdentifier.UTest
                 Description = string.Empty,
                 Version = "1.0.0",
                 Purl = "pkg:npm/animations@1.0.0",
-                Author = "{ testcomponent:1.2.3 , subdepenendency:3.4.1 }"
-
+                Manufacturer = new OrganizationalEntity
+                {
+                    BomRef = "{ testcomponent:1.2.3 , subdepenendency:3.4.1 }"
+                }
             };
             List<Component> componentsForBOM = new List<Component>();
             componentsForBOM.Add(component);

--- a/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
+++ b/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
@@ -441,7 +441,7 @@ namespace LCT.PackageIdentifier.UTest
 
         [Test]
         public void GetdependencyDetailsOfAComponent_ReturnsListOfDependency_SuccessFully()
-        {            
+        {
             // Arrange
             Component component = new Component
             {

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -14,7 +14,6 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -24,6 +24,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 
 namespace LCT.PackageIdentifier

--- a/src/LCT.PackageIdentifier/BomHelper.cs
+++ b/src/LCT.PackageIdentifier/BomHelper.cs
@@ -12,7 +12,6 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/LCT.PackageIdentifier/BomHelper.cs
+++ b/src/LCT.PackageIdentifier/BomHelper.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Level = log4net.Core.Level;
 
 namespace LCT.PackageIdentifier
 {

--- a/src/LCT.PackageIdentifier/BomValidator.cs
+++ b/src/LCT.PackageIdentifier/BomValidator.cs
@@ -6,10 +6,8 @@
 
 using LCT.APICommunications.Model;
 using LCT.Common;
-using LCT.Common.Interface;
 using LCT.Services.Interface;
 using log4net;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -20,7 +18,7 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public static class BomValidator
     {
-        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);        
+        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         public static async Task<int> ValidateAppSettings(CommonAppSettings appSettings, ISw360ProjectService bomService, ProjectReleases projectReleases)
         {
             string sw360ProjectName = await bomService.GetProjectNameByProjectIDFromSW360(appSettings.SW360.ProjectID, appSettings.SW360.ProjectName, projectReleases);

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -62,6 +62,7 @@ namespace LCT.PackageIdentifier
         {
             new Component
             {
+                Type= Component.Classification.Application,
                 Supplier = new OrganizationalEntity
                 {
                     Name = "Siemens AG"
@@ -91,7 +92,7 @@ namespace LCT.PackageIdentifier
             Value = "clearing"
         }
     };
-        }        
+        }
         private static Component CreateMetadataComponent(CommonAppSettings appSettings, ProjectReleases projectReleases)
         {
             return new Component

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -73,7 +73,7 @@ namespace LCT.PackageIdentifier
                     new ExternalReference
                     {
                         Type = ExternalReference.ExternalReferenceType.Website,
-                        Url = GetExternalReferenceUrl("GitHubRepo")
+                        Url = Dataconstant.GithubUrl
                     }
                 }
             }
@@ -91,18 +91,7 @@ namespace LCT.PackageIdentifier
             Value = "clearing"
         }
     };
-        }
-        private static string GetExternalReferenceUrl(string key)
-        {
-            var urls = new Dictionary<string, string>
-    {
-        { "GitHubRepo", "https://github.com/siemens/continuous-clearing" },
-        { "StandardBOM", "https://sbom.siemens.io/" }
-    };
-
-            return urls.TryGetValue(key, out string value) ? value : string.Empty;
-        }
-
+        }        
         private static Component CreateMetadataComponent(CommonAppSettings appSettings, ProjectReleases projectReleases)
         {
             return new Component
@@ -129,7 +118,7 @@ namespace LCT.PackageIdentifier
                     new ExternalReference
                     {
                         Type = ExternalReference.ExternalReferenceType.Website,
-                        Url = GetExternalReferenceUrl("StandardBOM")
+                        Url = Dataconstant.StandardSbomUrl
                     }
                 },
                 BomRef = "standard-bom"

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -10,7 +10,6 @@ using LCT.Common;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using log4net;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -74,7 +73,7 @@ namespace LCT.PackageIdentifier
                     new ExternalReference
                     {
                         Type = ExternalReference.ExternalReferenceType.Website,
-                        Url = "https://github.com/siemens/continuous-clearing"
+                        Url = GetExternalReferenceUrl("GitHubRepo")
                     }
                 }
             }
@@ -93,6 +92,16 @@ namespace LCT.PackageIdentifier
         }
     };
         }
+        private static string GetExternalReferenceUrl(string key)
+        {
+            var urls = new Dictionary<string, string>
+    {
+        { "GitHubRepo", "https://github.com/siemens/continuous-clearing" },
+        { "StandardBOM", "https://sbom.siemens.io/" }
+    };
+
+            return urls.TryGetValue(key, out string value) ? value : string.Empty;
+        }
 
         private static Component CreateMetadataComponent(CommonAppSettings appSettings, ProjectReleases projectReleases)
         {
@@ -103,7 +112,7 @@ namespace LCT.PackageIdentifier
                 Type = Component.Classification.Application
             };
         }
-        public static Definitions AddDefinitionsToBom()
+        private static Definitions AddDefinitionsToBom()
         {
             Definitions definitions = new Definitions
             {
@@ -120,7 +129,7 @@ namespace LCT.PackageIdentifier
                     new ExternalReference
                     {
                         Type = ExternalReference.ExternalReferenceType.Website,
-                        Url = "https://sbom.siemens.io/"
+                        Url = GetExternalReferenceUrl("StandardBOM")
                     }
                 },
                 BomRef = "standard-bom"
@@ -129,7 +138,7 @@ namespace LCT.PackageIdentifier
             };
 
             return definitions;
-        }        
+        }
         public static void SetProperties(CommonAppSettings appSettings, Component component, ref List<Component> componentForBOM, string repo = "Not Found in JFrogRepo")
         {
             List<Property> propList = new();

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -21,9 +21,9 @@ namespace LCT.PackageIdentifier
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         public static Bom SetMetadataInComparisonBOM(Bom bom,
-                                             CommonAppSettings appSettings,
-                                             ProjectReleases projectReleases,
-                                             CatoolInfo caToolInformation)
+                                                     CommonAppSettings appSettings,
+                                                     ProjectReleases projectReleases,
+                                                     CatoolInfo caToolInformation)
         {
             Logger.Debug("Starting to add metadata info into the BOM");
 

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -27,7 +27,7 @@
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
 		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.11" />
 	</ItemGroup>
   
 	<ItemGroup>

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -127,7 +127,7 @@ namespace LCT.PackageIdentifier
                 component.Purl = RemoveSuffix(component.Purl, suffix);
             }
 
-            foreach (var dependency in bom?.Dependencies ?? Enumerable.Empty<Dependency>())
+            foreach (var dependency in bom?.Dependencies ?? Enumerable.Empty<Dependency>()) 
             {
                 RemoveTypeJarSuffixFromDependency(dependency);
             }

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -127,7 +127,7 @@ namespace LCT.PackageIdentifier
                 component.Purl = RemoveSuffix(component.Purl, suffix);
             }
 
-            foreach (var dependency in bom?.Dependencies ?? Enumerable.Empty<Dependency>()) 
+            foreach (var dependency in bom?.Dependencies ?? Enumerable.Empty<Dependency>())
             {
                 RemoveTypeJarSuffixFromDependency(dependency);
             }

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -214,7 +214,7 @@ namespace LCT.PackageIdentifier
                     continue;
                 }
 
-                Component components = new Component();
+                Component components = new Component() { Manufacturer = new OrganizationalEntity() };
                 var properties = JObject.Parse(Convert.ToString(prop.Value));
 
                 // dev components are not ignored and added as a part of SBOM 
@@ -238,7 +238,7 @@ namespace LCT.PackageIdentifier
                 components.Type = Component.Classification.Library;
                 components.Description = folderPath;
                 components.Version = Convert.ToString(properties[Version]);
-                components.Author = prop.Value[Dependencies]?.ToString();
+                components.Manufacturer.BomRef = prop.Value[Dependencies]?.ToString();
                 components.Purl = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.BomRef = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
 
@@ -311,7 +311,7 @@ namespace LCT.PackageIdentifier
 
             foreach (JProperty prop in depencyComponentList)
             {
-                Component components = new Component();
+                Component components = new Component() {Manufacturer= new OrganizationalEntity() };
                 Property isdev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
 
                 var properties = JObject.Parse(Convert.ToString(prop.Value));
@@ -352,7 +352,7 @@ namespace LCT.PackageIdentifier
 
                 components.Description = folderPath;
                 components.Version = Convert.ToString(properties[Version]);
-                components.Author = prop.Value[Requires]?.ToString();
+                components.Manufacturer.BomRef = prop.Value[Requires]?.ToString();
                 components.Purl = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.BomRef = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.Type = Component.Classification.Library;
@@ -563,10 +563,10 @@ namespace LCT.PackageIdentifier
 
             foreach (var component in componentsForBOM)
             {
-                if ((component.Author?.Split(",")) != null)
+                if ((component.Manufacturer?.BomRef?.Split(",")) != null)
                 {
                     List<Dependency> subDependencies = new();
-                    foreach (var item in (component.Author?.Split(",")).Where(item => item.Contains(':')))
+                    foreach (var item in (component.Manufacturer?.BomRef?.Split(",")).Where(item => item.Contains(':')))
                     {
                         var componentDetails = item.Split(":");
                         string name;
@@ -599,9 +599,10 @@ namespace LCT.PackageIdentifier
 
                     dependencyList.Add(dependency);
 
-                    component.Author = null;
+                    component.Manufacturer = null;
 
                 }
+                component.Manufacturer = null;
             }
             dependencies.AddRange(dependencyList);
         }

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -311,7 +311,7 @@ namespace LCT.PackageIdentifier
 
             foreach (JProperty prop in depencyComponentList)
             {
-                Component components = new Component() {Manufacturer= new OrganizationalEntity() };
+                Component components = new Component() { Manufacturer = new OrganizationalEntity() };
                 Property isdev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
 
                 var properties = JObject.Parse(Convert.ToString(prop.Value));

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -462,7 +462,7 @@ namespace LCT.PackageIdentifier
                         CycloneDXBomParser.CheckValidComponentsForProjectType(
                             bom.Components, appSettings.ProjectType);
                         componentsForBOM.AddRange(bom.Components);
-                        CommonHelper.GetDetailsforManuallyAdded(componentsForBOM,
+                        CommonHelper.GetDetailsForManuallyAdded(componentsForBOM,
                             listComponentForBOM);
                     }
                 }

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -56,7 +56,7 @@ namespace LCT.PackageIdentifier
             CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
             ProjectReleases projectReleases = new ProjectReleases();
-            
+
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);
             Logger.Logger.Log(null, Level.Debug, $"log manager initiated folder path: {FolderPath}", null);
             settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -39,7 +39,7 @@ namespace LCT.PackageIdentifier
 
         public static Stopwatch BomStopWatch { get; set; }
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();
+        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();        
         protected Program() { }
 
         static async Task Main(string[] args)
@@ -57,7 +57,7 @@ namespace LCT.PackageIdentifier
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
 
             ProjectReleases projectReleases = new ProjectReleases();
-
+            
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);
             Logger.Logger.Log(null, Level.Debug, $"log manager initiated folder path: {FolderPath}", null);
             settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
@@ -156,6 +156,6 @@ namespace LCT.PackageIdentifier
             {
                 environmentHelper.CallEnvironmentExit(-1);
             }
-        }
+        }        
     }
 }

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -55,6 +55,7 @@ namespace LCT.PackageIdentifier
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
             CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
+
             ProjectReleases projectReleases = new ProjectReleases();
 
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -55,7 +55,6 @@ namespace LCT.PackageIdentifier
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
             CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
-
             ProjectReleases projectReleases = new ProjectReleases();
             
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -55,7 +55,7 @@ namespace LCT.PackageIdentifier
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
             CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
-
+            
             ProjectReleases projectReleases = new ProjectReleases();
 
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -23,8 +23,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
 
@@ -41,7 +39,7 @@ namespace LCT.PackageIdentifier
 
         public static Stopwatch BomStopWatch { get; set; }
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();        
+        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();
         protected Program() { }
 
         static async Task Main(string[] args)
@@ -57,7 +55,7 @@ namespace LCT.PackageIdentifier
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
             CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
             CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
-            
+
             ProjectReleases projectReleases = new ProjectReleases();
 
             string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);
@@ -158,6 +156,6 @@ namespace LCT.PackageIdentifier
             {
                 environmentHelper.CallEnvironmentExit(-1);
             }
-        }        
+        }
     }
 }

--- a/src/LCT.PackageIdentifier/SbomTemplate.cs
+++ b/src/LCT.PackageIdentifier/SbomTemplate.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Level = log4net.Core.Level;
 
 namespace LCT.PackageIdentifier
 {

--- a/src/LCT.PackageIdentifier/SbomTemplate.cs
+++ b/src/LCT.PackageIdentifier/SbomTemplate.cs
@@ -8,7 +8,6 @@ using CycloneDX.Models;
 using LCT.Common;
 using LCT.Common.Constants;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
@@ -282,7 +282,7 @@ namespace LCT.SW360PackageCreator.UTest
 
 
         [Test]
-        public async Task TriggerFossologyValidation_WhenNoValidReleaseFound_LogsFailureMessage()
+        public Task TriggerFossologyValidation_WhenNoValidReleaseFound_LogsFailureMessage()
         {
             // Arrange
             var appSettings = new CommonAppSettings
@@ -298,6 +298,7 @@ namespace LCT.SW360PackageCreator.UTest
 
             // Assert
             Assert.IsFalse(validReleaseFound);
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -17,7 +17,6 @@ using LCT.Services.Model;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 namespace LCT.SW360PackageCreator
 {

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -28,6 +28,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 namespace LCT.SW360PackageCreator
 {

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -16,7 +16,6 @@ using LCT.Services.Interface;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using log4net;
-using log4net.Core;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -164,8 +164,8 @@ namespace LCT.SW360PackageCreator
             List<ComparisonBomData> parsedBomData = await componentCreator.CycloneDxBomParser(appSettings, sw360Service, cycloneDXBomParser, creatorHelper);
 
             // initializing Component creation 
-           await componentCreator.CreateComponentInSw360(appSettings, sw360CreatorService, sw360Service,
-                 sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
+            await componentCreator.CreateComponentInSw360(appSettings, sw360CreatorService, sw360Service,
+                  sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
         }
     }
 }

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -165,7 +165,7 @@ namespace LCT.SW360PackageCreator
 
             // initializing Component creation 
             await componentCreator.CreateComponentInSw360(appSettings, sw360CreatorService, sw360Service,
-                  sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
+                 sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
         }
     }
 }

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -164,7 +164,7 @@ namespace LCT.SW360PackageCreator
             List<ComparisonBomData> parsedBomData = await componentCreator.CycloneDxBomParser(appSettings, sw360Service, cycloneDXBomParser, creatorHelper);
 
             // initializing Component creation 
-            await componentCreator.CreateComponentInSw360(appSettings, sw360CreatorService, sw360Service,
+           await componentCreator.CreateComponentInSw360(appSettings, sw360CreatorService, sw360Service,
                  sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
         }
     }

--- a/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
+++ b/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
@@ -24,7 +24,7 @@ namespace LCT.Telemetry
             }
 
             var aiConfig = TelemetryConfiguration.CreateDefault();
-            aiConfig.ConnectionString = $"InstrumentationKey={instrumentationKey}";
+            aiConfig.InstrumentationKey = instrumentationKey;
 
             _telemetryClient = new TelemetryClient(aiConfig);
         }

--- a/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
+++ b/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
@@ -24,17 +24,17 @@ namespace LCT.Telemetry
             }
 
             var aiConfig = TelemetryConfiguration.CreateDefault();
-            aiConfig.InstrumentationKey = instrumentationKey;
+            aiConfig.ConnectionString = $"InstrumentationKey={instrumentationKey}";
 
             _telemetryClient = new TelemetryClient(aiConfig);
         }
 
-        public void TrackEvent(string eventName, Dictionary<string, string> properties = null)
+        public void TrackEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryClient.TrackEvent(eventName, properties);
         }
 
-        public void TrackException(Exception ex, Dictionary<string, string> properties = null)
+        public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             var exceptionTelemetry = new ExceptionTelemetry(ex);
 

--- a/src/LCT.Telemetry/ITelemetryProvider.cs
+++ b/src/LCT.Telemetry/ITelemetryProvider.cs
@@ -7,8 +7,8 @@ namespace LCT.Telemetry
 {
     public interface ITelemetryProvider
     {
-        void TrackEvent(string eventName, Dictionary<string, string> properties = null);
-        void TrackException(Exception ex, Dictionary<string, string> properties = null);
+        void TrackEvent(string eventName, Dictionary<string, string>? properties = null);
+        void TrackException(Exception ex, Dictionary<string, string>? properties = null);
         void Flush();
     }
 }

--- a/src/LCT.Telemetry/Telemetry.cs
+++ b/src/LCT.Telemetry/Telemetry.cs
@@ -48,12 +48,12 @@ namespace LCT.Telemetry
             TrackUserDetails();
         }
 
-        public void TrackCustomEvent(string eventName, Dictionary<string, string> properties = null)
+        public void TrackCustomEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackEvent(eventName, properties);
         }
 
-        public void TrackException(Exception ex, Dictionary<string, string> properties = null)
+        public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackException(ex, properties);
         }

--- a/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
+++ b/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
@@ -144,7 +144,6 @@ namespace SW360IntegrationTest.Alpine
                 new AuthenticationHeaderValue(testParameters.SW360AuthTokenType, testParameters.SW360AuthTokenValue);
             string expectedname = "apk-tools";
             string expectedversion = "2.12.9-r3";
-            string expecteddownloadurl = "https://gitlab.alpinelinux.org/alpine/apk-tools/-/archive/v2.12.9/apk-tools-v2.12.9.tar.gz";
             string expectedexternalid = "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=source";
             //url formation for retrieving component details
             string url = TestConstant.Sw360ReleaseApi + TestConstant.componentNameUrl + "apk-tools";

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:6cdf02ad-b1f2-4f4b-b46f-176ad93005ee",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T13:56:05Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -223,5 +217,22 @@
       "ref": "pkg:nuget/SonarAnalyzer.CSharp@9.5.0.73987",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3e407ffb-8ef0-4b06-bcdb-bdbe12dcd2a7",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:57:03Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -125,5 +119,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7943c30-a8e6-4e9d-a36f-21721184b5b9",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T14:57:50Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -206,5 +200,23 @@
         }
       ]
     }
-  ]
+  ],
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7b3d78c-3b44-41c4-a7d2-1f4be11916bc",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:54:44Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -409,5 +403,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:fe6bfc03-6e58-4ee4-bbe3-b1dc8fd73ad5",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T14:06:17Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -406,5 +400,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:c5d86610-3513-41c3-abe6-6eeca868ac4f",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:57:36Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -263,5 +257,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:383df7b9-7355-4912-98ce-dc0c93573a11",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:12Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -361,5 +355,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Python/CCTComparisonBOMPythonInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Python/CCTComparisonBOMPythonInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:ce2e46d2-f383-47c1-81b2-05bc25d23f31",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T02:23:36Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -207,5 +201,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:24c9b04e-faa5-4616-b353-b6657a3e98f8",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T16:32:35Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -199,5 +193,22 @@
       "ref": "pkg:nuget/SonarAnalyzer.CSharp@9.5.0.73987",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3ff8bbf4-df51-4152-8fb8-e5f9ab766bfa",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:17:06Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -84,5 +78,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
@@ -1,60 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7943c30-a8e6-4e9d-a36f-21721184b5b9",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T14:57:50Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -228,5 +200,23 @@
         }
       ]
     }
-  ]
+  ],
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:2862b6c8-02a5-4005-87b6-c9cd30360293",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-07T00:00:20Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -373,5 +367,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:c4c04a17-1eae-4088-b241-fb02a48524bd",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T17:43:26Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -442,5 +436,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
@@ -1,60 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:25d1e9dc-0981-4766-9f62-c41afe0c13e0",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T18:00:02Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -675,5 +647,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:d2d0a930-3595-4c0d-b554-3883fb23da07",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T18:04:37Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:0e862bd9-65f2-4bde-8033-bb441e0e02e2",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T16:49:00Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -289,5 +283,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
@@ -8,7 +8,7 @@
     "tools": {
       "components": [
         {
-          "type": "null",
+          "type": "application",
           "supplier": {
             "name": "Siemens AG"
           },

--- a/src/Telemetry.UTest/Telemetry.UTest.cs
+++ b/src/Telemetry.UTest/Telemetry.UTest.cs
@@ -30,7 +30,7 @@ namespace LCT.Telemetry.UTest
                 { "InstrumentationKey", "1" }
             };
             _telemetry = new LCT.Telemetry.Telemetry(telemetryType, configuration);
-            aiConfig.InstrumentationKey = "1";
+            aiConfig.ConnectionString = $"InstrumentationKey=1";
             _mockTelemetryClient = new TelemetryClient(aiConfig);
         }
         [Test]
@@ -94,13 +94,13 @@ namespace LCT.Telemetry.UTest
         public void GetHashString_InputIsNull_ReturnsEmptyString()
         {
             // Arrange
-            string input = null;
+            string? input = null;
 
             // Act
-            string result = HashUtility.GetHashString(input);
+            string result = HashUtility.GetHashString(input ?? string.Empty);
 
             // Assert
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace LCT.Telemetry.UTest
             string result = HashUtility.GetHashString(input);
 
             // Assert
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace LCT.Telemetry.UTest
             string result = HashUtility.GetHashString(input);
 
             // Assert
-            Assert.AreEqual(expectedHash, result);
+            Assert.That(result, Is.EqualTo(expectedHash));
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace LCT.Telemetry.UTest
             string result2 = HashUtility.GetHashString(input2);
 
             // Assert
-            Assert.AreNotEqual(result1, result2);
+            Assert.That(result1, Is.Not.EqualTo(result2));
         }
 
     }

--- a/src/Telemetry.UTest/Telemetry.UTest.cs
+++ b/src/Telemetry.UTest/Telemetry.UTest.cs
@@ -30,7 +30,7 @@ namespace LCT.Telemetry.UTest
                 { "InstrumentationKey", "1" }
             };
             _telemetry = new LCT.Telemetry.Telemetry(telemetryType, configuration);
-            aiConfig.ConnectionString = $"InstrumentationKey=1";
+            aiConfig.InstrumentationKey = "1";
             _mockTelemetryClient = new TelemetryClient(aiConfig);
         }
         [Test]


### PR DESCRIPTION
1.Upgrade the CA Tool to support the latest CycloneDX SBOM schema (v1.6) with Siemens SBOM Standard version v3.
2.Updated Unit test cases and Integration test cases.
3.Updated test files with new schema(v1.6)