### PR TITLE
fix: Packages shown that attachment is missing even when the status is report approved

### DIFF
--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -55,7 +55,7 @@ namespace LCT.SW360PackageCreator
             {
                 if (comparionBomData.ApprovedStatus == "APPROVED")
                 {
-                    Logger.Info($"Component {comparionBomData.Name} with version {comparionBomData.Version} is approved and will be skipped.");
+                    Logger.Debug($"Component {comparionBomData.Name} with version {comparionBomData.Version} is in approved state.");
                     continue;
                 }
                 if ((comparionBomData.DownloadUrl == Dataconstant.DownloadUrlNotFound || string.IsNullOrEmpty(comparionBomData.DownloadUrl)) && !comparionBomData.SourceAttachmentStatus)


### PR DESCRIPTION
Issue resolved for "Packages shown that attachment is missing even when the status is report approved."
now the approved state is ignored from the attachment missing list.