### PR TITLE
fix: Updated warning message for get releases api call

### DIFF
--- a/src/LCT.APICommunications/RetryHttpClientHandler.cs
+++ b/src/LCT.APICommunications/RetryHttpClientHandler.cs
@@ -48,7 +48,7 @@ namespace LCT.APICommunications
 
             if (!_initialRetryLogged && context["LogWarnings"] as bool? != false)
             {
-                Logger.Warn($"Retry attempt triggered for {operationInfo}: {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
+                Logger.Warn($"Retry attempt initiated: {operationInfo} Error: {(outcome.Exception != null ? outcome.Exception.Message : $"{outcome.Result.StatusCode}")}");
             }
 
             context["RetryAttempt"] = attempt;

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -142,7 +142,7 @@ namespace LCT.APICommunications
         public async Task<string> GetReleases()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "SW360 releases details could not be retrieved");
+            httpClient.SetLogWarnings(true, "Unable to retrieve details for SW360 releases.");
             var result = string.Empty;
             try
             {
@@ -368,7 +368,7 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetAllReleasesWithAllData(int page, int pageEntries)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "SW360 releases full details could not be retrieved");
+            httpClient.SetLogWarnings(true, "Unable to retrieve full details for SW360 releases.");
             string url = $"{sw360ReleaseApi}?page={page}&allDetails=true&page_entries={pageEntries}";
             return await httpClient.GetAsync(url);
         }

--- a/src/LCT.APICommunications/SW360Apicommunication.cs
+++ b/src/LCT.APICommunications/SW360Apicommunication.cs
@@ -142,7 +142,7 @@ namespace LCT.APICommunications
         public async Task<string> GetReleases()
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get releases");
+            httpClient.SetLogWarnings(true, "SW360 releases details could not be retrieved");
             var result = string.Empty;
             try
             {
@@ -368,7 +368,7 @@ namespace LCT.APICommunications
         public async Task<HttpResponseMessage> GetAllReleasesWithAllData(int page, int pageEntries)
         {
             HttpClient httpClient = GetHttpClient();
-            httpClient.SetLogWarnings(true, "unable to get all releases details");
+            httpClient.SetLogWarnings(true, "SW360 releases full details could not be retrieved");
             string url = $"{sw360ReleaseApi}?page={page}&allDetails=true&page_entries={pageEntries}";
             return await httpClient.GetAsync(url);
         }


### PR DESCRIPTION
Updated the warning message shown to the user when the retry attempt is triggered. 