### PR TITLE
fix: Bugfix for remove duplicate properties in package creater while updateing SBOM, Identify debian component by using package url for avoiding create duplicate components.

### DIFF
--- a/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
+++ b/src/AritfactoryUploader.UTest/PackageUploadHelperTest.cs
@@ -111,7 +111,7 @@ namespace AritfactoryUploader.UTest
             PackageUploadHelper.UpdateBomArtifactoryRepoUrl(ref bom, components);
 
             //Assert
-            var repoUrl = bom.Components.First(x => x.Properties[3].Name == Dataconstant.Cdx_ArtifactoryRepoName).Properties[3].Value;
+            var repoUrl = bom.Components.First(x => x.Properties[5].Name == Dataconstant.Cdx_ArtifactoryRepoName).Properties[5].Value;
             var repoPath = bom.Components.First(x => x.Properties[6].Name == Dataconstant.Cdx_JfrogRepoPath).Properties[6].Value;
             Assert.AreEqual("org1-npmjs-npm-remote", repoUrl);
             Assert.AreEqual("org1-npmjs-npm-remote/rxjs/-/rxjs-6.5.4.tgz", repoPath);

--- a/src/ArtifactoryUploader/PackageUploadHelper.cs
+++ b/src/ArtifactoryUploader/PackageUploadHelper.cs
@@ -432,10 +432,13 @@ namespace LCT.ArtifactoryUploader
             foreach (var component in componentsUploaded)
             {
                 var bomComponent = bom.Components.Find(x => x.Purl.Equals(component.Purl, StringComparison.OrdinalIgnoreCase));
-                if (component.DestRepoName != null && !component.DryRun)
+                if (bomComponent != null && component.DestRepoName != null && !component.DryRun)
                 {
-                    bomComponent.Properties.First(x => x.Name == Dataconstant.Cdx_ArtifactoryRepoName).Value = component.DestRepoName;
-                    bomComponent.Properties.First(x => x.Name == Dataconstant.Cdx_JfrogRepoPath).Value = component.JfrogRepoPath;
+                    bomComponent.Properties ??= new List<Property>();
+                    var properties = bomComponent.Properties;                    
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_ArtifactoryRepoName, component.DestRepoName);
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_JfrogRepoPath, component.JfrogRepoPath);
+                    bomComponent.Properties = properties;
                 }
             }
         }

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -1370,7 +1370,101 @@ namespace LCT.Common.UTest
             Assert.IsNotNull(sha256Hash);
             Assert.AreEqual("validsha256hash", sha256Hash.Content);
         }
+        [Test]
+        public void RemoveDuplicateAndAddProperty_WhenPropertiesIsNull_InitializesListAndAddsProperty()
+        {
+            // Arrange
+            List<Property> properties = null;
+            string propertyName = "TestProperty";
+            string propertyValue = "TestValue";
 
+            // Act
+            CommonHelper.RemoveDuplicateAndAddProperty( ref properties, propertyName, propertyValue);
+
+            // Assert
+            Assert.IsNotNull(properties);
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual(propertyName, properties[0].Name);
+            Assert.AreEqual(propertyValue, properties[0].Value);
+        }
+
+        [Test]
+        public void RemoveDuplicateAndAddProperty_WhenPropertyExists_UpdatesValue()
+        {
+            // Arrange
+            var properties = new List<Property>
+            {
+                new Property { Name = "TestProperty", Value = "OldValue" }
+            };
+            string propertyName = "TestProperty";
+            string propertyValue = "NewValue";
+
+            // Act
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, propertyName, propertyValue);
+
+            // Assert
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual(propertyName, properties[0].Name);
+            Assert.AreEqual(propertyValue, properties[0].Value);
+        }
+
+        [Test]
+        public void RemoveDuplicateAndAddProperty_WhenMultiplePropertiesExist_RemovesDuplicatesAndAddsNewProperty()
+        {
+            // Arrange
+            var properties = new List<Property>
+            {
+                new Property { Name = "TestProperty", Value = "OldValue1" },
+                new Property { Name = "TestProperty", Value = "OldValue2" },
+                new Property { Name = "AnotherProperty", Value = "AnotherValue" }
+            };
+            string propertyName = "TestProperty";
+            string propertyValue = "NewValue";
+
+            // Act
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, propertyName, propertyValue);
+
+            // Assert
+            Assert.AreEqual(2, properties.Count);
+            Assert.AreEqual(propertyName, properties.First(p => p.Name == propertyName).Name);
+            Assert.AreEqual(propertyValue, properties.First(p => p.Name == propertyName).Value);
+        }
+
+        [Test]
+        public void RemoveDuplicateAndAddProperty_WhenPropertyDoesNotExist_AddsNewProperty()
+        {
+            // Arrange
+            var properties = new List<Property>
+            {
+                new Property { Name = "AnotherProperty", Value = "AnotherValue" }
+            };
+            string propertyName = "TestProperty";
+            string propertyValue = "TestValue";
+
+            // Act
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, propertyName, propertyValue);
+
+            // Assert
+            Assert.AreEqual(2, properties.Count);
+            Assert.IsTrue(properties.Any(p => p.Name == propertyName && p.Value == propertyValue));
+        }
+
+        [Test]
+        public void RemoveDuplicateAndAddProperty_WhenPropertiesIsEmpty_AddsNewProperty()
+        {
+            // Arrange
+            var properties = new List<Property>();
+            string propertyName = "TestProperty";
+            string propertyValue = "TestValue";
+
+            // Act
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, propertyName, propertyValue);
+
+            // Assert
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual(propertyName, properties[0].Name);
+            Assert.AreEqual(propertyValue, properties[0].Value);
+        }
         #endregion
 
         // ...existing code...

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -1317,7 +1317,7 @@ namespace LCT.Common.UTest
                 
             // Verify basic behavior
             Assert.IsNotNull(component.Properties);
-            Assert.AreEqual(4, component.Properties.Count); // 4 null properties added
+            Assert.AreEqual(1, component.Properties.Count); 
             Assert.IsNull(component.Description);
             Assert.IsNull(component.Hashes);
         }

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -556,6 +556,12 @@ namespace LCT.Common
             }
             
         }
+        public static void RemoveDuplicateAndAddProperty(ref List<Property> properties, string propertyName, string propertyValue)
+        {
+            properties ??= new List<Property>();
+            properties.RemoveAll(p => p.Name == propertyName);
+            properties.Add(new Property { Name = propertyName, Value = propertyValue });
+        }
         #endregion
 
         #region private

--- a/src/LCT.PackageIdentifier/ConanProcessor.cs
+++ b/src/LCT.PackageIdentifier/ConanProcessor.cs
@@ -81,18 +81,12 @@ namespace LCT.PackageIdentifier
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData, CommonAppSettings appSettings,
             IJFrogService jFrogService, IBomHelper bomhelper)
         {
-            // get the  component list from Jfrog for given repository
             List<AqlResult> aqlResultList =
                 await bomhelper.GetListOfComponentsFromRepo(appSettings.Conan.Artifactory.InternalRepos, jFrogService);
-
             var inputIterationList = componentData.comparisonBOMData;
-            
-            // Use the common helper method
             var (processedComponents, internalComponents) = CommonHelper.ProcessInternalComponentIdentification(
                 inputIterationList, 
                 component => IsInternalConanComponent(aqlResultList, component));
-
-            // update the comparison bom data
             componentData.comparisonBOMData = processedComponents;
             componentData.internalComponents = internalComponents;
 
@@ -525,19 +519,24 @@ namespace LCT.PackageIdentifier
             {
                 component.Properties ??= new List<Property>();
 
-                Property isDev;
-                Property identifierType;
                 if (identifiedBy == "PackageFile")
                 {
-                    identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.Discovered };
-                    component.Properties.Add(identifierType);
+                    var properties= component.Properties;
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                        Dataconstant.Cdx_IdentifierType,
+                        Dataconstant.Discovered);
+                    component.Properties = properties;
                 }
                 else
                 {
-                    isDev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
-                    identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.ManullayAdded };
-                    component.Properties.Add(isDev);
-                    component.Properties.Add(identifierType);
+                    var properties = component.Properties;
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                        Dataconstant.Cdx_IsDevelopment,
+                        "false");
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                        Dataconstant.Cdx_IdentifierType,
+                        Dataconstant.ManullayAdded);
+                    component.Properties = properties;
                 }
             }
         }
@@ -561,14 +560,19 @@ namespace LCT.PackageIdentifier
         {
             foreach (var component in componentsForBOM)
             {
-                // check existence of property and add new
-                component.Properties = new List<Property>();
-                Property isDev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
-                Property identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.ManullayAdded };
-                component.Properties.Add(isDev);
-                component.Properties.Add(identifierType);
+                // Initialize properties list if null, otherwise keep existing properties
+                component.Properties ??= new List<Property>();
+                var properties= component.Properties;
+                // Use helper method to safely add properties without duplicates
+                CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                    Dataconstant.Cdx_IsDevelopment,
+                    "false");
+                CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                    Dataconstant.Cdx_IdentifierType,
+                    Dataconstant.ManullayAdded);
+                component.Properties= properties;
             }
-        }             
+        }
 
         #endregion
     }

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -131,58 +131,16 @@ namespace LCT.PackageIdentifier
         }
         public static void SetProperties(CommonAppSettings appSettings, Component component, ref List<Component> componentForBOM, string repo = "Not Found in JFrogRepo")
         {
-            List<Property> propList = new();
-            if (component.Properties?.Count == null || component.Properties.Count <= 0)
-            {
-                component.Properties = propList;
-            }
-
-            Property projectType = new()
-            {
-                Name = Dataconstant.Cdx_ProjectType,
-                Value = appSettings.ProjectType
-            };
-
-            Property artifactoryrepo = new()
-            {
-                Name = Dataconstant.Cdx_ArtifactoryRepoName,
-                Value = repo
-            };
-
-            Property internalType = new()
-            {
-                Name = Dataconstant.Cdx_IsInternal,
-                Value = "false"
-            };
-
-            Property isDevelopment = new()
-            {
-                Name = Dataconstant.Cdx_IsDevelopment,
-                Value = "false"
-            };
-
-            Property isDirect = new()
-            {
-                Name = Dataconstant.Cdx_SiemensDirect,
-                Value = "true"
-            };
-            Property filname = new()
-            {
-                Name = Dataconstant.Cdx_Siemensfilename,
-                Value = Dataconstant.PackageNameNotFoundInJfrog
-            };
-            Property jfrogRepoPathProperty = new()
-            {
-                Name = Dataconstant.Cdx_JfrogRepoPath,
-                Value = Dataconstant.JfrogRepoPathNotFound
-            };
-            component.Properties.Add(internalType);
-            component.Properties.Add(artifactoryrepo);
-            component.Properties.Add(projectType);
-            component.Properties.Add(isDevelopment);
-            component.Properties.Add(isDirect);
-            component.Properties.Add(filname);
-            component.Properties.Add(jfrogRepoPathProperty);
+            component.Properties ??= new List<Property>();
+            var properties = component.Properties;
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_ProjectType, appSettings.ProjectType);
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_ArtifactoryRepoName, repo);
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_IsInternal, "false");
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_IsDevelopment, "false");
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_SiemensDirect, "true");
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_Siemensfilename, Dataconstant.PackageNameNotFoundInJfrog);
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_JfrogRepoPath, Dataconstant.JfrogRepoPathNotFound);
+            component.Properties = properties;
             component.Description = null;
             componentForBOM.Add(component);
         }

--- a/src/LCT.PackageIdentifier/DebianProcessor.cs
+++ b/src/LCT.PackageIdentifier/DebianProcessor.cs
@@ -366,10 +366,10 @@ namespace LCT.PackageIdentifier
             else
             {
                 //For Debian projects we will be considering CycloneDX file reading components as Discovered
-                //since it's Discovered from syft Tool
-                Property identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.Discovered };
-                component.Properties.Add(identifierType);
-
+                //since it's Discovered from syft Tool                
+                var properties=component.Properties;
+                CommonHelper.RemoveDuplicateAndAddProperty(ref properties,Dataconstant.Cdx_IdentifierType,Dataconstant.Discovered);
+                component.Properties = properties;
             }
         }
         private static void SetSpdxComponentDetails(string filePath, DebianPackage package,Component componentInfo)

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -197,19 +197,17 @@ namespace LCT.PackageIdentifier
             List<string> mavenDirectDependencies = new List<string>();
             mavenDirectDependencies.AddRange(bom.Dependencies?.Select(x => x.Ref).ToList() ?? new List<string>());
             var bomComponentsList = bom.Components;
+
             foreach (var component in bomComponentsList)
             {
-                Property siemensDirect = new() { Name = Dataconstant.Cdx_SiemensDirect, Value = "false" };
-                if (mavenDirectDependencies.Exists(x => x.Contains(component.Name) && x.Contains(component.Version)))
-                {
-                    siemensDirect.Value = "true";
-                }
-
+                string siemensDirectValue = mavenDirectDependencies.Exists(x => x.Contains(component.Name) && x.Contains(component.Version))
+                    ? "true"
+                    : "false";
                 component.Properties ??= new List<Property>();
-                bool isPropExists = component.Properties.Exists(x => x.Name.Equals(Dataconstant.Cdx_SiemensDirect));
-                if (!isPropExists) { component.Properties.Add(siemensDirect); }
+                var properties = component.Properties;
+                CommonHelper.RemoveDuplicateAndAddProperty(ref properties,Dataconstant.Cdx_SiemensDirect,siemensDirectValue);
+                component.Properties = properties;
             }
-
             bom.Components = bomComponentsList;
         }
 

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -716,18 +716,19 @@ namespace LCT.PackageIdentifier
             return components;
         }
 
-        private static void AddingIdentifierType(List<Component> components, string identifiedBy,string filePath)
+        private static void AddingIdentifierType(List<Component> components, string identifiedBy, string filePath)
         {
             foreach (var component in components)
             {
                 component.Properties ??= new List<Property>();
 
-                Property isDev;
-                Property identifierType;
                 if (identifiedBy == "PackageFile")
                 {
-                    identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.Discovered };
-                    component.Properties.Add(identifierType);
+                    var properties=component.Properties;
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                        Dataconstant.Cdx_IdentifierType,
+                        Dataconstant.Discovered);
+                    component.Properties = properties;
                 }
                 else
                 {
@@ -737,12 +738,16 @@ namespace LCT.PackageIdentifier
                         SpdxSbomHelper.AddSpdxComponentProperties(fileName, component);
                     }
                     else
-                    {                        
-                        identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.ManullayAdded };                        
-                        component.Properties.Add(identifierType);
-                        isDev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
-                        component.Properties.Add(isDev);
-                    }                    
+                    {
+                        var properties = component.Properties;
+                        CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                            Dataconstant.Cdx_IdentifierType,
+                            Dataconstant.ManullayAdded);
+                        CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                            Dataconstant.Cdx_IsDevelopment,
+                            "false");
+                        component.Properties = properties;
+                    }
                 }
             }
         }

--- a/src/LCT.PackageIdentifier/NugetProcessor.cs
+++ b/src/LCT.PackageIdentifier/NugetProcessor.cs
@@ -410,19 +410,17 @@ namespace LCT.PackageIdentifier
             var bomComponentsList = bom.Components;
             foreach (var component in bomComponentsList)
             {
-                Property siemensDirect = new() { Name = Dataconstant.Cdx_SiemensDirect, Value = "false" };
-
                 var isDirectDep = NugetDevDependencyParser.NugetDirectDependencies
                     .Any(x => x.Contains(component.Name) && x.Contains(component.Version));
 
-                if (isDirectDep) { siemensDirect.Value = "true"; }
+                string siemensDirectValue = isDirectDep ? "true" : "false";
 
                 component.Properties ??= new List<Property>();
-
-                bool isPropExists = component.Properties.Exists(
-                    x => x.Name.Equals(Dataconstant.Cdx_SiemensDirect));
-
-                if (!isPropExists) { component.Properties.Add(siemensDirect); }
+                var properties = component.Properties;
+                CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                    Dataconstant.Cdx_SiemensDirect,
+                    siemensDirectValue);
+                component.Properties = properties;
             }
 
             bom.Components = bomComponentsList;

--- a/src/LCT.PackageIdentifier/PythonProcessor.cs
+++ b/src/LCT.PackageIdentifier/PythonProcessor.cs
@@ -465,7 +465,6 @@ namespace LCT.PackageIdentifier
             if (prop.SpdxComponentDetails.SpdxComponent)
             {
                 AddSpdxProperties(prop, component);
-                component.Properties.Add(devDependency);
             }
             else
             {
@@ -482,14 +481,17 @@ namespace LCT.PackageIdentifier
 
         private static void AddIdentifierTypeProperty(PythonPackage prop, Component component, Property devDependency)
         {
-            var identifierType = new Property
-            {
-                Name = Dataconstant.Cdx_IdentifierType,
-                Value = prop.FoundType == Dataconstant.Discovered ? Dataconstant.Discovered : Dataconstant.ManullayAdded
-            };
+            component.Properties ??= new List<Property>();
 
-            component.Properties.Add(devDependency);
-            component.Properties.Add(identifierType);
+            string identifierTypeValue = prop.FoundType == Dataconstant.Discovered ? Dataconstant.Discovered : Dataconstant.ManullayAdded;
+            var properties = component.Properties;
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                devDependency.Name,
+                devDependency.Value);
+            CommonHelper.RemoveDuplicateAndAddProperty(ref properties,
+                Dataconstant.Cdx_IdentifierType,
+                identifierTypeValue);
+            component.Properties = properties;
         }
         private static void SetSpdxComponentDetails(string filePath, PythonPackage package,Component componentInfo)
         {

--- a/src/LCT.PackageIdentifier/SbomTemplate.cs
+++ b/src/LCT.PackageIdentifier/SbomTemplate.cs
@@ -60,27 +60,16 @@ namespace LCT.PackageIdentifier
         {
             try
             {
-                Property cdxIdentifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.TemplateAdded };
-                Property cdxIsDev = new() { Name = Dataconstant.Cdx_IsDevelopment, Value = "false" };
-
                 Component bomComp = bom.Find(x => x.Name == sbomcomp.Name && x.Version == sbomcomp.Version);
                 if (bomComp == null)
                 {
-                    if (sbomcomp.Properties == null)
-                    {
-                        sbomcomp.Properties = new List<Property>();
-                        sbomcomp.Properties.Add(cdxIdentifierType);
-                        sbomcomp.Properties.Add(cdxIsDev);
-                        bom.Add(sbomcomp);
-                        BomCreator.bomKpiData.ComponentsinSBOMTemplateFile++;
-                    }
-                    else
-                    {
-                        sbomcomp.Properties.Add(cdxIdentifierType);
-                        sbomcomp.Properties.Add(cdxIsDev);
-                        bom.Add(sbomcomp);
-                        BomCreator.bomKpiData.ComponentsinSBOMTemplateFile++;
-                    }
+                    sbomcomp.Properties ??= new List<Property>();
+                    var properties = sbomcomp.Properties;
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_IdentifierType, Dataconstant.TemplateAdded);
+                    CommonHelper.RemoveDuplicateAndAddProperty(ref properties, Dataconstant.Cdx_IsDevelopment, "false");
+                    sbomcomp.Properties= properties;
+                    bom.Add(sbomcomp);
+                    BomCreator.bomKpiData.ComponentsinSBOMTemplateFile++;
                 }
                 else
                 {
@@ -89,21 +78,18 @@ namespace LCT.PackageIdentifier
             }
             catch (ArgumentException ex)
             {
-                Logger.Error($"AddComponentDetails():ArgumentException:Error from " + sbomcomp.Name + " : " + sbomcomp.Version, ex);
+                Logger.Error($"PropertyAdditionForTemplate():ArgumentException:Error from {sbomcomp.Name} : {sbomcomp.Version}", ex);
             }
             catch (InvalidOperationException ex)
             {
-                Logger.Error($"AddComponentDetails():InvalidOperationException:Error from " + sbomcomp.Name + " : " + sbomcomp.Version, ex);
+                Logger.Error($"PropertyAdditionForTemplate():InvalidOperationException:Error from {sbomcomp.Name} : {sbomcomp.Version}", ex);
             }
         }
 
         private static void TemplateComponentUpdation(Component sbomcomp, Component bomComp)
-        {
-            bool isLicenseUpdated = false;
-            bool isPropertiesUpdated = false;
-
-            isLicenseUpdated = UpdateLicenseDetails(bomComp, sbomcomp);
-            isPropertiesUpdated = UpdatePropertiesDetails(bomComp, sbomcomp);
+        {  
+            bool isLicenseUpdated = UpdateLicenseDetails(bomComp, sbomcomp);
+            bool isPropertiesUpdated = UpdatePropertiesDetails(bomComp, sbomcomp);
 
             if (isLicenseUpdated || isPropertiesUpdated)
             {

--- a/src/LCT.Services/Sw360CommonService.cs
+++ b/src/LCT.Services/Sw360CommonService.cs
@@ -130,7 +130,7 @@ namespace LCT.Services
                     var sw360releasesdata = componentsRelease?.Embedded?.Sw360Releases ?? new List<Sw360Releases>();
 
                     //It's for Local Sw360 servers,making an API call with EscapeDataString..
-                    if (sw360releasesdata.Count == 0 && releaseExternalId.Contains(Dataconstant.PurlCheck()["NPM"]))
+                    if (sw360releasesdata.Count == 0 && (releaseExternalId.Contains(Dataconstant.PurlCheck()["NPM"]) || releaseExternalId.Contains(Dataconstant.PurlCheck()["DEBIAN"]) || releaseExternalId.Contains(Dataconstant.PurlCheck()["ALPINE"])))
                     {
                         releaseExternalId = Uri.EscapeDataString(releaseExternalId);
                         httpResponseComponent = await m_SW360ApiCommunicationFacade.GetReleaseByExternalId(releaseExternalId, externalIdKey);


### PR DESCRIPTION
Bugfix
1.Remove duplicate properties in package creater updated SBOM.
2.Identify debian component by using escape data string package url for avoiding create duplicate components.