### PR TITLE
feat: CycloneDx upgraded to v1.6 with Siemens SBOM Standard version v3 along with .NET Framework Detection logic

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build . --file Dockerfile --tag ${{ github.repository }}:continuous-clearing-v8.0.0
-          docker save ${{ github.repository }}:continuous-clearing-v8.0.0 -o continuous-clearing-v8.0.0.tar
+          docker build . --file Dockerfile --tag ${{ github.repository }}:continuous-clearing-v8.1.0
+          docker save ${{ github.repository }}:continuous-clearing-v8.1.0 -o continuous-clearing-v8.1.0.tar
 
       - name: Upload Docker Image
         uses: actions/upload-artifact@v4
@@ -114,8 +114,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v8.0.0
-          release_name: Release v8.0.0
+          tag_name: v8.1.0
+          release_name: Release v8.1.0
           body: |
             ${{ github.event.head_commit.message }}
           draft: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: Compress Full Build Output into ZIP
         run: |
-          powershell -Command "& {Compress-Archive -Path ${{ github.workspace }}/out/* -DestinationPath ${{ github.workspace }}/continuous-clearing-v8.0.0.zip}"
+          powershell -Command "& {Compress-Archive -Path ${{ github.workspace }}/out/* -DestinationPath ${{ github.workspace }}/continuous-clearing-v8.1.0.zip}"
 
       - name: Upload Full Build Output ZIP to Release
         uses: actions/upload-release-asset@v1
@@ -131,8 +131,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/continuous-clearing-v8.0.0.zip
-          asset_name: continuous-clearing-v8.0.0.zip
+          asset_path: ${{ github.workspace }}/continuous-clearing-v8.1.0.zip
+          asset_name: continuous-clearing-v8.1.0.zip
           asset_content_type: application/zip
 
       - name: Upload Docker Image(tar) to Release
@@ -141,8 +141,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./continuous-clearing-v8.0.0.tar
-          asset_name: continuous-clearing-v8.0.0.tar
+          asset_path: ./continuous-clearing-v8.1.0.tar
+          asset_name: continuous-clearing-v8.1.0.tar
           asset_content_type: application/x-tar
 
       - name: Upload NuGet Package to Release

--- a/CA.nuspec
+++ b/CA.nuspec
@@ -64,6 +64,9 @@
     <file src="out\net8.0\Microsoft.Build.Locator.dll" target="tools\Microsoft.Build.Locator.dll"/>
     <file src="out\net8.0\Microsoft.CodeAnalysis.CSharp.dll" target="tools\Microsoft.CodeAnalysis.CSharp.dll"/>
     <file src="out\net8.0\Microsoft.CodeAnalysis.dll" target="tools\Microsoft.CodeAnalysis.dll"/>
+    <file src="out\net8.0\Microsoft.ComponentDetection.Common.dll" target="tools\Microsoft.ComponentDetection.Common.dll"/>
+    <file src="out\net8.0\Microsoft.ComponentDetection.Contracts.dll" target="tools\Microsoft.ComponentDetection.Contracts.dll"/>
+    <file src="out\net8.0\Microsoft.ComponentDetection.Detectors.dll" target="tools\Microsoft.ComponentDetection.Detectors.dll"/>
     <file src="out\net8.0\Microsoft.Extensions.Configuration.Abstractions.dll" target="tools\Microsoft.Extensions.Configuration.Abstractions.dll"/>
     <file src="out\net8.0\Microsoft.Extensions.Configuration.Binder.dll" target="tools\Microsoft.Extensions.Configuration.Binder.dll"/>
     <file src="out\net8.0\Microsoft.Extensions.Configuration.CommandLine.dll" target="tools\Microsoft.Extensions.Configuration.CommandLine.dll"/>
@@ -125,6 +128,9 @@
     <file src="out\net8.0\System.Security.Permissions.dll" target="tools\System.Security.Permissions.dll"/>
     <file src="out\net8.0\System.Threading.AccessControl.dll" target="tools\System.Threading.AccessControl.dll"/>
     <file src="out\net8.0\System.Windows.Extensions.dll" target="tools\System.Windows.Extensions.dll"/>
+    <file src="out\net8.0\System.Text.Json.dll" target="tools\System.Text.Json.dll"/>
+    <file src="out\net8.0\System.IO.Pipelines.dll" target="tools\System.IO.Pipelines.dll"/>
+    <file src="out\net8.0\System.Text.Encodings.Web.dll" target="tools\System.Text.Encodings.Web.dll"/>
     <file src="out\net8.0\LCT.Telemetry.dll" target="tools\LCT.Telemetry.dll"/>
     <file src="out\net8.0\Tommy.dll" target="tools\Tommy.dll"/>
     <file src="out\net8.0\YamlDotNet.dll" target="tools\YamlDotNet.dll"/>

--- a/CA.nuspec
+++ b/CA.nuspec
@@ -4,7 +4,7 @@
 <package >
   <metadata>
     <id>continuous-clearing</id>
-    <version>8.0.0</version>
+    <version>8.1.0</version>
     <authors>Siemens AG</authors>
     <owners>continuous-clearing contributors</owners>
     <projectUrl>https://github.com/siemens/continuous-clearing</projectUrl>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To ensure such practises are in place, we need to provide software bill of mater
 
 This tool has been  logically split into 3 different executables that enable it to be used as separate modules as per the user's requirement.
 
+**_Note: The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements._**
+
 **_Note: Continuous Clearing Tool internally uses [Syft](https://github.com/anchore/syft) for component detection for debian/alpine type projects._**
 
 

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Conan/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3e407ffb-8ef0-4b06-bcdb-bdbe12dcd2a7",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:57:03Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -149,5 +143,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Npm/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:fe6bfc03-6e58-4ee4-bbe3-b1dc8fd73ad5",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T14:06:17Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -382,5 +376,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Nuget/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:383df7b9-7355-4912-98ce-dc0c93573a11",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:12Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -361,5 +355,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
+++ b/TestFiles/IntegrationTestFiles/ArtifactoryUploaderTestData/Poetry/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/TestFiles/IntegrationTestFiles/SystemTest1stIterationData/Nuget-Assets/FrameworkDependent/project.assets.json
+++ b/TestFiles/IntegrationTestFiles/SystemTest1stIterationData/Nuget-Assets/FrameworkDependent/project.assets.json
@@ -1,0 +1,219 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {
+      "System.Text.Encoding/4.3.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Text.Encoding/4.3.0": {
+      "sha512": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+      "type": "package",
+      "path": "system.text.encoding/4.3.0",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/portable-net45+win8+wp8+wpa81/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
+        "ref/netcore50/de/System.Text.Encoding.xml",
+        "ref/netcore50/es/System.Text.Encoding.xml",
+        "ref/netcore50/fr/System.Text.Encoding.xml",
+        "ref/netcore50/it/System.Text.Encoding.xml",
+        "ref/netcore50/ja/System.Text.Encoding.xml",
+        "ref/netcore50/ko/System.Text.Encoding.xml",
+        "ref/netcore50/ru/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/netstandard1.0/System.Text.Encoding.dll",
+        "ref/netstandard1.0/System.Text.Encoding.xml",
+        "ref/netstandard1.0/de/System.Text.Encoding.xml",
+        "ref/netstandard1.0/es/System.Text.Encoding.xml",
+        "ref/netstandard1.0/fr/System.Text.Encoding.xml",
+        "ref/netstandard1.0/it/System.Text.Encoding.xml",
+        "ref/netstandard1.0/ja/System.Text.Encoding.xml",
+        "ref/netstandard1.0/ko/System.Text.Encoding.xml",
+        "ref/netstandard1.0/ru/System.Text.Encoding.xml",
+        "ref/netstandard1.0/zh-hans/System.Text.Encoding.xml",
+        "ref/netstandard1.0/zh-hant/System.Text.Encoding.xml",
+        "ref/netstandard1.3/System.Text.Encoding.dll",
+        "ref/netstandard1.3/System.Text.Encoding.xml",
+        "ref/netstandard1.3/de/System.Text.Encoding.xml",
+        "ref/netstandard1.3/es/System.Text.Encoding.xml",
+        "ref/netstandard1.3/fr/System.Text.Encoding.xml",
+        "ref/netstandard1.3/it/System.Text.Encoding.xml",
+        "ref/netstandard1.3/ja/System.Text.Encoding.xml",
+        "ref/netstandard1.3/ko/System.Text.Encoding.xml",
+        "ref/netstandard1.3/ru/System.Text.Encoding.xml",
+        "ref/netstandard1.3/zh-hans/System.Text.Encoding.xml",
+        "ref/netstandard1.3/zh-hant/System.Text.Encoding.xml",
+        "ref/portable-net45+win8+wp8+wpa81/_._",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._",
+        "system.text.encoding.4.3.0.nupkg.sha512",
+        "system.text.encoding.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net8.0": [
+      "Microsoft.EntityFrameworkCore >= 8.0.10",
+      "Microsoft.NET.Test.Sdk >= 17.8.0",
+      "Moq >= 4.20.72",
+      "Moq.EntityFrameworkCore >= 8.0.1.2",
+      "NUnit >= 3.14.0",
+      "NUnit.Analyzers >= 3.9.0",
+      "NUnit3TestAdapter >= 4.5.0",
+      "coverlet.collector >= 6.0.0"
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\z004neay\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Workspace\\Customers\\SMM\\Test\\Test.FSL.BL\\Test.FSL.BL.AdditionalAttributeManager\\Test.FSL.BL.AdditionalAttributeManager.csproj",
+      "projectName": "Test.FSL.BL.AdditionalAttributeManager",
+      "projectPath": "C:\\Workspace\\Customers\\SMM\\Test\\Test.FSL.BL\\Test.FSL.BL.AdditionalAttributeManager\\Test.FSL.BL.AdditionalAttributeManager.csproj",
+      "packagesPath": "C:\\Users\\z004neay\\.nuget\\packages\\",
+      "outputPath": "C:\\Workspace\\Customers\\SMM\\Test\\Test.FSL.BL\\Test.FSL.BL.AdditionalAttributeManager\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\z004neay\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {},
+        "https://nuget.pkg.github.com/siemens/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {
+            "C:\\Workspace\\Customers\\SMM\\DataAccessLayer\\Fsl.DataAccessLayer.Entities\\FSL.DataAccessLayer.Entities.csproj": {
+              "projectPath": "C:\\Workspace\\Customers\\SMM\\DataAccessLayer\\Fsl.DataAccessLayer.Entities\\FSL.DataAccessLayer.Entities.csproj"
+            },
+            "C:\\Workspace\\Customers\\SMM\\DataAccessLayer\\Fsl.DbContext\\FSL.DataAccessLayer.DbContext.csproj": {
+              "projectPath": "C:\\Workspace\\Customers\\SMM\\DataAccessLayer\\Fsl.DbContext\\FSL.DataAccessLayer.DbContext.csproj"
+            },
+            "C:\\Workspace\\Customers\\SMM\\FSL.BL\\FSL.BL.AdditionAttributesProfileManager\\FSL.BL.AdditionalAttributesProfileManager.csproj": {
+              "projectPath": "C:\\Workspace\\Customers\\SMM\\FSL.BL\\FSL.BL.AdditionAttributesProfileManager\\FSL.BL.AdditionalAttributesProfileManager.csproj"
+            },
+            "C:\\Workspace\\Customers\\SMM\\FSL.Server\\FSL.Server.csproj": {
+              "projectPath": "C:\\Workspace\\Customers\\SMM\\FSL.Server\\FSL.Server.csproj"
+            }
+          }
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      },
+      "SdkAnalysisLevel": "9.0.300"
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": {
+            "target": "Package",
+            "version": "[8.0.10, )"
+          },
+          "Microsoft.NET.Test.Sdk": {
+            "target": "Package",
+            "version": "[17.8.0, )"
+          },
+          "Moq": {
+            "target": "Package",
+            "version": "[4.20.72, )"
+          },
+          "Moq.EntityFrameworkCore": {
+            "target": "Package",
+            "version": "[8.0.1.2, )"
+          },
+          "NUnit": {
+            "target": "Package",
+            "version": "[3.14.0, )"
+          },
+          "NUnit.Analyzers": {
+            "target": "Package",
+            "version": "[3.9.0, )"
+          },
+          "NUnit3TestAdapter": {
+            "target": "Package",
+            "version": "[4.5.0, )"
+          },
+          "coverlet.collector": {
+            "target": "Package",
+            "version": "[6.0.0, )"
+          }
+        },
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.300/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
+++ b/TestFiles/MavenTestFile/ArtifactoryUploaderTestData/Test_Bom.cdx.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7b3d78c-3b44-41c4-a7d2-1f4be11916bc",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:54:44Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -409,5 +403,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -138,6 +138,8 @@ Explore these configurations in the [DemoProject](../../DemoProject). These samp
 ### Overview
 The Continuous Clearing Tool comprises three executable DLLs, each playing a crucial role in achieving a comprehensive license clearing process. Execute them sequentially as listed below:
 
+**Note** :The SBOM created by this tool follows the CycloneDX version [v1.6](https://cyclonedx.org/docs/1.6/json/) and Siemens SBOM standard [v3](https://sbom.siemens.io/v3/format.html). These formats ensure the SBOM is detailed, secure, and meets industry and Siemens-specific requirements.
+
 > **1. Package Identifier**
 > - This DLL processes the input file and generates a CycloneDX BOM file. The input can be a package file or a CycloneDX BOM file created using a standard tool. If multiple input files are present, simply provide the path to the directory as an argument.
 

--- a/src/AritfactoryUploader.UTest/AritfactoryUploader.UTest.csproj
+++ b/src/AritfactoryUploader.UTest/AritfactoryUploader.UTest.csproj
@@ -22,6 +22,9 @@
 		<PackageReference Include="nunit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AritfactoryUploader.UTest/ArtifactoryUploaderTest.cs
+++ b/src/AritfactoryUploader.UTest/ArtifactoryUploaderTest.cs
@@ -45,7 +45,7 @@ namespace AritfactoryUploader.UTest
                 URL = UTParams.JFrogURL
             };
 
-            ArtfactoryUploader.jFrogService = GetJfrogService(appSettings);
+            ArtfactoryUploader.JFrogService = GetJfrogService(appSettings);
             DisplayPackagesInfo displayPackagesInfo = PackageUploadInformation.GetComponentsToBePackages();
             var componentsToArtifactory = new ComponentsToArtifactory
             {
@@ -101,7 +101,7 @@ namespace AritfactoryUploader.UTest
             var jFrogServiceMock = new Mock<IJFrogService>();
             jFrogServiceMock.Setup(x => x.GetPackageInfo(component))
                 .ReturnsAsync((AqlResult)null);
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             // Act
             var response = await ArtfactoryUploader.UploadPackageToRepo(component, timeout, displayPackagesInfo);
 
@@ -131,7 +131,7 @@ namespace AritfactoryUploader.UTest
                 .ReturnsAsync(new AqlResult());
             jfrogApicommunicationMock.Setup(x => x.CopyFromRemoteRepo(It.IsAny<ComponentsToArtifactory>()))
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             ArtfactoryUploader.JFrogApiCommInstance = jfrogApicommunicationMock.Object;
             // Act
             _ = await ArtfactoryUploader.UploadPackageToRepo(component, timeout, displayPackagesInfo);
@@ -161,7 +161,7 @@ namespace AritfactoryUploader.UTest
                 .ReturnsAsync(new AqlResult());
             jfrogApicommunicationMock.Setup(x => x.MoveFromRepo(It.IsAny<ComponentsToArtifactory>()))
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             ArtfactoryUploader.JFrogApiCommInstance = jfrogApicommunicationMock.Object;
             // Act
             var response = await ArtfactoryUploader.UploadPackageToRepo(component, timeout, displayPackagesInfo);
@@ -187,7 +187,7 @@ namespace AritfactoryUploader.UTest
             var timeout = 10000;
             var displayPackagesInfo = new DisplayPackagesInfo();
             var jFrogServiceMock = new Mock<IJFrogService>();
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             // Act
             var response = await ArtfactoryUploader.UploadPackageToRepo(component, timeout, displayPackagesInfo);
 
@@ -213,7 +213,7 @@ namespace AritfactoryUploader.UTest
             var jfrogApicommunicationMock = new Mock<IJFrogApiCommunication>();
             jFrogServiceMock.Setup(x => x.GetPackageInfo(component))
                 .ThrowsAsync(new HttpRequestException());
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             ArtfactoryUploader.JFrogApiCommInstance = jfrogApicommunicationMock.Object;
 
             // Act
@@ -242,7 +242,7 @@ namespace AritfactoryUploader.UTest
             var jfrogApicommunicationMock = new Mock<IJFrogApiCommunication>();
             jFrogServiceMock.Setup(x => x.GetPackageInfo(component))
                 .ThrowsAsync(new InvalidOperationException());
-            ArtfactoryUploader.jFrogService = jFrogServiceMock.Object;
+            ArtfactoryUploader.JFrogService = jFrogServiceMock.Object;
             ArtfactoryUploader.JFrogApiCommInstance = jfrogApicommunicationMock.Object;
 
             // Act

--- a/src/AritfactoryUploader.UTest/JfrogRepoUpdaterTest.cs
+++ b/src/AritfactoryUploader.UTest/JfrogRepoUpdaterTest.cs
@@ -34,7 +34,7 @@ namespace AritfactoryUploader.UTest
             var jFrogServiceMock = new Mock<IJFrogService>();
             jFrogServiceMock.Setup(service => service.GetInternalComponentDataByRepo(It.IsAny<string>()))
                             .ReturnsAsync(expectedAqlResultList);
-            JfrogRepoUpdater.jFrogService = jFrogServiceMock.Object;
+            JfrogRepoUpdater.JFrogService = jFrogServiceMock.Object;
 
             // Act
             var actualAqlResultList = await JfrogRepoUpdater.GetJfrogRepoInfoForAllTypePackages(destRepoNames);

--- a/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
+++ b/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
@@ -4,11 +4,14 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+// Ignore Spelling: Aritfactory Uploader
+
 using CycloneDX.Models;
 using LCT.APICommunications;
 using LCT.APICommunications.Model;
 using LCT.ArtifactoryUploader;
 using LCT.ArtifactoryUploader.Model;
+using LCT.Common.Constants;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -92,6 +95,7 @@ namespace AritfactoryUploader.UTest
                     Purl = "pkg:npm/rxjs@6.5.4",
                     DestRepoName = "org1-npmjs-npm-remote",
                     DryRun = false,
+                    JfrogRepoPath="org1-npmjs-npm-remote/rxjs/-/rxjs-6.5.4.tgz",
                 }
             };
 
@@ -99,8 +103,10 @@ namespace AritfactoryUploader.UTest
             PackageUploadHelper.UpdateBomArtifactoryRepoUrl(ref bom, components);
 
             //Assert
-            var repoUrl = bom.Components.First(x => x.Properties[3].Name == "internal:siemens:clearing:jfrog-repo-name").Properties[3].Value;
+            var repoUrl = bom.Components.First(x => x.Properties[3].Name == Dataconstant.Cdx_ArtifactoryRepoName).Properties[3].Value;
+            var repoPath = bom.Components.First(x => x.Properties[6].Name == Dataconstant.Cdx_JfrogRepoPath).Properties[6].Value;
             Assert.AreEqual("org1-npmjs-npm-remote", repoUrl);
+            Assert.AreEqual("org1-npmjs-npm-remote/rxjs/-/rxjs-6.5.4.tgz", repoPath);
         }
 
         [Test]
@@ -124,7 +130,7 @@ namespace AritfactoryUploader.UTest
             PackageUploadHelper.UpdateBomArtifactoryRepoUrl(ref bom, components);
 
             //Assert
-            var repoUrl = bom.Components.First(x => x.Properties[3].Name == "internal:siemens:clearing:jfrog-repo-name").Properties[3].Value;
+            var repoUrl = bom.Components.First(x => x.Properties[3].Name == Dataconstant.Cdx_ArtifactoryRepoName).Properties[3].Value;
             Assert.AreNotEqual("org1-npmjs-npm-remote", repoUrl);
         }
 

--- a/src/AritfactoryUploader.UTest/PackageUploaderTest.cs
+++ b/src/AritfactoryUploader.UTest/PackageUploaderTest.cs
@@ -78,9 +78,9 @@ namespace AritfactoryUploader.UTest
             };
 
             IJFrogService jFrogService = GetJfrogService(commonAppSettings);
-            PackageUploadHelper.jFrogService = jFrogService;
-            UploadToArtifactory.jFrogService = jFrogService;
-            ArtfactoryUploader.jFrogService = jFrogService;
+            PackageUploadHelper.JFrogService = jFrogService;
+            UploadToArtifactory.JFrogService = jFrogService;
+            ArtfactoryUploader.JFrogService = jFrogService;
 
             Program.UploaderStopWatch = new Stopwatch();
             Program.UploaderStopWatch.Start();

--- a/src/AritfactoryUploader.UTest/UploadToArtifactoryTest.cs
+++ b/src/AritfactoryUploader.UTest/UploadToArtifactoryTest.cs
@@ -5,6 +5,7 @@
 // -------------------------------------------------------------------------------------------------------------------- 
 
 using CycloneDX.Models;
+using LCT.APICommunications;
 using LCT.APICommunications.Model;
 using LCT.APICommunications.Model.AQL;
 using LCT.ArtifactoryUploader;
@@ -113,7 +114,7 @@ namespace AritfactoryUploader.UTest
 
             jFrogServiceMock.Setup(x => x.GetNpmComponentDataByRepo(It.IsAny<string>())).ReturnsAsync(aqlResultList);
 
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
 
             // Act
@@ -188,7 +189,7 @@ namespace AritfactoryUploader.UTest
             DisplayPackagesInfo displayPackagesInfo = PackageUploadInformation.GetComponentsToBePackages();
 
             var jFrogServiceMock = new Mock<IJFrogService>();
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
             CommonAppSettings commonAppSettings = new CommonAppSettings();
             commonAppSettings.Jfrog = new Jfrog()
@@ -265,7 +266,7 @@ namespace AritfactoryUploader.UTest
             DisplayPackagesInfo displayPackagesInfo = PackageUploadInformation.GetComponentsToBePackages();
 
             var jFrogServiceMock = new Mock<IJFrogService>();
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
             foreach (var component in componentLists)
             {
@@ -358,7 +359,7 @@ namespace AritfactoryUploader.UTest
             jFrogServiceMock.Setup(x => x.GetPypiComponentDataByRepo(It.IsAny<string>())).ReturnsAsync(aqlResultList);
 
 
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
             // Act
             var result = await UploadToArtifactory.GetSrcRepoDetailsForComponent(item);
@@ -396,7 +397,7 @@ namespace AritfactoryUploader.UTest
 
             var jFrogServiceMock = new Mock<IJFrogService>();
             jFrogServiceMock.Setup(x => x.GetInternalComponentDataByRepo(It.IsAny<string>())).ReturnsAsync(aqlResultList);
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
             // Act
             var result = await UploadToArtifactory.GetSrcRepoDetailsForComponent(item);
@@ -415,13 +416,120 @@ namespace AritfactoryUploader.UTest
                 Purl = "unknown://example-package"
             };
             var jFrogServiceMock = new Mock<IJFrogService>();
-            UploadToArtifactory.jFrogService = jFrogServiceMock.Object;
+            UploadToArtifactory.JFrogService = jFrogServiceMock.Object;
 
             // Act
             var result = await UploadToArtifactory.GetSrcRepoDetailsForComponent(item);
 
             // Assert
             Assert.IsNull(result);
+        }
+        [Test]
+        public void GetJfrogRepPath_NpmComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "NPM",
+                DestRepoName = "npm-repo",
+                Path = "package/path",
+                PypiOrNpmCompName = "my-npm-package"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual("npm-repo/package/path/my-npm-package", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_NugetComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "NUGET",
+                DestRepoName = "nuget-repo",
+                Name = "MyNuget",
+                Version = "1.2.3"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual($"nuget-repo/MyNuget.1.2.3{ApiConstant.NugetExtension}", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_MavenComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "MAVEN",
+                DestRepoName = "maven-repo",
+                Name = "my-maven",
+                Version = "2.0.0"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual("maven-repo/my-maven/2.0.0", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_PoetryComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "POETRY",
+                DestRepoName = "poetry-repo",
+                PypiOrNpmCompName = "my-poetry"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual("poetry-repo/my-poetry", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_ConanComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "CONAN",
+                DestRepoName = "conan-repo",
+                Path = "conan/path"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual("conan-repo/conan/path", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_DebianComponent_ReturnsExpectedPath()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "DEBIAN",
+                DestRepoName = "debian-repo",
+                Path = "debian/path",
+                Name = "my-deb",
+                Version = "1.0.0"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual("debian-repo/debian/path/my-deb_1.0.0*", result);
+        }
+
+        [Test]
+        public void GetJfrogRepPath_UnknownComponent_ReturnsEmptyString()
+        {
+            var component = new ComponentsToArtifactory
+            {
+                ComponentType = "UNKNOWN"
+            };
+
+            var result = UploadToArtifactory.GetJfrogRepPath(component);
+
+            Assert.AreEqual(string.Empty, result);
         }
         private static List<Component> GetComponentList()
         {

--- a/src/ArtifactoryUploader/ArtifactoryUploader.cs
+++ b/src/ArtifactoryUploader/ArtifactoryUploader.cs
@@ -24,7 +24,7 @@ namespace LCT.ArtifactoryUploader
     {
         //ConfigurationAttribute
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public static IJFrogService jFrogService { get; set; }
+        public static IJFrogService JFrogService { get; set; }
         public static IJFrogApiCommunication JFrogApiCommInstance { get; set; }
 
         public static async Task<HttpResponseMessage> UploadPackageToRepo(ComponentsToArtifactory component, int timeout, DisplayPackagesInfo displayPackagesInfo)
@@ -38,7 +38,7 @@ namespace LCT.ArtifactoryUploader
             {
 
                 // Package Information
-                var packageInfo = await GetPackageInfoWithRetry(jFrogService, component);
+                var packageInfo = await GetPackageInfoWithRetry(JFrogService, component);
                 if (packageInfo == null)
                 {
                     return new HttpResponseMessage(HttpStatusCode.NotFound)

--- a/src/ArtifactoryUploader/JfrogRepoUpdater.cs
+++ b/src/ArtifactoryUploader/JfrogRepoUpdater.cs
@@ -22,8 +22,8 @@ namespace LCT.ArtifactoryUploader
     public class JfrogRepoUpdater
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public static IJFrogService jFrogService { get; set; }
-        private static List<AqlResult> aqlResultList = new();
+        public static IJFrogService JFrogService { get; set; }
+        private readonly static List<AqlResult> aqlResultList = new();
         public static async Task<Bom> UpdateJfrogRepoPathForSucessfullyUploadedItems(Bom m_ComponentsInBOM,
                                                                             DisplayPackagesInfo displayPackagesInfo)
         {
@@ -114,7 +114,7 @@ namespace LCT.ArtifactoryUploader
             {
                 foreach (var repo in destRepoNames)
                 {
-                    var result = await jFrogService.GetInternalComponentDataByRepo(repo) ?? new List<AqlResult>();
+                    var result = await JFrogService.GetInternalComponentDataByRepo(repo) ?? new List<AqlResult>();
                     aqlResultList.AddRange(result);
                 }
             }

--- a/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
+++ b/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
@@ -1,29 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <AssemblyName>ArtifactoryUploader</AssemblyName>
-    <Version>8.0.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<AssemblyName>ArtifactoryUploader</AssemblyName>
+		<Version>8.0.0</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.15" />
+		<PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
-    <ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
-    <ProjectReference Include="..\LCT.Telemetry\LCT.Telemetry.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
+		<ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
+		<ProjectReference Include="..\LCT.Telemetry\LCT.Telemetry.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
+++ b/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>ArtifactoryUploader</AssemblyName>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ArtifactoryUploader/PackageUploadHelper.cs
+++ b/src/ArtifactoryUploader/PackageUploadHelper.cs
@@ -11,7 +11,6 @@ using CycloneDX.Models;
 using LCT.APICommunications;
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;
-using LCT.APICommunications.Model.AQL;
 using LCT.ArtifactoryUploader.Model;
 using LCT.Common;
 using LCT.Common.Constants;

--- a/src/ArtifactoryUploader/PackageUploadHelper.cs
+++ b/src/ArtifactoryUploader/PackageUploadHelper.cs
@@ -4,6 +4,8 @@
 //  SPDX-License-Identifier: MIT
 //---------------------------------------------------------------------------------------------------------------------
 
+// Ignore Spelling: Artifactory Bom Repo uploader Kpi Jfrog Api LCT aql
+
 using ArtifactoryUploader;
 using CycloneDX.Models;
 using LCT.APICommunications;
@@ -33,24 +35,23 @@ namespace LCT.ArtifactoryUploader
     public static class PackageUploadHelper
     {
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public static IJFrogService jFrogService { get; set; }
-        private static List<AqlResult> aqlResultList = new();
+        public static IJFrogService JFrogService { get; set; }
 
         private static bool SetWarningCode;
-        public static Bom GetComponentListFromComparisonBOM(string comparisionBomFilePath)
+        public static Bom GetComponentListFromComparisonBOM(string comparisonBomFilePath)
         {
             Logger.Debug("Starting GetComponentListFromComparisonBOM() method");
             Bom componentsToBoms = null;
             try
             {
-                if (File.Exists(comparisionBomFilePath))
+                if (File.Exists(comparisonBomFilePath))
                 {
-                    string json = File.ReadAllText(comparisionBomFilePath);
+                    string json = File.ReadAllText(comparisonBomFilePath);
                     componentsToBoms = CycloneDX.Json.Serializer.Deserialize(json);
                 }
                 else
                 {
-                    Logger.Error($"File not found: {comparisionBomFilePath}. Please provide a valid file path.");
+                    Logger.Error($"File not found: {comparisonBomFilePath}. Please provide a valid file path.");
                 }
             }
             catch (JsonReaderException ex)
@@ -263,7 +264,7 @@ namespace LCT.ArtifactoryUploader
         {
             const string dryRunSuffix = null;
             string operationType = item.PackageType == PackageType.ClearedThirdParty || item.PackageType == PackageType.Development ? "copy" : "move";
-            ArtfactoryUploader.jFrogService = jFrogService;
+            ArtfactoryUploader.JFrogService = JFrogService;
             ArtfactoryUploader.JFrogApiCommInstance = GetJfrogApiCommInstance(item, timeout);
             HttpResponseMessage responseMessage = await ArtfactoryUploader.UploadPackageToRepo(item, timeout, displayPackagesInfo);
 
@@ -431,6 +432,7 @@ namespace LCT.ArtifactoryUploader
                 if (component.DestRepoName != null && !component.DryRun)
                 {
                     bomComponent.Properties.First(x => x.Name == Dataconstant.Cdx_ArtifactoryRepoName).Value = component.DestRepoName;
+                    bomComponent.Properties.First(x => x.Name == Dataconstant.Cdx_JfrogRepoPath).Value = component.JfrogRepoPath;
                 }
             }
         }

--- a/src/ArtifactoryUploader/PackageUploader.cs
+++ b/src/ArtifactoryUploader/PackageUploader.cs
@@ -12,13 +12,13 @@ using LCT.Common;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Level = log4net.Core.Level;
 
 namespace LCT.ArtifactoryUploader
 {

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -4,6 +4,8 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+// Ignore Spelling: Uploader Artifactory
+
 using LCT.APICommunications;
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;
@@ -85,9 +87,9 @@ namespace ArtifactoryUploader
             }
 
             //Uploading Package to artifactory
-            PackageUploadHelper.jFrogService = GetJfrogService(appSettings);
-            UploadToArtifactory.jFrogService = GetJfrogService(appSettings);
-            JfrogRepoUpdater.jFrogService = GetJfrogService(appSettings);
+            PackageUploadHelper.JFrogService = GetJfrogService(appSettings);
+            UploadToArtifactory.JFrogService = GetJfrogService(appSettings);
+            JfrogRepoUpdater.JFrogService = GetJfrogService(appSettings);
             await PackageUploader.UploadPackageToArtifactory(appSettings);
 
             // Initialize telemetry with CATool version and instrumentation key only if Telemetry is enabled in appsettings

--- a/src/ArtifactoryUploader/Program.cs
+++ b/src/ArtifactoryUploader/Program.cs
@@ -23,8 +23,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ArtifactoryUploader

--- a/src/LCT.APICommunications.UTest/AttachmentHelperUTest.cs
+++ b/src/LCT.APICommunications.UTest/AttachmentHelperUTest.cs
@@ -46,7 +46,7 @@ namespace LCT.APICommunications.UTest
             var result = _attachmentHelper.AttachComponentSourceToSW360(attachReport);
 
             // Assert
-            Assert.AreEqual("https://api.mock.com/release/123/attachments", result);
+            Assert.That(result, Is.EqualTo("https://api.mock.com/release/123/attachments"));
         }
 
         [Test]
@@ -66,12 +66,12 @@ namespace LCT.APICommunications.UTest
 
             // Assert
             var jsonFilePath = Path.Combine(folderPath, "Attachment.json");
-            Assert.IsTrue(File.Exists(jsonFilePath));
+            Assert.That(File.Exists(jsonFilePath), Is.True);
 
             // Validate JSON content
             var fileContent = File.ReadAllText(jsonFilePath);
-            Assert.IsTrue(fileContent.Contains("Source"));
-            Assert.IsTrue(fileContent.Contains("Test comment"));
+            Assert.That(fileContent, Does.Contain("Source"));
+            Assert.That(fileContent, Does.Contain("Test comment"));
 
             // Cleanup
             File.Delete(jsonFilePath);

--- a/src/LCT.APICommunications.UTest/LCT.APICommunications.UTest.csproj
+++ b/src/LCT.APICommunications.UTest/LCT.APICommunications.UTest.csproj
@@ -16,13 +16,16 @@
 		<OutputPath>..\..\out</OutputPath>
 	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />

--- a/src/LCT.APICommunications.UTest/NPMJfrogAPICommunicationUTest.cs
+++ b/src/LCT.APICommunications.UTest/NPMJfrogAPICommunicationUTest.cs
@@ -107,13 +107,13 @@ namespace LCT.APICommunications.UTest
             var response = await jfrogApiCommunication.GetPackageInfo(component);
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         // Custom HttpMessageHandler to mock SendAsync
         public class MockHttpMessageHandler : HttpMessageHandler
         {
-            private HttpResponseMessage _response;
+            private HttpResponseMessage? _response;
 
             public void SetResponse(HttpResponseMessage response)
             {
@@ -122,6 +122,10 @@ namespace LCT.APICommunications.UTest
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                if (_response == null)
+                {
+                    throw new InvalidOperationException("Mock response has not been set.");
+                }
                 return Task.FromResult(_response);
             }
         }

--- a/src/LCT.APICommunications.UTest/RetryHttpClientHandlerUTest.cs
+++ b/src/LCT.APICommunications.UTest/RetryHttpClientHandlerUTest.cs
@@ -47,7 +47,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
             handlerMock.Protected().Verify(
                 "SendAsync",
                 Times.Exactly(3), // 2 retries + 1 initial call
@@ -79,7 +79,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
             handlerMock.Protected().Verify(
                 "SendAsync",
                 Times.Once(), // No retries
@@ -113,7 +113,7 @@ namespace LCT.APICommunications.UTest
             var response = await httpClient.GetAsync("http://test.com");
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
         [Test]
         public async Task ExecuteWithRetryAsync_ShouldCompleteSuccessfully_WhenActionSucceedsAfterRetry()
@@ -134,7 +134,7 @@ namespace LCT.APICommunications.UTest
             await RetryHttpClientHandler.ExecuteWithRetryAsync(action);
 
             // Assert
-            Assert.AreEqual(ApiConstant.APIRetryIntervals.Count, attempts, "Action should have been attempted the expected number of times.");
+            Assert.That(attempts, Is.EqualTo(ApiConstant.APIRetryIntervals.Count), "Action should have been attempted the expected number of times.");
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace LCT.APICommunications.UTest
             await RetryHttpClientHandler.ExecuteWithRetryAsync(action);
 
             // Assert
-            Assert.IsTrue(actionExecuted, "Action should have been executed.");
+            Assert.That(actionExecuted, Is.True, "Action should have been executed.");
             _mockLogger.Verify(logger => logger.Debug(It.IsAny<string>()), Times.Never, "Retry should not occur if there is no exception.");
         }
 

--- a/src/LCT.APICommunications/LCT.APICommunications.csproj
+++ b/src/LCT.APICommunications/LCT.APICommunications.csproj
@@ -16,20 +16,23 @@
     <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
-    <PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="7.0.3" />
-    <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Polly" Version="8.5.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
-    <PackageReference Include="System.Management.Automation" Version="7.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.15" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+		<PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
+		<PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="7.0.3" />
+		<PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Polly" Version="8.5.2" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+		<PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+		<PackageReference Include="System.Management.Automation" Version="7.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />

--- a/src/LCT.APICommunications/LCT.APICommunications.csproj
+++ b/src/LCT.APICommunications/LCT.APICommunications.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.APICommunications/Model/ComponentsToArtifactory.cs
+++ b/src/LCT.APICommunications/Model/ComponentsToArtifactory.cs
@@ -33,6 +33,7 @@ namespace LCT.APICommunications.Model
         public string JfrogPackageName { get; set; }
         public string OperationType { get; set; }
         public string DryRunSuffix { get; set; }
+        public string JfrogRepoPath { get; set; }
         public HttpResponseMessage ResponseMessage { get; set; }
     }
 }

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -67,7 +67,7 @@ namespace LCT.Common.UTest
         [Test]
         public void LogFolderInitialisation_WhenLogFolderIsNull_ReturnsDefaultLogPath()
         {
-            Log4Net.CatoolLogPath= "C:\\catool\\fds.log";
+            Log4Net.CatoolLogPath = "C:\\catool\\fds.log";
 
             // Act
             string result = CommonHelper.LogFolderInitialisation(appSettings, "catool.log", false);
@@ -145,7 +145,7 @@ namespace LCT.Common.UTest
             List<Component> listComponentForBOM = new List<Component>();
 
             //Act
-            CommonHelper.GetDetailsforManuallyAdded(componentsForBOM, listComponentForBOM);
+            CommonHelper.GetDetailsForManuallyAdded(componentsForBOM, listComponentForBOM);
 
             //Assert
             Assert.AreEqual(2, listComponentForBOM.Count);

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -502,17 +502,17 @@ namespace LCT.Common.UTest
             string[] result = CommonHelper.MaskSensitiveArguments(args);
 
             // Assert
-            Assert.IsEmpty(result, "Null input should return an empty array.");            
+            Assert.IsEmpty(result, "Null input should return an empty array.");
         }
         [Test]
         public void DefaultLogFolderInitialisation_SetsDefaultLogPath_Windows()
         {
             // Arrange
             string logFileName = FileConstant.BomCreatorLog;
-            string runningLocation=Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string runningLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             Log4Net.CatoolCurrentDirectory = System.IO.Directory.GetParent(runningLocation).FullName;
             bool m_Verbose = false;
-          
+
 
             // Act
             CommonHelper.DefaultLogFolderInitialisation(logFileName, m_Verbose);
@@ -524,9 +524,9 @@ namespace LCT.Common.UTest
             else
             {
                 Assert.AreEqual("/var/log", CommonHelper.DefaultLogPath);
-            }               
-            
-        }       
+            }
+
+        }
     }
 
     public class TestObject

--- a/src/LCT.Common.UTests/LCT.Common.UTest.csproj
+++ b/src/LCT.Common.UTests/LCT.Common.UTest.csproj
@@ -29,6 +29,9 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/LCT.Common.UTests/Log4NetTests.cs
+++ b/src/LCT.Common.UTests/Log4NetTests.cs
@@ -196,7 +196,7 @@ namespace LCT.Common.UTest
         {
             // Arrange
             bool verbose = true;
-            string? logPath = null;
+            string logPath = null;
             IAppender[] appenders = [new RollingFileAppender()];
 
             // Act

--- a/src/LCT.Common.UTests/TelemetryHelperTests.cs
+++ b/src/LCT.Common.UTests/TelemetryHelperTests.cs
@@ -6,7 +6,6 @@
 
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace LCT.Common.UTest
 {
@@ -15,7 +14,6 @@ namespace LCT.Common.UTest
     {
         private TelemetryHelper telemetryHelper;
         private CommonAppSettings appSettings;
-        private readonly StringWriter consoleOutput;
         [SetUp]
         public void Setup()
         {

--- a/src/LCT.Common/CommonAppSettings.cs
+++ b/src/LCT.Common/CommonAppSettings.cs
@@ -33,7 +33,6 @@ namespace LCT.Common
         public static string AlpineAportsGitURL { get; set; } = $"https://gitlab.alpinelinux.org/alpine/aports.git";
 
         private string m_ProjectType;
-        private string m_LogFolderPath;
         public CommonAppSettings()
         {
             folderAction = new FolderAction();

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Level = log4net.Core.Level;
 
 namespace LCT.Common
 {
@@ -233,7 +234,7 @@ namespace LCT.Common
             return component.Properties.Exists(x => x.Name == constant);
         }
 
-        public static void GetDetailsforManuallyAdded(List<Component> componentsForBOM, List<Component> listComponentForBOM)
+        public static void GetDetailsForManuallyAdded(List<Component> componentsForBOM, List<Component> listComponentForBOM)
         {
             foreach (var component in componentsForBOM)
             {
@@ -252,9 +253,10 @@ namespace LCT.Common
             listOfComponentsToBom.SerialNumber = $"urn:uuid:{guid}";
             listOfComponentsToBom.Version = 1;
             listOfComponentsToBom.Metadata.Timestamp = DateTime.UtcNow;
-            var formattedString = CycloneDX.Json.Serializer.Serialize(listOfComponentsToBom);
-
-            return formattedString;
+            listOfComponentsToBom.SpecVersion = CycloneDX.SpecificationVersion.v1_6;
+            listOfComponentsToBom.SpecVersionString = Dataconstant.SbomSpecVersionString;
+            var serializedBomData = CycloneDX.Json.Serializer.Serialize(listOfComponentsToBom);
+            return serializedBomData;
         }
         public static string[] GetRepoList(CommonAppSettings appSettings)
         {

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -73,7 +73,9 @@ namespace LCT.Common.Constants
         public const string ScanAvailableState = "SCAN_AVAILABLE";
         public const string SentToClearingState = "SENT_TO_CLEARING_TOOL";
         public const string TypeJarSuffix = "?type=jar";
-
+        public const string GithubUrl = "https://github.com/siemens/continuous-clearing";
+        public const string StandardSbomUrl = "https://sbom.siemens.io/";
+        public const string SbomSpecVersionString = "1.6";
         public static Dictionary<string, string> PurlCheck()
         {
             return purlids;

--- a/src/LCT.Common/Constants/Dataconstant.cs
+++ b/src/LCT.Common/Constants/Dataconstant.cs
@@ -76,6 +76,7 @@ namespace LCT.Common.Constants
         public const string GithubUrl = "https://github.com/siemens/continuous-clearing";
         public const string StandardSbomUrl = "https://sbom.siemens.io/";
         public const string SbomSpecVersionString = "1.6";
+        public const string FossologyModerationMessage = "Moderation request is created";
         public static Dictionary<string, string> PurlCheck()
         {
             return purlids;

--- a/src/LCT.Common/Constants/FileConstant.cs
+++ b/src/LCT.Common/Constants/FileConstant.cs
@@ -9,9 +9,9 @@ using System.IO;
 
 namespace LCT.Common.Constants
 {
-    /// <summary>
-    /// The file constants 
-    /// </summary>
+    /// <summary>  
+    /// The file constants   
+    /// </summary>  
     [ExcludeFromCodeCoverage]
     public static class FileConstant
     {
@@ -54,5 +54,7 @@ namespace LCT.Common.Constants
         public const string multipleversionsFileName = "Multipleversions.json";
         public const string artifactoryReportNotApproved = "ReportNotApproved.json";
         public const string basicSBOMName = "ContinuousClearing";
+        public static readonly string[] Nuget_DeploymentType_DetectionExt = ["*.csproj", "*.Build.props"];
+        public static readonly string[] Nuget_DeploymentType_DetectionTags = ["SelfContained"];
     }
 }

--- a/src/LCT.Common/LCT.Common.csproj
+++ b/src/LCT.Common/LCT.Common.csproj
@@ -14,24 +14,27 @@
     <OutputPath>..\..\out</OutputPath>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.15" />
+		<PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.7.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.6.1" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
-    <PackageReference Include="Tommy" Version="3.1.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="NuGet.Packaging" Version="6.13.2" />
+		<PackageReference Include="NuGet.ProjectModel" Version="6.13.2" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
+		<PackageReference Include="Tommy" Version="3.1.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LCT.CycloneDxProcessor\LCT.CycloneDxProcessor.csproj" />

--- a/src/LCT.Common/LCT.Common.csproj
+++ b/src/LCT.Common/LCT.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.Common/Model/ComparisonBomData.cs
+++ b/src/LCT.Common/Model/ComparisonBomData.cs
@@ -38,7 +38,7 @@ namespace LCT.Common.Model
         public string FossologyUploadId { get; set; }
         public string ClearingState { get; set; }
         public string ReleaseCreatedBy { get; set; }
-        public bool SourceAttachmentStatus { get; set; }=false;
+        public bool SourceAttachmentStatus { get; set; } = false;
 
     }
 }

--- a/src/LCT.Common/Model/ComparisonBomData.cs
+++ b/src/LCT.Common/Model/ComparisonBomData.cs
@@ -37,5 +37,8 @@ namespace LCT.Common.Model
         public string ParentReleaseName { get; set; }
         public string FossologyUploadId { get; set; }
         public string ClearingState { get; set; }
+        public string ReleaseCreatedBy { get; set; }
+        public bool SourceAttachmentStatus { get; set; }=false;
+
     }
 }

--- a/src/LCT.Common/Model/Components.cs
+++ b/src/LCT.Common/Model/Components.cs
@@ -63,6 +63,8 @@ namespace LCT.Common.Model
         public string IsDev { get; set; }
         [JsonIgnore]
         public string ExcludeComponent { get; set; }
+        [JsonIgnore]
+        public string ReleaseCreatedBy { get; set; }
 
     }
 }

--- a/src/LCT.CycloneDxProcessor/App.config
+++ b/src/LCT.CycloneDxProcessor/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--SPDX-FileCopyrightText: 2025 Siemens AG
 SPDX-License-Identifier: MIT-->
-<configuration xmlns="schema url">
+<configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT-->
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.222.6406" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
+++ b/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
+++ b/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CycloneDX.Utils" Version="5.2.0" />
+    <PackageReference Include="CycloneDX.Utils" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
+++ b/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
@@ -1,31 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>8.0.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<Version>8.0.0</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-  </PropertyGroup>
-    
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CycloneDX.Utils" Version="8.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Update="App.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="CycloneDX.Utils" Version="8.0.3" />
+		<PackageReference Include="NuGet.Versioning" Version="6.10.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="App.config">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/LCT.Facade.UTest/LCT.Facade.UTest.csproj
+++ b/src/LCT.Facade.UTest/LCT.Facade.UTest.csproj
@@ -13,15 +13,18 @@
     <OutputPath>..\..\out</OutputPath>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+		<PackageReference Include="Moq" Version="4.13.1" />
+		<PackageReference Include="NUnit" Version="3.12.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />

--- a/src/LCT.Facade/LCT.Facade.csproj
+++ b/src/LCT.Facade/LCT.Facade.csproj
@@ -1,21 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Version>8.0.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Version>8.0.0</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />
-    <ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />
+		<ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/LCT.Facade/LCT.Facade.csproj
+++ b/src/LCT.Facade/LCT.Facade.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomHelperUnitTests.cs
@@ -338,8 +338,11 @@ namespace LCT.PackageIdentifier.UTest
             };
             mockIProcessor.Setup(x => x.GetJfrogArtifactoryRepoInfo(It.IsAny<CommonAppSettings>(), It.IsAny<ArtifactoryCredentials>(), It.IsAny<Component>(), It.IsAny<string>())).ReturnsAsync(lstComponentForBOM);
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            Mock<IFrameworkPackages> frameworkPackages = new Mock<IFrameworkPackages>();
+            Mock<ICompositionBuilder> compositionBuilder = new Mock<ICompositionBuilder>();
 
-            IParser parser = new NugetProcessor(cycloneDXBomParser.Object);
+            IParser parser = new NugetProcessor(cycloneDXBomParser.Object, frameworkPackages.Object, compositionBuilder.Object);
+            //IParser parser = new NugetProcessor(cycloneDXBomParser.Object);
             Mock<IJFrogService> jFrogService = new Mock<IJFrogService>();
             Mock<IBomHelper> bomHelper = new Mock<IBomHelper>();
             bomHelper.Setup(x => x.GetListOfComponentsFromRepo(It.IsAny<string[]>(), It.IsAny<IJFrogService>())).ReturnsAsync(aqlResultList);

--- a/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/BomValidatorUnitTests.cs
@@ -52,10 +52,10 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             //Act
-            int result=await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
+            int result = await BomValidator.ValidateAppSettings(CommonAppSettings, mockISw360ProjectService.Object, projectReleases);
 
             //Assert
-            Assert.AreEqual(-1,result, "Expected -1 when clearing state is CLOSED.");
+            Assert.AreEqual(-1, result, "Expected -1 when clearing state is CLOSED.");
 
         }
 
@@ -92,6 +92,6 @@ namespace LCT.PackageIdentifier.UTest
             return Task.CompletedTask;
         }
 
-        
+
     }
 }

--- a/src/LCT.PackageIdentifier.UTest/CompositionBuilderTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/CompositionBuilderTests.cs
@@ -1,0 +1,209 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using CycloneDX.Models;
+using NuGet.Versioning;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LCT.PackageIdentifier.UTest
+{
+    [TestFixture]
+    public class CompositionBuilderTests
+    {
+        private CompositionBuilder _builder;
+        private ComponentConfig _config;
+        private Bom _bom;
+
+        [SetUp]
+        public void Setup()
+        {
+            _config = new ComponentConfig
+            {
+                RuntimeName = "Test Runtime",
+                RuntimePackage = "test-runtime",
+                DefaultVersion = "1.0.0"
+            };
+            _builder = new CompositionBuilder(_config);
+            _bom = new Bom();
+        }
+
+        [Test]
+        public void AddCompositionsToBom_WithValidInput_AddsCompositions()
+        {
+            // Arrange
+            var bom = new Bom();
+            var frameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+            {
+                { "net6.0", new Dictionary<string, NuGetVersion> { { "Newtonsoft.Json", new NuGetVersion("13.0.1") } } }
+            };
+            var builder = new CompositionBuilder();
+
+            // Act
+            builder.AddCompositionsToBom(bom, frameworkPackages);
+
+            // Assert
+            Assert.IsNotNull(bom.Compositions);
+            Assert.That(bom.Compositions, Has.Count.EqualTo(1));
+            var composition = bom.Compositions[0];
+            Assert.IsNotNull(composition.Assemblies);
+            Assert.That(composition.Assemblies, Has.Count.EqualTo(1));
+            StringAssert.Contains("dotnet-runtime", composition.Assemblies[0]);
+            Assert.IsNotNull(composition.Dependencies);
+            Assert.That(composition.Dependencies, Has.Count.EqualTo(1));
+            StringAssert.Contains("Newtonsoft.Json", composition.Dependencies[0]);
+        }
+
+        [Test]
+        public void AddCompositionsToBom_NullBom_DoesNothing()
+        {
+            // Arrange
+            var frameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+            {
+                { "net6.0", new Dictionary<string, NuGetVersion> { { "Newtonsoft.Json", new NuGetVersion("13.0.1") } } }
+            };
+            var builder = new CompositionBuilder();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => builder.AddCompositionsToBom(null, frameworkPackages));
+        }
+
+        [Test]
+        public void AddCompositionsToBom_NullFrameworkPackages_DoesNothing()
+        {
+            // Arrange
+            var bom = new Bom();
+            var builder = new CompositionBuilder();
+
+            // Act
+            builder.AddCompositionsToBom(bom, null);
+
+            // Assert
+            Assert.IsNull(bom.Compositions);
+        }
+
+        [Test]
+        public void AddCompositionsToBom_NullBomAndFrameworkPackages_DoesNothing()
+        {
+            // Arrange
+            var builder = new CompositionBuilder();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => builder.AddCompositionsToBom(null, null));
+        }
+
+        [Test]
+        public void AddCompositionsToBom_WithValidInput_CreatesCorrectCompositions()
+        {
+            // Arrange
+            var packages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+            {
+                ["net6.0"] = new Dictionary<string, NuGetVersion>
+                {
+                    ["PackageA"] = new NuGetVersion("1.0.0"),
+                    ["PackageB"] = new NuGetVersion("2.0.0")
+                }
+            };
+
+            // Act
+            _builder.AddCompositionsToBom(_bom, packages);
+
+            // Assert
+            Assert.IsNotNull(_bom.Compositions);
+            Assert.AreEqual(1, _bom.Compositions.Count);
+            var composition = _bom.Compositions.First();
+            Assert.AreEqual(Composition.AggregateType.Complete, composition.Aggregate);
+            Assert.AreEqual(1, composition.Assemblies.Count);
+            Assert.AreEqual(2, composition.Dependencies.Count);
+        }
+
+        [Test]
+        public void CreateComposition_WithFrameworkVersion_GeneratesCorrectIdentifiers()
+        {
+            // Arrange
+            var frameworkPackages = new Dictionary<string, NuGetVersion>
+            {
+                ["PackageA"] = new NuGetVersion("1.0.0")
+            };
+            var framework = new KeyValuePair<string, Dictionary<string, NuGetVersion>>(
+                "net6.0", frameworkPackages);
+
+            // Act
+            var composition = _builder.GetType()
+                .GetMethod("CreateComposition", System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(_builder, new object[] { framework }) as Composition;
+
+            // Assert
+            Assert.IsNotNull(composition);
+            Assert.IsTrue(composition.Assemblies.First()
+                .Contains("pkg:nuget/test-runtime@6.0.0"));
+        }
+
+        [Test]
+        public void CreateRuntimeComponentIdentifier_WithInvalidFrameworkMoniker_UsesDefaultVersion()
+        {
+            // Arrange
+            var frameworkMoniker = "invalid-moniker";
+
+            // Act
+            var identifier = _builder.GetType()
+                .GetMethod("CreateRuntimeComponentIdentifier",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(_builder, new object[] { frameworkMoniker }) as string;
+
+            // Assert
+            Assert.IsNotNull(identifier);
+            Assert.IsTrue(identifier.Contains("pkg:nuget/test-runtime@1.0.0")); // Default version from config
+        }
+
+
+        [Test]
+        [TestCase("net6.0", "6.0.0")]
+        [TestCase("net5.0-windows", "5.0.0")]
+        [TestCase("net4", "4.0.0")]
+        [TestCase("", "1.0.0")] // Default version from config
+        public void ExtractFrameworkVersion_ReturnsCorrectVersion(
+            string frameworkMoniker, string expectedVersion)
+        {
+            // Arrange & Act
+            var version = _builder.GetType()
+                .GetMethod("ExtractFrameworkVersion",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(_builder, new object[] { frameworkMoniker }) as string;
+
+            // Assert
+            Assert.AreEqual(expectedVersion, version);
+        }
+
+        [Test]
+        public void CreateDependencyIdentifiers_GeneratesCorrectPurls()
+        {
+            // Arrange
+            var dependencies = new Dictionary<string, NuGetVersion>
+            {
+                ["PackageA"] = new NuGetVersion("1.0.0"),
+                ["PackageB"] = new NuGetVersion("2.0.0-beta")
+            };
+
+            // Act
+            var identifiers = _builder.GetType()
+                .GetMethod("CreateDependencyIdentifiers",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(_builder, new object[] { dependencies }) as List<string>;
+
+            // Assert
+            Assert.IsNotNull(identifiers);
+            Assert.AreEqual(2, identifiers.Count);
+            Assert.IsTrue(identifiers.Any(i => i.Contains("PackageA@1.0.0")));
+            Assert.IsTrue(identifiers.Any(i => i.Contains("PackageB@2.0.0-beta")));
+        }
+    }
+}

--- a/src/LCT.PackageIdentifier.UTest/CycloneBomProcessorTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/CycloneBomProcessorTests.cs
@@ -41,10 +41,11 @@ namespace LCT.PackageIdentifier.UTest
             projectReleases.Version = "1.2.3";
             CatoolInfo caToolInformation = new CatoolInfo() { CatoolVersion = "6.0.0", CatoolRunningLocation = "" };
             //Act
-            Bom files = CycloneBomProcessor.SetMetadataInComparisonBOM(bom, appSettings, projectReleases, caToolInformation);
+            Bom resultBom = CycloneBomProcessor.SetMetadataInComparisonBOM(bom, appSettings, projectReleases, caToolInformation);
 
             //Assert
-            Assert.That(2, Is.EqualTo(files.Metadata.Tools.Count), "Returns bom with metadata ");
+            Assert.IsNotNull(resultBom.Metadata, "Metadata should not be null.");
+            Assert.AreEqual(1, resultBom.Metadata.Tools.Components.Count, "Metadata should contain one tool component.");
 
         }
         [Test]
@@ -54,39 +55,44 @@ namespace LCT.PackageIdentifier.UTest
             ProjectReleases projectReleases = new ProjectReleases();
             projectReleases.Version = "1.0";
 
-            Bom bom = new Bom()
+            Bom bom = new Bom
             {
-                Metadata = new Metadata()
+                Metadata = new Metadata
                 {
-                    Tools = new List<Tool>() {
-                        new Tool() {
-                            Name = "Existing Data", Version = "1.0.", Vendor = "AG" } },
-                    Component = new Component()
-                },
-                Components = new List<Component>()
+                    Tools = new ToolChoices
+                    {
+                        Components = new List<Component>
             {
-                new Component(){Name="Test",Version="2.2"},
-                new Component(){Name="new",Version="4.2"}
+                new Component
+                {
+                    Supplier = new OrganizationalEntity
+                    {
+                        Name = "Siemens AG"
+                    },
+                    Name = "Clearing Automation Tool",
+                    Version = "8.0.0",
+                    ExternalReferences = new List<ExternalReference>
+                    {
+                        new ExternalReference
+                        {
+                            Url = "",
+                            Type = ExternalReference.ExternalReferenceType.Website
+                        }
+                    }
+                }
             }
+                    }
+                },
+                Definitions = new Definitions()
             };
+
             CommonAppSettings appSettings = new CommonAppSettings()
             {
                 SW360 = new() { ProjectName = "Test" }
             };
             projectReleases.Version = "1.2.3";
 
-            Tool tools = new Tool()
-            {
-                Name = "Clearing Automation Tool",
-                Version = "1.0.17",
-                Vendor = "Siemens AG"
-            };
-            Tool SiemensSBOM = new Tool
-            {
-                Name = "Siemens SBOM",
-                Version = "2.0.0",
-                Vendor = "Siemens AG",
-            };
+
             Component component = new Component
             {
                 Name = appSettings.SW360.ProjectName,
@@ -99,8 +105,9 @@ namespace LCT.PackageIdentifier.UTest
             Bom files = CycloneBomProcessor.SetMetadataInComparisonBOM(bom, appSettings, projectReleases, caToolInformation);
 
             //Assert
-            Assert.That(tools.Name, Is.EqualTo(files.Metadata.Tools[0].Name), "Returns bom with metadata tools");
-            Assert.That(SiemensSBOM.Name, Is.EqualTo(files.Metadata.Tools[1].Name), "Returns bom with metadata tools");
+            Assert.That(bom.Metadata.Tools.Components[0].Name, Is.EqualTo(files.Metadata.Tools.Components[0].Name), "Returns bom with metadata tools");
+            Assert.AreEqual(files.Definitions.Standards[0].Name, "Standard BOM");
+            Assert.AreEqual(files.Definitions.Standards[0].Version, "3.0.0");
             Assert.That(component.Name, Is.EqualTo(files.Metadata.Component.Name), "Returns bom with metadata component ");
             Assert.That(component.Version, Is.EqualTo(files.Metadata.Component.Version), "Returns bom with metadata component ");
             Assert.That(component.Type, Is.EqualTo(files.Metadata.Component.Type), "Returns bom with metadata component ");

--- a/src/LCT.PackageIdentifier.UTest/LCT.PackageIdentifier.UTest.csproj
+++ b/src/LCT.PackageIdentifier.UTest/LCT.PackageIdentifier.UTest.csproj
@@ -33,9 +33,13 @@
 		<None Include="PackageIdentifierUTTestFiles\Nuget.csproj">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Include="PackageIdentifierUTTestFiles\NugetSelfContainedProject\Nuget-SelfContained.csproj">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
 		<PackageReference Include="Moq" Version="4.13.1" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
@@ -44,183 +48,185 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
 	</ItemGroup>
 	<!--<ItemGroup>
     <None Update="appsetting.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>-->
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.PackageIdentifier\LCT.PackageIdentifier.csproj" />
-    <ProjectReference Include="..\UnitTestUtilities\UnitTestUtilities.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="PackageIdentifierUTTestFiles\AlpineSourceDetails_Cyclonedx.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\conan.lock">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX2_Alpine.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX2_Python.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX_Alpine.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\Cyclonedx_Debian.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\Cyclonedx2_Debian.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX2_NPM.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX_NPM.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\CycloneDX_Python.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\Duplicate_Cyclonedx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\MavenDevDependency\bom-without.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\MavenDevDependency\bom.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithDev\bom-without.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithDev\bom.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithOneInputFile\bom-without.cdx.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\package-lock16.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\poetry.lock">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\POM.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\project.assets.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\PythonTestProject\example_package\__init__.py">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\PythonTestProject\poetry.lock">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\PythonTestProject\pyproject.toml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\PythonTestProject\tests\__init__.py">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMAlpineCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMDebianCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Alpine.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Debian.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Maven.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_MavenCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Npm.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_NpmCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Nuget.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_NugetCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Python.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_PythonCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_AlpineCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_ConanCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_DebianCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_MavenCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_NpmCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_NugetCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_PythonCATemplate.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SourceDetails_Cyclonedx.cdx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\SourceDetails_Cyclonedx.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\DupDir\package-lock.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\DupDir\package.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\packages.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\packages.lock.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\package-lock.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\package.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\SubDir\package-lock.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="PackageIdentifierUTTestFiles\TestDir\SubDir\package.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-	  <None Update="PackageIdentifierUTTestFiles\Cyclonedx_Maven.cdx.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	  <None Update="PackageIdentifierUTTestFiles\Cyclonedx2_Maven.cdx.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.PackageIdentifier\LCT.PackageIdentifier.csproj" />
+		<ProjectReference Include="..\UnitTestUtilities\UnitTestUtilities.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="PackageIdentifierUTTestFiles\AlpineSourceDetails_Cyclonedx.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\conan.lock">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX2_Alpine.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX2_Python.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX_Alpine.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\Cyclonedx_Debian.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\Cyclonedx2_Debian.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX2_NPM.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX_NPM.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\CycloneDX_Python.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\Duplicate_Cyclonedx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\MavenDevDependency\bom-without.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\MavenDevDependency\bom.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithDev\bom-without.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithDev\bom.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\MavenDevDependency\WithOneInputFile\bom-without.cdx.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\package-lock16.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\poetry.lock">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\POM.xml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\project.assets.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\PythonTestProject\example_package\__init__.py">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\PythonTestProject\poetry.lock">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\PythonTestProject\pyproject.toml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\PythonTestProject\tests\__init__.py">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMAlpineCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMDebianCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Alpine.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Debian.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Maven.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_MavenCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Npm.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_NpmCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Nuget.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_NugetCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_Python.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOMTemplate_PythonCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_AlpineCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_ConanCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_DebianCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_MavenCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_NpmCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_NugetCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SBOMTemplates\SBOM_PythonCATemplate.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SourceDetails_Cyclonedx.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\SourceDetails_Cyclonedx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\DupDir\package-lock.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\DupDir\package.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\packages.config">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\packages.lock.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\package-lock.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\package.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\SubDir\package-lock.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\TestDir\SubDir\package.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\Cyclonedx_Maven.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="PackageIdentifierUTTestFiles\Cyclonedx2_Maven.cdx.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\LCT.PackageIdentifier\LCT.PackageIdentifier.csproj" />
 		<ProjectReference Include="..\UnitTestUtilities\UnitTestUtilities.csproj" />

--- a/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
+++ b/src/LCT.PackageIdentifier.UTest/NpmProcessorUTest.cs
@@ -450,8 +450,10 @@ namespace LCT.PackageIdentifier.UTest
                 Description = string.Empty,
                 Version = "1.0.0",
                 Purl = "pkg:npm/animations@1.0.0",
-                Author = "{ testcomponent:1.2.3 , subdepenendency:3.4.1 }"
-
+                Manufacturer = new OrganizationalEntity
+                {
+                    BomRef = "{ testcomponent:1.2.3 , subdepenendency:3.4.1 }"
+                }
             };
             List<Component> componentsForBOM = new List<Component>();
             componentsForBOM.Add(component);

--- a/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/NugetParserTests.cs
@@ -14,6 +14,8 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using Moq;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -29,12 +31,18 @@ namespace LCT.PackageIdentifier.UTest
         private Mock<IBomHelper> _mockBomHelper;
         private NugetProcessor _nugetProcessor;
         private ICycloneDXBomParser _cycloneDXBomParser;
+        private Mock<IFrameworkPackages> _frameworkPackages;
+        private Mock<ICompositionBuilder> _compositionBuilder;
+
         [SetUp]
         public void Setup()
         {
             _mockBomHelper = new Mock<IBomHelper>();
             _cycloneDXBomParser = new Mock<ICycloneDXBomParser>().Object;
-            _nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
+            _frameworkPackages = new Mock<IFrameworkPackages>();
+            _compositionBuilder = new Mock<ICompositionBuilder>();
+
+            _nugetProcessor = new NugetProcessor(_cycloneDXBomParser, _frameworkPackages.Object, _compositionBuilder.Object);
         }
 
         [Test]
@@ -47,10 +55,9 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = ""
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
 
             // Act
-            var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
+            var result = _nugetProcessor.GetJfrogRepoPath(aqlResult);
 
             // Assert
             Assert.AreEqual("my-repo/my-package", result);
@@ -66,10 +73,9 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = "."
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
 
             // Act
-            var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
+            var result = _nugetProcessor.GetJfrogRepoPath(aqlResult);
 
             // Assert
             Assert.AreEqual("my-repo/my-package", result);
@@ -85,10 +91,9 @@ namespace LCT.PackageIdentifier.UTest
                 Name = "my-package",
                 Path = "my-folder"
             };
-            var nugetProcessor = new NugetProcessor(_cycloneDXBomParser);
 
             // Act
-            var result = nugetProcessor.GetJfrogRepoPath(aqlResult);
+            var result = _nugetProcessor.GetJfrogRepoPath(aqlResult);
 
             // Assert
             Assert.AreEqual("my-repo/my-folder/my-package", result);
@@ -237,10 +242,10 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
 
             // Act
-            nugetProcessor.AddSiemensDirectProperty(ref bom);
+            NugetProcessor.AddSiemensDirectProperty(ref bom);
 
             // Assert
             Assert.AreEqual(expectedBom.Components.Count, bom.Components.Count);
@@ -294,10 +299,10 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
 
             // Act
-            nugetProcessor.AddSiemensDirectProperty(ref bom);
+            NugetProcessor.AddSiemensDirectProperty(ref bom);
 
             // Assert
             // Assert
@@ -381,10 +386,10 @@ namespace LCT.PackageIdentifier.UTest
                 }
             };
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            var nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
 
             // Act
-            nugetProcessor.AddSiemensDirectProperty(ref bom);
+            NugetProcessor.AddSiemensDirectProperty(ref bom);
 
             // Assert
             Assert.AreEqual(expectedBom.Components.Count, bom.Components.Count);
@@ -545,7 +550,7 @@ namespace LCT.PackageIdentifier.UTest
             }
 
             //Assert
-            Assert.That(1, Is.EqualTo(devDependent), "Checks for total dev dependent components found");
+            Assert.That(2, Is.EqualTo(devDependent), "Checks for total dev dependent components found");
         }
 
         [TestCase]
@@ -622,7 +627,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -672,7 +677,7 @@ namespace LCT.PackageIdentifier.UTest
 
             // Act
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(component, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
             // Assert
@@ -724,7 +729,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.IdentificationOfInternalComponents(
                 componentIdentification, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -776,8 +781,8 @@ namespace LCT.PackageIdentifier.UTest
             mockBomHelper.Setup(m => m.GetFullNameOfComponent(It.IsAny<Component>())).Returns("animations/common");
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
-            // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            // Act  
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -829,7 +834,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -881,7 +886,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -933,7 +938,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -985,7 +990,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -1038,7 +1043,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             // Act
-            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object);
+            NugetProcessor nugetProcessor = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object);
             var actual = await nugetProcessor.GetJfrogRepoDetailsOfAComponent(
                 components, appSettings, mockJfrogService.Object, mockBomHelper.Object);
 
@@ -1071,7 +1076,7 @@ namespace LCT.PackageIdentifier.UTest
             Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
 
             //Act
-            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object).ParsePackageFile(appSettings);
 
             //Assert
             Assert.That(expectednoofcomponents, Is.EqualTo(listofcomponents.Components.Count), "Checks for no of components");
@@ -1104,7 +1109,7 @@ namespace LCT.PackageIdentifier.UTest
 
 
             //Act
-            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object).ParsePackageFile(appSettings);
+            Bom listofcomponents = new NugetProcessor(cycloneDXBomParser.Object, _frameworkPackages.Object, _compositionBuilder.Object).ParsePackageFile(appSettings);
             var IsDevDependency =
                 listofcomponents.Components.Find(a => a.Name == "SonarAnalyzer.CSharp")
                 .Properties[0].Value;
@@ -1113,5 +1118,213 @@ namespace LCT.PackageIdentifier.UTest
             Assert.That(IsDev, Is.EqualTo(IsDevDependency), "Checks if Dev Dependency Component or not");
 
         }
+
+        [Test]
+        public void ParsePackageFile_WhenSelfContainedProject_DetectsDeploymentTypeCorrectlyAndFrameworkLogicWillNotApply()
+        {
+            // Arrange
+            Mock<ICycloneDXBomParser> _mockCycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string outFolder = Path.GetDirectoryName(exePath);
+            string packagefilepath = Path.GetFullPath(Path.Combine(outFolder, "PackageIdentifierUTTestFiles"));
+
+            string[] Includes = { "project.assets.json", "Nuget-SelfContained.csproj" };
+            IFolderAction folderAction = new FolderAction();
+            IFileOperations fileOperations = new FileOperations();
+            CommonAppSettings appSettings = new CommonAppSettings(folderAction, fileOperations)
+            {
+                Nuget = new Config() { Include = Includes },
+                SW360 = new SW360(),
+                Directory = new LCT.Common.Directory(folderAction, fileOperations)
+                {
+                    InputFolder = packagefilepath
+                }
+            };
+
+            var frameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+        {
+            { "net6.0-Microsoft.NETCore.App", new Dictionary<string, NuGetVersion> { { "Newtonsoft.Json", NuGetVersion.Parse("13.0.3") } } }
+        };
+
+            string[] frameworkReferences = new[] {
+                "Microsoft.NETCore.App"
+            };
+
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkPackages(It.IsAny<List<string>>()))
+                .Returns(frameworkPackages);
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkReferences(It.IsAny<LockFile>(), It.IsAny<LockFileTarget>()))
+                .Returns(frameworkReferences);
+
+            var bom = new Bom
+            {
+                Components = new List<Component>
+            {
+                new Component
+                {
+                    Name = "TestComponent",
+                    Version = "1.0.0",
+                    Properties = new List<Property>()
+                }
+            }
+            };
+
+            _mockCycloneDXBomParser
+                .Setup(x => x.ParseCycloneDXBom(It.IsAny<string>()))
+                .Returns(bom);
+
+            // Act
+            var result = _nugetProcessor.ParsePackageFile(appSettings);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("false", result.Components.First().Properties.FirstOrDefault(p => p.Name == Dataconstant.Cdx_IsDevelopment)?.Value);
+        }
+
+        [Test]
+        public void ParsePackageFile_WhenFrameworkPackagesAreProvided_AddsFrameworkPackagesAlsoToBom()
+        {
+            // Arrange
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string outFolder = Path.GetDirectoryName(exePath);
+            string packagefilepath = Path.GetFullPath(Path.Combine(outFolder, "PackageIdentifierUTTestFiles"));
+
+            string[] Includes = { "project.assets.json", "Nuget.csproj" };
+            string[] excludes = { "NugetSelfContainedProject" };
+            IFolderAction folderAction = new FolderAction();
+            IFileOperations fileOperations = new FileOperations();
+            CommonAppSettings appSettings = new CommonAppSettings(folderAction, fileOperations)
+            {
+                Nuget = new Config() { Include = Includes, Exclude = excludes },
+                SW360 = new SW360(),
+                Directory = new LCT.Common.Directory(folderAction, fileOperations)
+                {
+                    InputFolder = packagefilepath
+                }
+            };
+
+            var frameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+            {
+                { "net6.0-runtime", new Dictionary<string, NuGetVersion> { { "TestComponent", NuGetVersion.Parse("1.0.0") } } }
+            };
+
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkPackages(It.IsAny<List<string>>()))
+                .Returns(frameworkPackages);
+
+            _compositionBuilder
+                .Setup(x => x.AddCompositionsToBom(It.IsAny<Bom>(), It.IsAny<Dictionary<string, Dictionary<string, NuGetVersion>>>()))
+                .Verifiable();
+
+            // Act
+            var result = _nugetProcessor.ParsePackageFile(appSettings);
+
+            // Assert
+            _frameworkPackages.Verify(x => x.GetFrameworkPackages(It.IsAny<List<string>>()), Times.Once);
+            Assert.AreEqual(2, result.Components.Count);
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void ParsePackageFile_WhenComponentIsFrameworkDependent_MarksComponentAsDevDependency()
+        {
+            // Arrange
+            Mock<ICycloneDXBomParser> _mockCycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string outFolder = Path.GetDirectoryName(exePath);
+            string packagefilepath = Path.GetFullPath(Path.Combine(outFolder, "PackageIdentifierUTTestFiles"));
+
+            string[] Includes = { "project.assets.json" };
+            string[] excludes = { "NugetSelfContainedProject" };
+            IFolderAction folderAction = new FolderAction();
+            IFileOperations fileOperations = new FileOperations();
+            CommonAppSettings appSettings = new CommonAppSettings(folderAction, fileOperations)
+            {
+                Nuget = new Config() { Include = Includes, Exclude = excludes },
+                SW360 = new SW360(),
+                Directory = new LCT.Common.Directory(folderAction, fileOperations)
+                {
+                    InputFolder = packagefilepath
+                }
+            };
+
+            var frameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>
+        {
+            { "net6.0-Microsoft.NETCore.App", new Dictionary<string, NuGetVersion> { { "Newtonsoft.Json", NuGetVersion.Parse("13.0.3") } } }
+        };
+
+            string[] frameworkReferences = new[] {
+                "Microsoft.NETCore.App"
+            };
+
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkPackages(It.IsAny<List<string>>()))
+                .Returns(frameworkPackages);
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkReferences(It.IsAny<LockFile>(), It.IsAny<LockFileTarget>()))
+                .Returns(frameworkReferences);
+
+            var bom = new Bom
+            {
+                Components = new List<Component>
+            {
+                new Component
+                {
+                    Name = "TestComponent",
+                    Version = "1.0.0",
+                    Properties = new List<Property>()
+                }
+            }
+            };
+
+            _mockCycloneDXBomParser
+                .Setup(x => x.ParseCycloneDXBom(It.IsAny<string>()))
+                .Returns(bom);
+
+            // Act
+            var result = _nugetProcessor.ParsePackageFile(appSettings);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("true", result.Components.First().Properties.FirstOrDefault(p => p.Name == Dataconstant.Cdx_IsDevelopment)?.Value);
+        }
+
+        [Test]
+        public void ParsePackageFile_WhenNoFrameworkPackagesAreProvided_FrameworkPackagesWillBeAddedAsRequiredComponents()
+        {
+            // Arrange
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string outFolder = Path.GetDirectoryName(exePath);
+            string packagefilepath = Path.GetFullPath(Path.Combine(outFolder, "PackageIdentifierUTTestFiles"));
+
+            string[] Includes = { "project.assets.json" };
+            string[] excludes = { "NugetSelfContainedProject" };
+            IFolderAction folderAction = new FolderAction();
+            IFileOperations fileOperations = new FileOperations();
+            CommonAppSettings appSettings = new CommonAppSettings(folderAction, fileOperations)
+            {
+                Nuget = new Config() { Include = Includes, Exclude = excludes },
+                SW360 = new SW360(),
+                Directory = new LCT.Common.Directory(folderAction, fileOperations)
+                {
+                    InputFolder = packagefilepath
+                }
+            };
+
+            _frameworkPackages
+                .Setup(x => x.GetFrameworkPackages(It.IsAny<List<string>>()))
+                .Returns(new Dictionary<string, Dictionary<string, NuGetVersion>>());
+
+            // Act
+            var result = _nugetProcessor.ParsePackageFile(appSettings);
+
+            // Assert
+            _frameworkPackages.Verify(x => x.GetFrameworkPackages(It.IsAny<List<string>>()), Times.Once);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("false", result.Components.First().Properties.FirstOrDefault(p => p.Name == Dataconstant.Cdx_IsDevelopment)?.Value);
+        }
+
     }
 }

--- a/src/LCT.PackageIdentifier.UTest/PackageIdentifierUTTestFiles/NugetSelfContainedProject/Nuget-SelfContained.csproj
+++ b/src/LCT.PackageIdentifier.UTest/PackageIdentifierUTTestFiles/NugetSelfContainedProject/Nuget-SelfContained.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>SEPP.Nuget</AssemblyName>
+    <RootNamespace>SEPP.Nuget</RootNamespace>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
+    <Platforms>x64</Platforms>    
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.9">
+	<PrivateAssets>all</PrivateAssets>	</PackageReference>
+    <PackageReference Include="System.Json" Version="4.7.1" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
+    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
+    <SelfContained>true</SelfContained>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SEPP.Common\SEPP.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -41,11 +41,16 @@ namespace LCT.PackageIdentifier
         public IJFrogService JFrogService { get; set; }
         public IBomHelper BomHelper { get; set; }
 
+        private readonly IFrameworkPackages _frameworkPackages;
+        private readonly ICompositionBuilder _compositionBuilder;
+
         public static Jfrog jfrog { get; set; } = new Jfrog();
         public static SW360 sw360 { get; set; } = new SW360();
-        public BomCreator(ICycloneDXBomParser cycloneDXBomParser)
+        public BomCreator(ICycloneDXBomParser cycloneDXBomParser, IFrameworkPackages frameworkPackages, ICompositionBuilder compositionBuilder)
         {
             CycloneDXBomParser = cycloneDXBomParser;
+            _frameworkPackages = frameworkPackages;
+            _compositionBuilder = compositionBuilder;
         }
 
         public async Task GenerateBom(CommonAppSettings appSettings,
@@ -147,7 +152,7 @@ namespace LCT.PackageIdentifier
                     parser = new NpmProcessor(CycloneDXBomParser);
                     return await ComponentIdentification(appSettings, parser);
                 case "NUGET":
-                    parser = new NugetProcessor(CycloneDXBomParser);
+                    parser = new NugetProcessor(CycloneDXBomParser, _frameworkPackages, _compositionBuilder);
                     return await ComponentIdentification(appSettings, parser);
                 case "MAVEN":
                     parser = new MavenProcessor(CycloneDXBomParser);

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -14,7 +14,6 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -24,6 +23,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 
 namespace LCT.PackageIdentifier

--- a/src/LCT.PackageIdentifier/BomHelper.cs
+++ b/src/LCT.PackageIdentifier/BomHelper.cs
@@ -12,7 +12,6 @@ using LCT.PackageIdentifier.Interface;
 using LCT.PackageIdentifier.Model;
 using LCT.Services.Interface;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -22,6 +21,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Level = log4net.Core.Level;
 
 namespace LCT.PackageIdentifier
 {

--- a/src/LCT.PackageIdentifier/BomValidator.cs
+++ b/src/LCT.PackageIdentifier/BomValidator.cs
@@ -6,10 +6,8 @@
 
 using LCT.APICommunications.Model;
 using LCT.Common;
-using LCT.Common.Interface;
 using LCT.Services.Interface;
 using log4net;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -20,7 +18,7 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public static class BomValidator
     {
-        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);        
+        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         public static async Task<int> ValidateAppSettings(CommonAppSettings appSettings, ISw360ProjectService bomService, ProjectReleases projectReleases)
         {
             string sw360ProjectName = await bomService.GetProjectNameByProjectIDFromSW360(appSettings.SW360.ProjectID, appSettings.SW360.ProjectName, projectReleases);

--- a/src/LCT.PackageIdentifier/CompositionBuilder.cs
+++ b/src/LCT.PackageIdentifier/CompositionBuilder.cs
@@ -1,0 +1,128 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using CycloneDX.Models;
+using LCT.Common.Constants;
+using LCT.PackageIdentifier.Interface;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LCT.PackageIdentifier
+{
+    /// <summary>
+    /// Responsible for building compositions and adding them to the BOM (Bill of Materials).
+    /// </summary>
+    public class CompositionBuilder : ICompositionBuilder
+    {
+        private readonly ComponentConfig _config;
+        private readonly string _basePurl;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionBuilder"/> class.
+        /// </summary>
+        /// <param name="config">Optional configuration for component settings.</param>
+        public CompositionBuilder(ComponentConfig config = null)
+        {
+            _config = config ?? new ComponentConfig();
+            _basePurl = Dataconstant.PurlCheck()["NUGET"];
+        }
+
+        /// <summary>
+        /// Adds compositions to the provided BOM based on the framework packages.
+        /// </summary>
+        /// <param name="bom">The BOM to which compositions will be added.</param>
+        /// <param name="frameworkPackages">Framework packages grouped by framework moniker.</param>
+        public void AddCompositionsToBom(Bom bom, Dictionary<string, Dictionary<string, NuGetVersion>> frameworkPackages)
+        {
+            if (bom != null && frameworkPackages != null)
+            {
+                bom.Compositions = frameworkPackages.Select(CreateComposition).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Creates a composition for a specific framework.
+        /// </summary>
+        /// <param name="framework">The framework and its associated packages.</param>
+        /// <returns>A new <see cref="Composition"/> instance.</returns>
+        private Composition CreateComposition(KeyValuePair<string, Dictionary<string, NuGetVersion>> framework)
+        {
+            return new Composition
+            {
+                Aggregate = Composition.AggregateType.Complete,
+                Assemblies = new List<string> { CreateRuntimeComponentIdentifier(framework.Key) },
+                Dependencies = CreateDependencyIdentifiers(framework.Value)
+            };
+        }
+
+        /// <summary>
+        /// Creates a runtime component identifier for a given framework moniker.
+        /// </summary>
+        /// <param name="frameworkMoniker">The framework moniker (e.g., "net6.0").</param>
+        /// <returns>A runtime component identifier string.</returns>
+        private string CreateRuntimeComponentIdentifier(string frameworkMoniker)
+        {
+            var version = ExtractFrameworkVersion(frameworkMoniker);
+            return $"{_basePurl}/{_config.RuntimePackage}@{version}";
+        }
+
+        /// <summary>
+        /// Creates a list of dependency identifiers for the given packages.
+        /// </summary>
+        /// <param name="dependencies">A dictionary of package names and their versions.</param>
+        /// <returns>A list of dependency identifier strings.</returns>
+        private List<string> CreateDependencyIdentifiers(Dictionary<string, NuGetVersion> dependencies)
+        {
+            return dependencies.Select(pkg =>
+                $"{_basePurl}/{pkg.Key}@{pkg.Value.ToNormalizedString()}"
+            ).ToList();
+        }
+
+        /// <summary>
+        /// Extracts the framework version from a framework moniker.
+        /// </summary>
+        /// <param name="frameworkMoniker">The framework moniker (e.g., "net6.0").</param>
+        /// <returns>The extracted version string.</returns>
+        private string ExtractFrameworkVersion(string frameworkMoniker)
+        {
+            if (string.IsNullOrEmpty(frameworkMoniker))
+                return _config.DefaultVersion;
+
+            // Remove any platform-specific suffix (e.g., "net6.0-windows").
+            if (frameworkMoniker.Contains('-'))
+            {
+                frameworkMoniker = frameworkMoniker.Split('-')[0];
+            }
+
+            // Ensure the moniker starts with "net".
+            if (!frameworkMoniker.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+                return _config.DefaultVersion;
+
+            // Extract and normalize the version.
+            var version = frameworkMoniker[3..];
+            var parts = version.Split('.');
+
+            return parts.Length switch
+            {
+                1 => $"{version}.0.0",
+                2 => $"{version}.0",
+                _ => version
+            };
+        }
+    }
+
+    /// <summary>
+    /// Configuration settings for the <see cref="CompositionBuilder"/>.
+    /// </summary>
+    public class ComponentConfig
+    {
+        public string RuntimeName { get; set; } = ".NET Runtime";
+        public string RuntimePackage { get; set; } = "dotnet-runtime";
+        public string DefaultVersion { get; set; } = "0.0.0";
+    }
+}

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -26,52 +26,108 @@ namespace LCT.PackageIdentifier
                                                      CatoolInfo caToolInformation)
         {
             Logger.Debug("Starting to add metadata info into the BOM");
+
+            // Create metadata
+            Metadata metadata = CreateMetadata(appSettings, projectReleases, caToolInformation);
+            // Create definitions
+            Definitions definitions = AddDefinitionsToBom();
+            // Add metadata to BOM
+            bom.Metadata = metadata;
+
+            // Add definitions to BOM
+            bom.Definitions = definitions;
+
+            return bom;
+        }
+
+        private static Metadata CreateMetadata(CommonAppSettings appSettings, ProjectReleases projectReleases, CatoolInfo caToolInformation)
+        {
             Metadata metadata = new Metadata
             {
-                Tools = new List<Tool>(),
-                Properties = new List<Property>()
+                Tools = CreateToolChoices(caToolInformation),
+                Properties = CreateProperties()
             };
 
-            SetMetaDataToolsValues(metadata, caToolInformation);
+            // Add metadata component
+            metadata.Component = CreateMetadataComponent(appSettings, projectReleases);
 
-            Component component = new Component
+            return metadata;
+        }
+
+        private static ToolChoices CreateToolChoices(CatoolInfo caToolInformation)
+        {
+            return new ToolChoices
+            {
+                Components = new List<Component>
+        {
+            new Component
+            {
+                Type= Component.Classification.Application,
+                Supplier = new OrganizationalEntity
+                {
+                    Name = "Siemens AG"
+                },
+                Name = "Clearing Automation Tool",
+                Version = caToolInformation.CatoolVersion,
+                ExternalReferences = new List<ExternalReference>
+                {
+                    new ExternalReference
+                    {
+                        Type = ExternalReference.ExternalReferenceType.Website,
+                        Url = Dataconstant.GithubUrl
+                    }
+                }
+            }
+        }
+            };
+        }
+
+        private static List<Property> CreateProperties()
+        {
+            return new List<Property>
+    {
+        new Property
+        {
+            Name = "siemens:profile",
+            Value = "clearing"
+        }
+    };
+        }
+        private static Component CreateMetadataComponent(CommonAppSettings appSettings, ProjectReleases projectReleases)
+        {
+            return new Component
             {
                 Name = appSettings?.SW360?.ProjectName,
                 Version = projectReleases.Version,
                 Type = Component.Classification.Application
             };
-            metadata.Component = component;
-
-            Property projectType = new Property
-            {
-                Name = "siemens:profile",
-                Value = "clearing"
-            };
-            metadata.Properties.Add(projectType);
-
-            bom.Metadata = metadata;
-            return bom;
         }
-
-        public static void SetMetaDataToolsValues(Metadata metadata, CatoolInfo caToolInformation)
+        private static Definitions AddDefinitionsToBom()
         {
-            Tool tool = new Tool
+            Definitions definitions = new Definitions
             {
-                Name = "Clearing Automation Tool",
-                Version = caToolInformation.CatoolVersion,
-                Vendor = "Siemens AG",
-                ExternalReferences = new List<ExternalReference>() { new ExternalReference { Url = "https://github.com/siemens/continuous-clearing", Type = ExternalReference.ExternalReferenceType.Website } }
+                Standards = new List<Standard>
+        {
+            new Standard
+            {
+                Name = "Standard BOM",
+                Version = "3.0.0",
+                Description = "The Standard for Software Bills of Materials in Siemens",
+                Owner = "Siemens AG",
+                ExternalReferences = new List<ExternalReference>
+                {
+                    new ExternalReference
+                    {
+                        Type = ExternalReference.ExternalReferenceType.Website,
+                        Url = Dataconstant.StandardSbomUrl
+                    }
+                },
+                BomRef = "standard-bom"
+            }
+        }
             };
-            metadata.Tools.Add(tool);
 
-            Tool SiemensSBOM = new Tool
-            {
-                Name = "Siemens SBOM",
-                Version = "2.0.0",
-                Vendor = "Siemens AG",
-                ExternalReferences = new List<ExternalReference>() { new ExternalReference { Url = "https://sbom.siemens.io/", Type = ExternalReference.ExternalReferenceType.Website } }
-            };
-            metadata.Tools.Add(SiemensSBOM);
+            return definitions;
         }
         public static void SetProperties(CommonAppSettings appSettings, Component component, ref List<Component> componentForBOM, string repo = "Not Found in JFrogRepo")
         {

--- a/src/LCT.PackageIdentifier/FrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/FrameworkPackages.cs
@@ -1,0 +1,157 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using LCT.PackageIdentifier.Interface;
+using log4net;
+using log4net.Core;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace LCT.PackageIdentifier
+{
+    public class FrameworkPackages : IFrameworkPackages
+    {
+        readonly Dictionary<string, Dictionary<string, NuGetVersion>> _foundFrameworkPackages = [];
+        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        #region public methods
+        public Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths)
+        {
+            try
+            {
+                var uniqueTargets = new Dictionary<NuGetFramework, HashSet<string>>();
+
+                foreach (var lockFilePath in lockFilePaths)
+                {
+                    var lockFile = new LockFileFormat().Read(lockFilePath);
+                    foreach (var target in lockFile.Targets)
+                    {
+                        var frameworkReferences = GetFrameworkReferences(lockFile, target);
+                        if (!uniqueTargets.TryGetValue(target.TargetFramework, out HashSet<string> value))
+                        {
+                            value = new HashSet<string>();
+                            uniqueTargets[target.TargetFramework] = value;
+                        }
+                        foreach (var reference in frameworkReferences)
+                        {
+                            value.Add(reference);
+                        }
+                    }
+                }
+
+                var frameworkPackagesType = LoadAssembly();
+
+                if (frameworkPackagesType == null)
+                {
+                    Logger.Warn("Assembly type 'Microsoft.ComponentDetection.Detectors.NuGet.FrameworkPackages' could not be found.");
+                }
+
+                var getFrameworkPackagesMethod = GetFrameworkPackagesMethod(frameworkPackagesType);
+
+                if (getFrameworkPackagesMethod == null)
+                {
+                    Logger.Logger.Log(null, Level.Notice, $"Method 'GetFrameworkPackages' not found.", null);
+                    return _foundFrameworkPackages;
+                }
+
+                foreach (var target in uniqueTargets)
+                {
+                    InvokeGetFrameworkPackagesMethod(getFrameworkPackagesMethod, target.Key, target.Value.ToArray(), null);
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                Logger.Debug($"GetFrameworkPackages: Argument error: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logger.Debug($"GetFrameworkPackages : Invalid operation: {ex.Message}");
+            }
+
+            return _foundFrameworkPackages;
+        }
+
+        public string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target)
+        {
+            var frameworkInformation = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(x => x.FrameworkName.Equals(target.TargetFramework));
+
+            if (frameworkInformation == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var results = frameworkInformation.FrameworkReferences.Select(x => x.Name)
+                .Concat(target.Libraries.SelectMany(l => l.FrameworkReferences))
+                .Distinct()
+                .ToArray();
+
+            return results;
+        }
+        #endregion
+
+        #region private methods
+        private static Type LoadAssembly()
+        {
+            try
+            {
+                Assembly componentDetectionAssembly = Assembly.Load("Microsoft.ComponentDetection.Detectors");
+                return componentDetectionAssembly.GetType("Microsoft.ComponentDetection.Detectors.NuGet.FrameworkPackages");
+            }
+            catch (FileNotFoundException ex)
+            {
+                Logger.Debug($"LoadAssembly: FileNotFoundException  {ex.Message}");
+            }
+            catch (FileLoadException ex)
+            {
+                Logger.Debug($"LoadAssembly: FileLoadException {ex.Message}");
+            }
+            return null;
+        }
+
+        private static MethodInfo GetFrameworkPackagesMethod(Type frameworkPackagesType)
+        {
+            var methods = frameworkPackagesType.GetMethods(BindingFlags.Static | BindingFlags.Public);
+            if (methods != null && methods.Any(m => m.Name == "GetFrameworkPackages"))
+            {
+                return frameworkPackagesType.GetMethod("GetFrameworkPackages", BindingFlags.Static | BindingFlags.Public);
+            }
+            return null;
+        }
+
+        private void InvokeGetFrameworkPackagesMethod(MethodInfo getFrameworkPackagesMethod, NuGetFramework targetFramework, string[] frameworkReferences, LockFileTarget lockFileTarget)
+        {
+            object[] parameters = { targetFramework, frameworkReferences, lockFileTarget };
+            var result = getFrameworkPackagesMethod.Invoke(null, parameters);
+
+            if (result is Array frameworkPackagesArray)
+            {
+                foreach (var frameworkPackage in frameworkPackagesArray)
+                {
+                    ProcessFrameworkPackage(targetFramework, frameworkPackage);
+                }
+            }
+        }
+
+        private void ProcessFrameworkPackage(NuGetFramework targetFramework, object frameworkPackage)
+        {
+            var frameworkNameProperty = frameworkPackage.GetType().GetProperty("FrameworkName");
+            var packagesProperty = frameworkPackage.GetType().GetProperty("Packages");
+
+            if (frameworkNameProperty != null && packagesProperty != null)
+            {
+                var frameworkName = frameworkNameProperty.GetValue(frameworkPackage)?.ToString() ?? string.Empty;
+                _foundFrameworkPackages[targetFramework + "-" + frameworkName] = packagesProperty.GetValue(frameworkPackage) as Dictionary<string, NuGetVersion> ?? new Dictionary<string, NuGetVersion>();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/LCT.PackageIdentifier/Interface/ICompositionBuilder.cs
+++ b/src/LCT.PackageIdentifier/Interface/ICompositionBuilder.cs
@@ -1,0 +1,17 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using CycloneDX.Models;
+using NuGet.Versioning;
+using System.Collections.Generic;
+
+namespace LCT.PackageIdentifier.Interface
+{
+    public interface ICompositionBuilder
+    {
+        void AddCompositionsToBom(Bom bom, Dictionary<string, Dictionary<string, NuGetVersion>> frameworkPackages);
+    }
+}

--- a/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System.Collections.Generic;
+
+namespace LCT.PackageIdentifier.Interface
+{
+    public interface IFrameworkPackages
+    {
+        Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths);
+
+        string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target);
+    }
+}

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>PackageIdentifier</AssemblyName>
-    <Version>8.0.0</Version>
+		<Version>8.0.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -22,24 +22,28 @@
 		<PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
 		<PackageReference Include="Microsoft.CodeCoverage" Version="17.1.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="NuGet.Packaging" Version="6.7.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<!--<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="NuGet.Packaging" Version="6.7.1" />-->
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
-		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.11" />
+		<!--<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />-->
+		<PackageReference Include="System.Text.Json" Version="9.0.2" />
+		<PackageReference Include="Microsoft.ComponentDetection.Detectors" Version="5.2.15" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 	</ItemGroup>
-  
+
 	<ItemGroup>
 		<ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
 		<ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
 		<ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
 		<ProjectReference Include="..\LCT.Telemetry\LCT.Telemetry.csproj" />
 	</ItemGroup>
-  
+
 	<ItemGroup>
-	  <None Update="CLIUsageNpkg.txt">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
+		<None Update="CLIUsageNpkg.txt">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -27,7 +27,7 @@
 		<PackageReference Include="NuGet.Resolver" Version="6.6.1" />
 		<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
 		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.11" />
 	</ItemGroup>
   
 	<ItemGroup>

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>PackageIdentifier</AssemblyName>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -214,7 +214,7 @@ namespace LCT.PackageIdentifier
                     continue;
                 }
 
-                Component components = new Component();
+                Component components = new Component() { Manufacturer = new OrganizationalEntity() };
                 var properties = JObject.Parse(Convert.ToString(prop.Value));
 
                 // dev components are not ignored and added as a part of SBOM 
@@ -238,7 +238,7 @@ namespace LCT.PackageIdentifier
                 components.Type = Component.Classification.Library;
                 components.Description = folderPath;
                 components.Version = Convert.ToString(properties[Version]);
-                components.Author = prop.Value[Dependencies]?.ToString();
+                components.Manufacturer.BomRef = prop.Value[Dependencies]?.ToString();
                 components.Purl = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.BomRef = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
 
@@ -311,7 +311,7 @@ namespace LCT.PackageIdentifier
 
             foreach (JProperty prop in depencyComponentList)
             {
-                Component components = new Component();
+                Component components = new Component() { Manufacturer = new OrganizationalEntity() };
                 Property isdev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
 
                 var properties = JObject.Parse(Convert.ToString(prop.Value));
@@ -352,7 +352,7 @@ namespace LCT.PackageIdentifier
 
                 components.Description = folderPath;
                 components.Version = Convert.ToString(properties[Version]);
-                components.Author = prop.Value[Requires]?.ToString();
+                components.Manufacturer.BomRef = prop.Value[Requires]?.ToString();
                 components.Purl = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.BomRef = $"{ApiConstant.NPMExternalID}{componentName}@{components.Version}";
                 components.Type = Component.Classification.Library;
@@ -563,10 +563,10 @@ namespace LCT.PackageIdentifier
 
             foreach (var component in componentsForBOM)
             {
-                if ((component.Author?.Split(",")) != null)
+                if ((component.Manufacturer?.BomRef?.Split(",")) != null)
                 {
                     List<Dependency> subDependencies = new();
-                    foreach (var item in (component.Author?.Split(",")).Where(item => item.Contains(':')))
+                    foreach (var item in (component.Manufacturer?.BomRef?.Split(",")).Where(item => item.Contains(':')))
                     {
                         var componentDetails = item.Split(":");
                         string name;
@@ -599,9 +599,10 @@ namespace LCT.PackageIdentifier
 
                     dependencyList.Add(dependency);
 
-                    component.Author = null;
+                    component.Manufacturer = null;
 
                 }
+                component.Manufacturer = null;
             }
             dependencies.AddRange(dependencyList);
         }

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -537,6 +537,7 @@ namespace LCT.PackageIdentifier
                         bom = RemoveExcludedComponents(appSettings, bom);
                         CheckValidComponentsForProjectType(bom.Components, appSettings.ProjectType);
                         AddingIdentifierType(bom.Components, "CycloneDXFile");
+                        BomCreator.bomKpiData.ComponentsinPackageLockJsonFile += bom.Components.Count;
                         componentsForBOM.AddRange(bom.Components);
                         dependencies = bom.Dependencies;
                     }

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -462,7 +462,7 @@ namespace LCT.PackageIdentifier
                         CycloneDXBomParser.CheckValidComponentsForProjectType(
                             bom.Components, appSettings.ProjectType);
                         componentsForBOM.AddRange(bom.Components);
-                        CommonHelper.GetDetailsforManuallyAdded(componentsForBOM,
+                        CommonHelper.GetDetailsForManuallyAdded(componentsForBOM,
                             listComponentForBOM);
                     }
                 }

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -23,8 +23,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
 

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -4,6 +4,8 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+// Ignore Spelling: Bom LCT
+
 using LCT.APICommunications;
 using LCT.APICommunications.Interfaces;
 using LCT.APICommunications.Model;

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -20,14 +20,15 @@ using LCT.Services;
 using LCT.Services.Interface;
 using log4net;
 using log4net.Core;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
-
 
 namespace LCT.PackageIdentifier
 {
@@ -41,28 +42,55 @@ namespace LCT.PackageIdentifier
 
         public static Stopwatch BomStopWatch { get; set; }
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();        
+        private static IEnvironmentHelper environmentHelper = new EnvironmentHelper();
+
+        private readonly ISettingsManager _settingsManager;
+        private readonly IBomCreator _bomCreator;
+
+        public Program(IFrameworkPackages frameworkPackages, ISettingsManager settingsManager, ICycloneDXBomParser cycloneDXBomParser, IBomCreator bomCreator)
+        {
+            _settingsManager = settingsManager;
+            _bomCreator = bomCreator;
+        }
         protected Program() { }
 
         static async Task Main(string[] args)
+        {
+            var serviceCollection = new ServiceCollection();
+            ConfigureServices(serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var program = serviceProvider.GetService<Program>();
+            await program.Run(args);
+        }
+
+        private static void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IFrameworkPackages, FrameworkPackages>();
+            services.AddTransient<ISettingsManager, SettingsManager>();
+            services.AddTransient<ICycloneDXBomParser, CycloneDXBomParser>();
+            services.AddTransient<IBomCreator, BomCreator>();
+            services.AddTransient<Program>();
+            services.AddScoped<ICompositionBuilder, CompositionBuilder>();
+        }
+
+        public async Task Run(string[] args)
         {
             BomStopWatch = new Stopwatch();
             BomStopWatch.Start();
 
             if (!m_Verbose && CommonHelper.IsAzureDevOpsDebugEnabled())
                 m_Verbose = true;
-            ISettingsManager settingsManager = new SettingsManager();
+
+            CommonAppSettings appSettings = _settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
+            ProjectReleases projectReleases = new ProjectReleases();
             // do not change the order of getting ca tool information
             CatoolInfo caToolInformation = GetCatoolVersionFromProjectfile();
             Log4Net.CatoolCurrentDirectory = Directory.GetParent(caToolInformation.CatoolRunningLocation).FullName;
-            CommonHelper.DefaultLogFolderInitialisation(FileConstant.BomCreatorLog, m_Verbose);
-            CommonAppSettings appSettings = settingsManager.ReadConfiguration<CommonAppSettings>(args, FileConstant.appSettingFileName);
-            
-            ProjectReleases projectReleases = new ProjectReleases();
+            LogFolderInitialisation(appSettings);
 
-            string FolderPath = CommonHelper.LogFolderInitialisation(appSettings, FileConstant.BomCreatorLog, m_Verbose);
-            Logger.Logger.Log(null, Level.Debug, $"log manager initiated folder path: {FolderPath}", null);
-            settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
+            _settingsManager.CheckRequiredArgsToRun(appSettings, "Identifer");
 
             Logger.Logger.Log(null, Level.Notice, $"\n====================<<<<< Package Identifier >>>>>====================", null);
             Logger.Logger.Log(null, Level.Notice, $"\nStart of Package Identifier execution: {DateTime.Now}", null);
@@ -90,16 +118,13 @@ namespace LCT.PackageIdentifier
             if (appSettings.IsTestMode)
                 Logger.Logger.Log(null, Level.Notice, $"\tMode\t\t\t --> {appSettings.Mode}\n", null);
 
-            ICycloneDXBomParser cycloneDXBomParser = new CycloneDXBomParser();
-            IBomCreator bomCreator = new BomCreator(cycloneDXBomParser);
-            bomCreator.JFrogService = GetJfrogService(appSettings);
-            bomCreator.BomHelper = new BomHelper();
+            _bomCreator.JFrogService = GetJfrogService(appSettings);
+            _bomCreator.BomHelper = new BomHelper();
 
             //Validating JFrog Settings
-            if (await bomCreator.CheckJFrogConnection(appSettings))
+            if (await _bomCreator.CheckJFrogConnection(appSettings))
             {
-                await bomCreator.GenerateBom(appSettings, new BomHelper(), new FileOperations(), projectReleases,
-                                             caToolInformation);
+                await _bomCreator.GenerateBom(appSettings, new BomHelper(), new FileOperations(), projectReleases, caToolInformation);
             }
 
             if (appSettings?.Telemetry?.Enable == true)
@@ -110,7 +135,6 @@ namespace LCT.PackageIdentifier
             Logger.Logger.Log(null, Level.Notice, $"End of Package Identifier execution : {DateTime.Now}\n", null);
             // publish logs and bom file to pipeline artifact
             PipelineArtifactUploader.UploadArtifacts();
-
         }
 
         private static CatoolInfo GetCatoolVersionFromProjectfile()
@@ -126,9 +150,7 @@ namespace LCT.PackageIdentifier
         {
             if (appSettings == null)
             {
-                Logger.Error("Application settings are missing. Please ensure the following:\n" +
-                     "1. Provide a valid settings file (e.g., appsettings.json) in the expected location.\n" +
-                     "2. Alternatively, pass the required configuration settings as inline arguments during application execution.");
+                return null;
             }
             ArtifactoryCredentials artifactoryUpload = new ArtifactoryCredentials()
             {
@@ -158,6 +180,28 @@ namespace LCT.PackageIdentifier
             {
                 environmentHelper.CallEnvironmentExit(-1);
             }
-        }        
+        }
+
+        private static void LogFolderInitialisation(CommonAppSettings appSettings)
+        {
+            string FolderPath;
+            if (!string.IsNullOrEmpty(appSettings.Directory.LogFolder))
+            {
+                Log4Net.Init(FileConstant.BomCreatorLog, appSettings.Directory.LogFolder, m_Verbose);
+            }
+            else
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    FolderPath = FileConstant.LogFolder;
+                }
+                else
+                {
+                    FolderPath = "/var/log";
+                }
+
+                Log4Net.Init(FileConstant.BomCreatorLog, FolderPath, m_Verbose);
+            }
+        }
     }
 }

--- a/src/LCT.PackageIdentifier/SbomTemplate.cs
+++ b/src/LCT.PackageIdentifier/SbomTemplate.cs
@@ -8,12 +8,12 @@ using CycloneDX.Models;
 using LCT.Common;
 using LCT.Common.Constants;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Level = log4net.Core.Level;
 
 namespace LCT.PackageIdentifier
 {

--- a/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
@@ -161,7 +161,7 @@ namespace LCT.SW360PackageCreator.UTest
                 ReleaseID = "67890"
             };
             string formattedName = "TestComponent";
-            string fossologyUrl= "http://fossology" + ApiConstant.FossUploadJobUrlSuffix + "12345";
+            string fossologyUrl = "http://fossology" + ApiConstant.FossUploadJobUrlSuffix + "12345";
             _appSettings.SW360.Fossology.URL = "http://fossology/";
             _mockSw360CreatorService
                 .Setup(s => s.UpdateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()))

--- a/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/ComponentCreatorTest.cs
@@ -4,6 +4,8 @@
 //  SPDX-License-Identifier: MIT
 // -------------------------------------------------------------------------------------------------------------------- 
 
+// Ignore Spelling: Fossology Expections Dx Sbom Bom Doesnt LCT
+
 using CycloneDX.Models;
 using LCT.APICommunications;
 using LCT.APICommunications.Model;
@@ -132,7 +134,7 @@ namespace LCT.SW360PackageCreator.UTest
             var item = new ComparisonBomData
             {
                 FossologyLink = "https://fossology.example.com/upload/12345",
-                FossologyUploadId = Dataconstant.NotUploaded,
+                FossologyUploadId = "12345",
                 Name = "TestComponent",
                 Version = "1.0.0"
             };
@@ -142,8 +144,8 @@ namespace LCT.SW360PackageCreator.UTest
             await ComponentCreator.UpdateFossologyStatus(item, _mockSw360CreatorService.Object, _appSettings, formattedName);
 
             // Assert
-            Assert.AreEqual(Dataconstant.Uploaded, item.FossologyUploadStatus);
-            _mockSw360CreatorService.Verify(x => x.UdpateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()), Times.Never);
+            Assert.AreEqual(Dataconstant.AlreadyUploaded, item.FossologyUploadStatus);
+            _mockSw360CreatorService.Verify(x => x.UpdateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()), Times.Never);
         }
 
         [Test]
@@ -153,19 +155,25 @@ namespace LCT.SW360PackageCreator.UTest
             var item = new ComparisonBomData
             {
                 FossologyLink = null,
-                FossologyUploadId = Dataconstant.NotUploaded,
+                FossologyUploadId = "12345",
                 Name = "TestComponent",
                 Version = "1.0.0",
                 ReleaseID = "67890"
             };
             string formattedName = "TestComponent";
+            string fossologyUrl= "http://fossology" + ApiConstant.FossUploadJobUrlSuffix + "12345";
+            _appSettings.SW360.Fossology.URL = "http://fossology/";
+            _mockSw360CreatorService
+                .Setup(s => s.UpdateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
 
             // Act
-            await ComponentCreator.UpdateFossologyStatus(item, _mockSw360CreatorService.Object, _appSettings, formattedName);
+            var result = await ComponentCreator.UpdateFossologyStatus(item, _mockSw360CreatorService.Object, _appSettings, formattedName);
 
             // Assert
+            Assert.IsTrue(result);
+            Assert.AreEqual(fossologyUrl, item.FossologyLink);
             Assert.AreEqual(Dataconstant.Uploaded, item.FossologyUploadStatus);
-
         }
 
         [Test]
@@ -187,7 +195,7 @@ namespace LCT.SW360PackageCreator.UTest
             // Assert
             Assert.IsNull(item.FossologyUploadStatus);
             Assert.IsNull(item.FossologyLink);
-            _mockSw360CreatorService.Verify(x => x.UdpateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()), Times.Never);
+            _mockSw360CreatorService.Verify(x => x.UpdateSW360ReleaseContent(It.IsAny<Components>(), It.IsAny<string>()), Times.Never);
         }
         [Test]
         public void GetFormattedName_ParentReleaseNameIsDifferent_ShouldReturnFormattedName()
@@ -671,7 +679,7 @@ namespace LCT.SW360PackageCreator.UTest
         }
 
         [Test]
-        public void AddReleaseIdToLink_WhenReleaseIdIsNotNull_AddsReleaseToReleasesFoundInCbom()
+        public void AddReleaseIdToLink_WhenReleaseIdIsNotNull_AddsReleaseToReleasesFoundInSbom()
         {
             // Arrange
             var item = new ComparisonBomData

--- a/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
@@ -281,7 +281,7 @@ namespace LCT.SW360PackageCreator.UTest
 
 
         [Test]
-        public async Task TriggerFossologyValidation_WhenNoValidReleaseFound_LogsFailureMessage()
+        public Task TriggerFossologyValidation_WhenNoValidReleaseFound_LogsFailureMessage()
         {
             // Arrange
             var appSettings = new CommonAppSettings
@@ -297,6 +297,7 @@ namespace LCT.SW360PackageCreator.UTest
 
             // Assert
             Assert.IsFalse(validReleaseFound);
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
@@ -128,7 +128,7 @@ namespace LCT.SW360PackageCreator.UTest
                     URL = "https://sw360.example.com"
                 }
             };
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             var responseBody = @"{""_embedded"": {""sw360:releases"": [{""id"": ""a3c5c9d1dd469d668433fb147c01bad2"",""name"": ""HC-Test Pugixml"",""version"": ""V1.2"",""clearingState"": ""APPROVED"",""_embedded"": {""sw360:attachments"": [[{""filename"": ""Protocol_Pugixml - 1.2.doc"",""attachmentType"": ""SOURCE""}]]},""_links"": {""self"": {""href"": ""https://sw360.siemens.com/resource/api/releases/a3c5c9d1dd469d668433fb147c01bad2""}}}]},""page"": {""totalPages"": 1}}";
             var releasesInfo = new ReleasesInfo
             {
@@ -159,8 +159,7 @@ namespace LCT.SW360PackageCreator.UTest
             mockISw360CreatorService.Setup(x => x.TriggerFossologyProcessForValidation(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(fossTriggerStatus);
 
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
-
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object,mockEnvironmentHelper.Object);
             // Assert
             mockISW360ApicommunicationFacade.Verify(x => x.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
             mockISW360ApicommunicationFacade.Verify(x => x.TriggerFossologyProcess(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
@@ -304,6 +303,7 @@ namespace LCT.SW360PackageCreator.UTest
         public async Task TriggerFossologyValidation_ShouldLogDebugMessage_WhenAggregateExceptionIsThrown()
         {
             mockISW360ApicommunicationFacade = new Mock<ISW360ApicommunicationFacade>();
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             CommonAppSettings appSettings = new CommonAppSettings
             {
                 SW360 = new SW360
@@ -321,7 +321,7 @@ namespace LCT.SW360PackageCreator.UTest
                 .ThrowsAsync(new AggregateException("Test exception"));
 
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
 
             // Assert            
             Assert.Pass("AggregateException was handled successfully.");
@@ -356,14 +356,13 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(mockResponse);
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
 
             // Assert
             Assert.Pass("No valid release was found, and the debug message was logged.");
         }
-
         [Test]
         public async Task TriggerFossologyValidation_ShouldLogDebugMessage_WhenReleaseResponseIsNull()
         {
@@ -383,8 +382,9 @@ namespace LCT.SW360PackageCreator.UTest
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync((HttpResponseMessage)null); // Simulate null response
 
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
 
             // Assert            
             Assert.Pass("FindValidRelease(): Fossology token validation failed in SW360 due to release not found.");
@@ -422,9 +422,9 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(mockResponse);
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
 
             // Assert           
             Assert.Pass("MoveToNextPage(): Successfully moved to the next page.");
@@ -448,9 +448,9 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ThrowsAsync(new HttpRequestException("Test HttpRequestException"));
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
 
             // Assert
             Assert.Pass("HttpRequestException was handled and logged.");
@@ -473,10 +473,9 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ThrowsAsync(new InvalidOperationException("Test InvalidOperationException"));
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
-
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
             // Assert
             Assert.Pass("InvalidOperationException was handled and logged.");
         }
@@ -498,10 +497,9 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ThrowsAsync(new UriFormatException("Test UriFormatException"));
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
-
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
             // Assert
             Assert.Pass("UriFormatException was handled and logged.");
         }
@@ -523,10 +521,9 @@ namespace LCT.SW360PackageCreator.UTest
             mockISW360ApicommunicationFacade
                 .Setup(facade => facade.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()))
                 .ThrowsAsync(new TaskCanceledException("Test TaskCanceledException"));
-
+            var mockEnvironmentHelper = new Mock<IEnvironmentHelper>();
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object);
-
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
             // Assert
             Assert.Pass("TaskCanceledException was handled and logged.");
         }

--- a/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
+++ b/src/LCT.SW360PackageCreator.UTest/CreatorValidatorTest.cs
@@ -159,7 +159,7 @@ namespace LCT.SW360PackageCreator.UTest
             mockISw360CreatorService.Setup(x => x.TriggerFossologyProcessForValidation(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(fossTriggerStatus);
 
             // Act
-            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object,mockEnvironmentHelper.Object);
+            await CreatorValidator.TriggerFossologyValidation(appSettings, mockISW360ApicommunicationFacade.Object, mockEnvironmentHelper.Object);
             // Assert
             mockISW360ApicommunicationFacade.Verify(x => x.GetAllReleasesWithAllData(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
             mockISW360ApicommunicationFacade.Verify(x => x.TriggerFossologyProcess(It.IsAny<string>(), It.IsAny<string>()), Times.Once);

--- a/src/LCT.SW360PackageCreator.UTest/LCT.SW360PackageCreator.UTest.csproj
+++ b/src/LCT.SW360PackageCreator.UTest/LCT.SW360PackageCreator.UTest.csproj
@@ -23,6 +23,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -32,16 +34,16 @@
 
 	<ItemGroup>
 		<None Update="ComponentCreatorUTFiles\adduser_3.118-debian10-combined.tar.bz2">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="ComponentCreatorUTFiles\Attachment.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="ComponentCreatorUTFiles\patched-file_022.tar.gz">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="ComponentCreatorUTFiles\TestComponent-1.0-sources.jar">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
 

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -17,7 +17,6 @@ using LCT.Services.Model;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,6 +24,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 namespace LCT.SW360PackageCreator
 {

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -379,7 +379,7 @@ namespace LCT.SW360PackageCreator
         {
 
             if (appSettings.SW360.Fossology.EnableTrigger && (item.ApprovedStatus.Equals(Dataconstant.NewClearing) || item.ApprovedStatus.Equals("Not Available") || item.ApprovedStatus.Equals(Dataconstant.SentToClearingState) || item.ApprovedStatus.Equals(Dataconstant.ScanAvailableState)))
-            {                
+            {
                 var formattedName = GetFormattedName(item);
 
                 bool fossologyUpload = await UpdateFossologyStatus(item, sw360CreatorService, appSettings, formattedName);
@@ -533,7 +533,7 @@ namespace LCT.SW360PackageCreator
 
             return componentId;
         }
-        private static async Task<bool> UpdateFossologyLinkAndStatus(ComparisonBomData item,ISw360CreatorService sw360CreatorService,CommonAppSettings appSettings,string formattedName,string uploadId,string logPrefix)
+        private static async Task<bool> UpdateFossologyLinkAndStatus(ComparisonBomData item, ISw360CreatorService sw360CreatorService, CommonAppSettings appSettings, string formattedName, string uploadId, string logPrefix)
         {
             item.FossologyLink = $"{appSettings.SW360.Fossology.URL}{ApiConstant.FossUploadJobUrlSuffix}{uploadId}";
             bool uploadStatus = await sw360CreatorService.UpdateSW360ReleaseContent(new Components
@@ -597,7 +597,7 @@ namespace LCT.SW360PackageCreator
 
             item.ApprovedStatus = releasesInfo.ClearingState;
             item.ReleaseCreatedBy = releasesInfo.CreatedBy;
-            item.SourceAttachmentStatus= IsReleaseAttachmentExist(releasesInfo);
+            item.SourceAttachmentStatus = IsReleaseAttachmentExist(releasesInfo);
             var uploadId = releasesInfo.ExternalToolProcesses?
                 .SelectMany(process => process.ProcessSteps)
                 .FirstOrDefault(step => step.StepName == "01_upload")?.ProcessStepIdInTool;

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -16,7 +16,6 @@ using LCT.Services.Interface;
 using LCT.SW360PackageCreator.Interfaces;
 using LCT.SW360PackageCreator.Model;
 using log4net;
-using log4net.Core;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -28,6 +27,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Directory = System.IO.Directory;
+using Level = log4net.Core.Level;
 
 namespace LCT.SW360PackageCreator
 {

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -53,7 +53,7 @@ namespace LCT.SW360PackageCreator
 
             foreach (ComparisonBomData comparionBomData in comparisionBomDataList)
             {
-                if (comparionBomData.DownloadUrl == Dataconstant.DownloadUrlNotFound || string.IsNullOrEmpty(comparionBomData.DownloadUrl))
+                if ((comparionBomData.DownloadUrl == Dataconstant.DownloadUrlNotFound || string.IsNullOrEmpty(comparionBomData.DownloadUrl)) && !comparionBomData.SourceAttachmentStatus)
                 {
                     comparionBomData.ReleaseID = string.IsNullOrEmpty(comparionBomData.ReleaseLink) ?
                         comparionBomData.ReleaseID : CommonHelper.GetSubstringOfLastOccurance(comparionBomData.ReleaseLink, "/");
@@ -219,6 +219,7 @@ namespace LCT.SW360PackageCreator
         {
             List<ComparisonBomData> comparisonBomData = new();
             ComparisonBomData mapper;
+
             foreach (Components item in lstComponentForBOM)
             {
                 mapper = new ComparisonBomData();
@@ -235,43 +236,59 @@ namespace LCT.SW360PackageCreator
                 mapper.ComponentStatus = GetComponentAvailabilityStatus(componentsAvailableInSw360, item);
                 mapper.ReleaseStatus = IsReleaseAvailable(item.Name, item.Version, item.ReleaseExternalId);
                 mapper.AlpineSource = item.AlpineSourceData;
+
                 if (!string.IsNullOrEmpty(item.ReleaseExternalId) && item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["DEBIAN"]))
                 {
-                    if ((string.IsNullOrEmpty(item.SourceUrl) || item.SourceUrl == Dataconstant.SourceUrlNotFound) && !string.IsNullOrEmpty(releasesInfo.SourceCodeDownloadUrl))
-                    {
-                        // If not able to get source details from snapshot.org, try getting source URL from SW360
-                        mapper.SourceUrl = releasesInfo.SourceCodeDownloadUrl;
-                        mapper.DownloadUrl = releasesInfo.SourceCodeDownloadUrl;
-                    }
-                    mapper.PatchURls = item.PatchURLs;
+                    SetDebianUrls(item, releasesInfo, mapper);
                 }
                 else if (!string.IsNullOrEmpty(item.ReleaseExternalId) && item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["MAVEN"]))
                 {
                     mapper.DownloadUrl = GetMavenDownloadUrl(mapper, item, releasesInfo);
                 }
-                else if (!string.IsNullOrEmpty(item.ReleaseExternalId) &&
-                            (item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["POETRY"]) || item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["CONAN"]) || item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["ALPINE"])))
+                else if (!string.IsNullOrEmpty(item.ReleaseExternalId) && IsOtherPackageType(item))
                 {
                     mapper.DownloadUrl = mapper.SourceUrl;
                 }
                 else
                 {
                     mapper.DownloadUrl = GetComponentDownloadUrl(mapper, item, repo, releasesInfo);
-                }
-                mapper.ApprovedStatus = GetApprovedStatus(mapper.ComponentStatus, mapper.ReleaseStatus, releasesInfo);
-                mapper.IsComponentCreated = GetCreatedStatus(mapper.ComponentStatus);
-                mapper.IsReleaseCreated = GetCreatedStatus(mapper.ReleaseStatus);
-                mapper.FossologyUploadStatus = GetFossologyUploadStatus(mapper.ApprovedStatus);
-                mapper.ReleaseAttachmentLink = string.Empty;
-                mapper.ReleaseLink = GetReleaseLink(componentsAvailableInSw360, item.Name, item.Version);
-
-                Logger.Debug($"Sw360 avilability status for Name " + mapper.Name + ":" + mapper.ComponentExternalId + "=" + mapper.ComponentStatus +
-                    "-Version " + mapper.Version + ":" + mapper.ReleaseExternalId + "=" + mapper.ReleaseStatus);
+                } 
+                SetMapperStatus(mapper, releasesInfo);
+                Logger.Debug($"Sw360 availability status for Name {mapper.Name}: {mapper.ComponentExternalId}={mapper.ComponentStatus} - Version {mapper.Version}: {mapper.ReleaseExternalId}={mapper.ReleaseStatus}");
                 comparisonBomData.Add(mapper);
             }
             return comparisonBomData;
         }
 
+        private static void SetDebianUrls(Components item, ReleasesInfo releasesInfo, ComparisonBomData mapper)
+        {
+            if ((string.IsNullOrEmpty(item.SourceUrl) || item.SourceUrl == Dataconstant.SourceUrlNotFound) && !string.IsNullOrEmpty(releasesInfo.SourceCodeDownloadUrl))
+            {
+                // If not able to get source details from snapshot.org, try getting source URL from SW360
+                mapper.SourceUrl = releasesInfo.SourceCodeDownloadUrl;
+                mapper.DownloadUrl = releasesInfo.SourceCodeDownloadUrl;
+            }
+            mapper.PatchURls = item.PatchURLs;
+        }
+
+        private static bool IsOtherPackageType(Components item)
+        {
+            return item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["POETRY"]) ||
+                   item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["CONAN"]) ||
+                   item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["ALPINE"]);
+        }
+
+        private void SetMapperStatus(ComparisonBomData mapper, ReleasesInfo releasesInfo)
+        {
+            mapper.ApprovedStatus = GetApprovedStatus(mapper.ComponentStatus, mapper.ReleaseStatus, releasesInfo);
+            mapper.IsComponentCreated = GetCreatedStatus(mapper.ComponentStatus);
+            mapper.IsReleaseCreated = GetCreatedStatus(mapper.ReleaseStatus);
+            mapper.FossologyUploadStatus = GetFossologyUploadStatus(mapper.ApprovedStatus);
+            mapper.ReleaseAttachmentLink = string.Empty;
+            mapper.ReleaseLink = GetReleaseLink(componentsAvailableInSw360, mapper.Name, mapper.Version);
+            mapper.FossologyLink = releasesInfo?.AdditionalData?.TryGetValue("fossology url", out string fossologyUrl) == true ? fossologyUrl : string.Empty;
+            mapper.ReleaseCreatedBy = releasesInfo?.CreatedBy ?? string.Empty;
+        }
         public static string GetMavenDownloadUrl(ComparisonBomData mapper, Components item, ReleasesInfo releasesInfo)
         {
             string sourceURL = string.Empty;

--- a/src/LCT.SW360PackageCreator/CreatorValidator.cs
+++ b/src/LCT.SW360PackageCreator/CreatorValidator.cs
@@ -38,7 +38,7 @@ namespace LCT.SW360PackageCreator
 
             return CommonHelper.ValidateSw360Project(sw360ProjectName, projectReleases?.clearingState, projectReleases?.Name, appSettings);
         }
-        public static async Task TriggerFossologyValidation(CommonAppSettings appSettings, ISW360ApicommunicationFacade sW360ApicommunicationFacade)
+        public static async Task TriggerFossologyValidation(CommonAppSettings appSettings, ISW360ApicommunicationFacade sW360ApicommunicationFacade,IEnvironmentHelper environmentHelper)
         {
             ISW360CommonService sw360CommonService = new SW360CommonService(sW360ApicommunicationFacade);
             ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sW360ApicommunicationFacade, sw360CommonService);
@@ -55,6 +55,8 @@ namespace LCT.SW360PackageCreator
                 else
                 {
                     Logger.Debug($"TriggerFossologyValidation(): Fossology URL validation failed");
+                    Logger.Error("Fossology URL validation failed due to release not found from SW360");
+                    environmentHelper.CallEnvironmentExit(-1);
                 }
             }
             catch (AggregateException ex)

--- a/src/LCT.SW360PackageCreator/CreatorValidator.cs
+++ b/src/LCT.SW360PackageCreator/CreatorValidator.cs
@@ -38,7 +38,7 @@ namespace LCT.SW360PackageCreator
 
             return CommonHelper.ValidateSw360Project(sw360ProjectName, projectReleases?.clearingState, projectReleases?.Name, appSettings);
         }
-        public static async Task TriggerFossologyValidation(CommonAppSettings appSettings, ISW360ApicommunicationFacade sW360ApicommunicationFacade,IEnvironmentHelper environmentHelper)
+        public static async Task TriggerFossologyValidation(CommonAppSettings appSettings, ISW360ApicommunicationFacade sW360ApicommunicationFacade, IEnvironmentHelper environmentHelper)
         {
             ISW360CommonService sw360CommonService = new SW360CommonService(sW360ApicommunicationFacade);
             ISw360CreatorService sw360CreatorService = new Sw360CreatorService(sW360ApicommunicationFacade, sw360CommonService);

--- a/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
+++ b/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>SW360PackageCreator</AssemblyName>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 		<RootNamespace>LCT.SW360PackageCreator</RootNamespace>
 	</PropertyGroup>
 

--- a/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
+++ b/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
@@ -1,38 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <AssemblyName>SW360PackageCreator</AssemblyName>
-    <Version>8.0.0</Version>
-    <RootNamespace>LCT.SW360PackageCreator</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<AssemblyName>SW360PackageCreator</AssemblyName>
+		<Version>8.0.0</Version>
+		<RootNamespace>LCT.SW360PackageCreator</RootNamespace>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+		<NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+		<NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.15" />
+		<PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="SharpZipLib" Version="1.4.2" />
+		<PackageReference Include="YamlDotNet" Version="13.7.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
-    <ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
-    <ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
-    <ProjectReference Include="..\LCT.Telemetry\LCT.Telemetry.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
+		<ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
+		<ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
+		<ProjectReference Include="..\LCT.Telemetry\LCT.Telemetry.csproj" />
+	</ItemGroup>
 
-  <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties />
+		</VisualStudio>
+	</ProjectExtensions>
 
 </Project>

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -98,7 +98,7 @@ namespace LCT.SW360PackageCreator
             {
                 HttpClient client = new HttpClient();
                 if (await CreatorValidator.FossologyUrlValidation(appSettings, client, environmentHelper))
-                    await CreatorValidator.TriggerFossologyValidation(appSettings, sW360ApicommunicationFacade,environmentHelper);
+                    await CreatorValidator.TriggerFossologyValidation(appSettings, sW360ApicommunicationFacade, environmentHelper);
             }
             await InitiatePackageCreatorProcess(appSettings, sw360ProjectService, sW360ApicommunicationFacade);
             // Initialize telemetry with CATool version and instrumentation key only if Telemetry is enabled in appsettings

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -98,7 +98,7 @@ namespace LCT.SW360PackageCreator
             {
                 HttpClient client = new HttpClient();
                 if (await CreatorValidator.FossologyUrlValidation(appSettings, client, environmentHelper))
-                    await CreatorValidator.TriggerFossologyValidation(appSettings, sW360ApicommunicationFacade);
+                    await CreatorValidator.TriggerFossologyValidation(appSettings, sW360ApicommunicationFacade,environmentHelper);
             }
             await InitiatePackageCreatorProcess(appSettings, sw360ProjectService, sW360ApicommunicationFacade);
             // Initialize telemetry with CATool version and instrumentation key only if Telemetry is enabled in appsettings

--- a/src/LCT.Services.UTest/LCT.Services.UTest.csproj
+++ b/src/LCT.Services.UTest/LCT.Services.UTest.csproj
@@ -1,38 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+		<PackageReference Include="Moq" Version="4.13.1" />
+		<PackageReference Include="NUnit" Version="3.12.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
-    <ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
-    <ProjectReference Include="..\UnitTestUtilities\UnitTestUtilities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
+		<ProjectReference Include="..\LCT.Services\LCT.Services.csproj" />
+		<ProjectReference Include="..\UnitTestUtilities\UnitTestUtilities.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="ServiceUTestFiles\Test.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="ServiceUTestFiles\Test.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/LCT.Services.UTest/Sw360CreatorServiceTest.cs
+++ b/src/LCT.Services.UTest/Sw360CreatorServiceTest.cs
@@ -833,7 +833,7 @@ namespace LCT.Services.UTest
         }
 
         [Test]
-        public async Task UdpateSW360ReleaseContent_ForGivenComponentInfo_ThorwsHttpRequestExceptionOnError()
+        public async Task UpdateSW360ReleaseContent_ForGivenComponentInfo_ThorwsHttpRequestExceptionOnError()
         {
             // Arrange
             UpdateReleaseAdditinoalData updateRelease = new UpdateReleaseAdditinoalData();
@@ -848,14 +848,14 @@ namespace LCT.Services.UTest
 
             // Act
             var sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
-            var actual = await sw360CreatorService.UdpateSW360ReleaseContent(component, "foss url");
+            var actual = await sw360CreatorService.UpdateSW360ReleaseContent(component, "foss url");
 
             // Assert
             Assert.That(actual, Is.False);
         }
 
         [Test]
-        public async Task UdpateSW360ReleaseContent_ForGivenComponentInfo_ThorwsAggregateExceptionOnError()
+        public async Task UpdateSW360ReleaseContent_ForGivenComponentInfo_ThrowsAggregateExceptionOnError()
         {
             // Arrange
             UpdateReleaseAdditinoalData updateRelease = new UpdateReleaseAdditinoalData();
@@ -870,7 +870,7 @@ namespace LCT.Services.UTest
 
             // Act
             var sw360CreatorService = new Sw360CreatorService(sw360ApiCommMock.Object);
-            var actual = await sw360CreatorService.UdpateSW360ReleaseContent(component, "foss url");
+            var actual = await sw360CreatorService.UpdateSW360ReleaseContent(component, "foss url");
 
             // Assert
             Assert.That(actual, Is.False);

--- a/src/LCT.Services/Interface/ISW360CreatorService.cs
+++ b/src/LCT.Services/Interface/ISW360CreatorService.cs
@@ -43,7 +43,7 @@ namespace LCT.Services.Interface
 
         Task<bool> UpdatePurlIdForExistingRelease(ComparisonBomData cbomData, string releaseId, ReleasesInfo releasesInfo = null);
 
-        Task<bool> UdpateSW360ReleaseContent(Components component, string fossUrl);
+        Task<bool> UpdateSW360ReleaseContent(Components component, string fossUrl);
         Task<FossTriggerStatus> TriggerFossologyProcessForValidation(string releaseId, string sw360link);
     }
 }

--- a/src/LCT.Services/LCT.Services.csproj
+++ b/src/LCT.Services/LCT.Services.csproj
@@ -1,30 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <Version>8.0.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<Version>8.0.0</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\..\out</OutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.15" />
+		<PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />
-    <ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
-    <ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />
+		<ProjectReference Include="..\LCT.Common\LCT.Common.csproj" />
+		<ProjectReference Include="..\LCT.Facade\LCT.Facade.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/LCT.Services/LCT.Services.csproj
+++ b/src/LCT.Services/LCT.Services.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2025 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
@@ -24,6 +24,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Level = log4net.Core.Level;
 
 namespace LCT.Services
 {
@@ -688,13 +689,13 @@ namespace LCT.Services
         }
 
 
-        public async Task<bool> UdpateSW360ReleaseContent(Components component, string fossUrl)
+        public async Task<bool> UpdateSW360ReleaseContent(Components component, string fossUrl)
         {
             bool isUpdated = false;
             try
             {
                 string releaseId = component.ReleaseId;
-                Logger.Debug($"UdpateSW360ReleaseContent():Name-{component.Name},Version-{component.Version}");
+                Logger.Debug($"UpdateSW360ReleaseContent():Name-{component.Name},Version-{component.Version}");
 
                 UpdateReleaseAdditinoalData updateRelease = await GetUpdateReleaseContent(releaseId, fossUrl, component.UploadId);
 
@@ -702,17 +703,26 @@ namespace LCT.Services
                     JsonConvert.SerializeObject(updateRelease),
                     Encoding.UTF8,
                     ApiConstant.ApplicationJson);
-                await m_SW360ApiCommunicationFacade.UpdateRelease(releaseId, content);
-
-                isUpdated = true;
+                HttpResponseMessage response=await m_SW360ApiCommunicationFacade.UpdateRelease(releaseId, content);
+                string responseContent = await response.Content.ReadAsStringAsync();
+                Logger.Debug($"UpdateSW360ReleaseContent():Response of fossology Url updation in SW360:{responseContent}");
+                if (responseContent.Contains(Dataconstant.FossologyModerationMessage, StringComparison.OrdinalIgnoreCase))
+                {
+                    Logger.Logger.Log(null, Level.Warn, $"\t⏳ Moderation request is created while updating the Fossology URL in SW360. Please request {component.ReleaseCreatedBy} or the license clearing team to approve the moderation request.", null);
+                }
+                else
+                {
+                    isUpdated = true;
+                }              
+                
             }
             catch (HttpRequestException ex)
             {
-                Logger.Error($"UdpateSW360ReleaseContent():", ex);
+                Logger.Error($"UpdateSW360ReleaseContent():", ex);
             }
             catch (AggregateException ex)
             {
-                Logger.Error($"UdpateSW360ReleaseContent():", ex);
+                Logger.Error($"UpdateSW360ReleaseContent():", ex);
             }
 
             return isUpdated;

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -703,7 +703,7 @@ namespace LCT.Services
                     JsonConvert.SerializeObject(updateRelease),
                     Encoding.UTF8,
                     ApiConstant.ApplicationJson);
-                HttpResponseMessage response=await m_SW360ApiCommunicationFacade.UpdateRelease(releaseId, content);
+                HttpResponseMessage response = await m_SW360ApiCommunicationFacade.UpdateRelease(releaseId, content);
                 string responseContent = await response.Content.ReadAsStringAsync();
                 Logger.Debug($"UpdateSW360ReleaseContent():Response of fossology Url updation in SW360:{responseContent}");
                 if (responseContent.Contains(Dataconstant.FossologyModerationMessage, StringComparison.OrdinalIgnoreCase))
@@ -713,8 +713,8 @@ namespace LCT.Services
                 else
                 {
                     isUpdated = true;
-                }              
-                
+                }
+
             }
             catch (HttpRequestException ex)
             {

--- a/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
+++ b/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
@@ -29,12 +29,12 @@ namespace LCT.Telemetry
             _telemetryClient = new TelemetryClient(aiConfig);
         }
 
-        public void TrackEvent(string eventName, Dictionary<string, string> properties = null)
+        public void TrackEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryClient.TrackEvent(eventName, properties);
         }
 
-        public void TrackException(Exception ex, Dictionary<string, string> properties = null)
+        public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             var exceptionTelemetry = new ExceptionTelemetry(ex);
 

--- a/src/LCT.Telemetry/ITelemetryProvider.cs
+++ b/src/LCT.Telemetry/ITelemetryProvider.cs
@@ -7,8 +7,8 @@ namespace LCT.Telemetry
 {
     public interface ITelemetryProvider
     {
-        void TrackEvent(string eventName, Dictionary<string, string> properties = null);
-        void TrackException(Exception ex, Dictionary<string, string> properties = null);
+        void TrackEvent(string eventName, Dictionary<string, string>? properties = null);
+        void TrackException(Exception ex, Dictionary<string, string>? properties = null);
         void Flush();
     }
 }

--- a/src/LCT.Telemetry/LCT.Telemetry.csproj
+++ b/src/LCT.Telemetry/LCT.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/LCT.Telemetry/Telemetry.cs
+++ b/src/LCT.Telemetry/Telemetry.cs
@@ -48,12 +48,12 @@ namespace LCT.Telemetry
             TrackUserDetails();
         }
 
-        public void TrackCustomEvent(string eventName, Dictionary<string, string> properties = null)
+        public void TrackCustomEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackEvent(eventName, properties);
         }
 
-        public void TrackException(Exception ex, Dictionary<string, string> properties = null)
+        public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackException(ex, properties);
         }

--- a/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
+++ b/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
@@ -144,7 +144,6 @@ namespace SW360IntegrationTest.Alpine
                 new AuthenticationHeaderValue(testParameters.SW360AuthTokenType, testParameters.SW360AuthTokenValue);
             string expectedname = "apk-tools";
             string expectedversion = "2.12.9-r3";
-            string expecteddownloadurl = "https://gitlab.alpinelinux.org/alpine/apk-tools/-/archive/v2.12.9/apk-tools-v2.12.9.tar.gz";
             string expectedexternalid = "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=source";
             //url formation for retrieving component details
             string url = TestConstant.Sw360ReleaseApi + TestConstant.componentNameUrl + "apk-tools";

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Alpine/CCTComparisonBOMAlpineInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
@@ -206,6 +206,61 @@
           "value": ""
         }
       ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Text.Encoding@4.3.0",
+      "name": "System.Text.Encoding",
+      "version": "4.3.0",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0ece90b64e8079b79c163fccd067647c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b1b83606b6c1da0f167d881937472e3a91397518"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "19cb475462d901afebaa404d86c0469ec89674acafe950ee6d8a4692e3a404b8"
+        }
+      ],
+      "purl": "pkg:nuget/System.Text.Encoding@4.3.0",
+      "properties": [
+        {
+          "name": "internal:siemens:clearing:development",
+          "value": "true"
+        },
+        {
+          "name": "internal:siemens:clearing:identifier-type",
+          "value": "Discovered"
+        },
+        {
+          "name": "internal:siemens:clearing:siemens:direct",
+          "value": "true"
+        },
+        {
+          "name": "internal:siemens:clearing:is-internal",
+          "value": "false"
+        },
+        {
+          "name": "internal:siemens:clearing:jfrog-repo-name",
+          "value": "Not Found in JFrogRepo"
+        },
+        {
+          "name": "internal:siemens:clearing:project-type",
+          "value": "NUGET"
+        },
+        {
+          "name": "internal:siemens:clearing:siemens:filename",
+          "value": "Package name not found in Jfrog"
+        },
+        {
+          "name": "internal:siemens:clearing:jfrog-repo-path",
+          "value": ""
+        }
+      ]
     }
   ],
   "dependencies": [
@@ -216,6 +271,17 @@
     {
       "ref": "pkg:nuget/SonarAnalyzer.CSharp@9.5.0.73987",
       "dependsOn": []
+    }
+  ],
+  "compositions": [
+    {
+      "aggregate": "complete",
+      "assemblies": [
+        "pkg:nuget/dotnet-runtime@8.0.0"
+      ],
+      "dependencies": [
+        "pkg:nuget/System.Text.Encoding@4.3.0"
+      ]
     }
   ],
   "definitions": {

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/CCTComparisonBOMNugetTemplateInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:6cdf02ad-b1f2-4f4b-b46f-176ad93005ee",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T13:56:05Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -223,5 +217,22 @@
       "ref": "pkg:nuget/SonarAnalyzer.CSharp@9.5.0.73987",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Conan/CCTComparisonBOMConanInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3e407ffb-8ef0-4b06-bcdb-bdbe12dcd2a7",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:57:03Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -125,5 +119,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Debian/CCTComparisonBOMDebianInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7943c30-a8e6-4e9d-a36f-21721184b5b9",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T14:57:50Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -206,5 +200,23 @@
         }
       ]
     }
-  ]
+  ],
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Maven/CCTComparisonBOMMavenUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7b3d78c-3b44-41c4-a7d2-1f4be11916bc",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:54:44Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -409,5 +403,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:fe6bfc03-6e58-4ee4-bbe3-b1dc8fd73ad5",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T14:06:17Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -406,5 +400,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Npm/CCTComparisonBOMNpmUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:c5d86610-3513-41c3-abe6-6eeca868ac4f",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:57:36Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -263,5 +257,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Nuget/CCTComparisonBOMNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:383df7b9-7355-4912-98ce-dc0c93573a11",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:12Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -361,5 +355,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageCreatorTestFiles/Python/CCTComparisonBOMPythonInitial.json
+++ b/src/SW360IntegrationTest/PackageCreatorTestFiles/Python/CCTComparisonBOMPythonInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:90e057bd-e809-412e-9412-267683355dcb",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T12:58:48Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "null",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Alpine/CCTLocalBOMAlpineInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:ce2e46d2-f383-47c1-81b2-05bc25d23f31",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T02:23:36Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -207,5 +201,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/CCTLocalBOMTemplateNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:24c9b04e-faa5-4616-b353-b6657a3e98f8",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T16:32:35Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -199,5 +193,22 @@
       "ref": "pkg:nuget/SonarAnalyzer.CSharp@9.5.0.73987",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Conan/CCTLocalBOMConanInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:3ff8bbf4-df51-4152-8fb8-e5f9ab766bfa",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T03:17:06Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -84,5 +78,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Debian/CCTLocalBOMDebianInitial.json
@@ -1,60 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:b7943c30-a8e6-4e9d-a36f-21721184b5b9",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-06T14:57:50Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -228,5 +200,23 @@
         }
       ]
     }
-  ]
+  ],
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Maven/CCTLocalBOMMavenInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:2862b6c8-02a5-4005-87b6-c9cd30360293",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-07T00:00:20Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -373,5 +367,22 @@
       "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "dependsOn": []
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:c4c04a17-1eae-4088-b241-fb02a48524bd",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T17:43:26Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -442,5 +436,22 @@
         "pkg:npm/webpack-sources@1.4.3"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmMultiplePackages.json
@@ -1,60 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:25d1e9dc-0981-4766-9f62-c41afe0c13e0",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T18:00:02Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -675,5 +647,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Npm/CCTLocalBOMNpmUpdated.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:d2d0a930-3595-4c0d-b554-3883fb23da07",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-27T18:04:37Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -255,5 +249,22 @@
         "pkg:npm/tslib@^1.9.0"
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
+++ b/src/SW360IntegrationTest/PackageIdentifierTestFiles/Nuget/CCTLocalBOMNugetInitial.json
@@ -1,38 +1,32 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "serialNumber": "urn:uuid:0e862bd9-65f2-4bde-8033-bb441e0e02e2",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:167dc9b4-dd8d-4f55-926a-c0f96cabf035",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-07-08T16:49:00Z",
-    "tools": [
-      {
-        "vendor": "Siemens AG",
-        "name": "Clearing Automation Tool",
-        "version": "6.1.0",
-        "externalReferences": [
-          {
-            "url": "https://github.com/siemens/continuous-clearing",
-            "type": "website"
-          }
-        ]
-      },
-      {
-        "vendor": "Siemens AG",
-        "name": "Siemens SBOM",
-        "version": "2.0.0",
-        "externalReferences": [
-          {
-            "url": "https://sbom.siemens.io/",
-            "type": "website"
-          }
-        ]
-      }
-    ],
+    "timestamp": "2025-05-26T04:19:21Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "name": "Clearing Automation Tool",
+          "version": "8.0.0",
+          "externalReferences": [
+            {
+              "url": "https://github.com/siemens/continuous-clearing",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
-      "name": "Test",
-      "version": "1.0"
+      "name": "continuous-clearing",
+      "version": "v9.0.x"
     },
     "properties": [
       {
@@ -289,5 +283,22 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "name": "Standard BOM",
+        "version": "3.0.0",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "owner": "Siemens AG",
+        "externalReferences": [
+          {
+            "url": "https://sbom.siemens.io/",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/SW360IntegrationTest/SW360IntegrationTest.csproj
+++ b/src/SW360IntegrationTest/SW360IntegrationTest.csproj
@@ -20,6 +20,8 @@
 		<PackageReference Include="nunit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -31,7 +33,7 @@
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="PackageIdentifierTestFiles\CCTLocalBOMTemplateNugetInitial.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="PackageIdentifierTestFiles\Maven\CCTLocalBOMMavenInitial.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Telemetry.UTest/Telemetry.UTest.cs
+++ b/src/Telemetry.UTest/Telemetry.UTest.cs
@@ -94,13 +94,13 @@ namespace LCT.Telemetry.UTest
         public void GetHashString_InputIsNull_ReturnsEmptyString()
         {
             // Arrange
-            string input = null;
+            string? input = null;
 
             // Act
-            string result = HashUtility.GetHashString(input);
+            string result = HashUtility.GetHashString(input ?? string.Empty);
 
             // Assert
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace LCT.Telemetry.UTest
             string result = HashUtility.GetHashString(input);
 
             // Assert
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace LCT.Telemetry.UTest
             string result = HashUtility.GetHashString(input);
 
             // Assert
-            Assert.AreEqual(expectedHash, result);
+            Assert.That(result, Is.EqualTo(expectedHash));
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace LCT.Telemetry.UTest
             string result2 = HashUtility.GetHashString(input2);
 
             // Assert
-            Assert.AreNotEqual(result1, result2);
+            Assert.That(result1, Is.Not.EqualTo(result2));
         }
 
     }

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -14,11 +14,13 @@
     <OutputPath>..\..\out</OutputPath>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LCT.APICommunications\LCT.APICommunications.csproj" />


### PR DESCRIPTION
**Framework Detection logic:**

1. Implemented reflection-based access to Microsoft component detection tool's internal APIs
2. Added framework package detection via internal GetFrameworkPackages method

3. Enhanced SBOM generation:

      - Mark framework packages as Dev_Dependency.
      - Include explicit .NET runtime version requirements.
 
4. Distinguish between deployment types (Classical vs Self-contained)
5. Framework package filtering applied only for Classical deployments
6. Added comprehensive unit test coverage

**CycloneDx v1.6**

- Upgraded the CA Tool to support the latest CycloneDX SBOM schema (v1.6) with Siemens SBOM Standard version v3.

**Bugs Fixes:**

- After the package is copied in the Artifactory uploader the JFrog package path is updated in SBOM.
- If fossology-url is found in SW360 we updated that details in SBOM.
- Initiating fossology process we are displaying Un-wanted message shown to the user in each run ,we removed that message.
- While updating fossology url in sw360.user won't have enough permission to updating url its sending moderation request.Now we are displaying that message as warning.