### PR TITLE
fix: v8.2.1

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build . --file Dockerfile --tag ${{ github.repository }}:continuous-clearing-v8.2.0
-          docker save ${{ github.repository }}:continuous-clearing-v8.2.0 -o continuous-clearing-v8.2.0.tar
+          docker build . --file Dockerfile --tag ${{ github.repository }}:continuous-clearing-v8.2.1
+          docker save ${{ github.repository }}:continuous-clearing-v8.2.1 -o continuous-clearing-v8.2.1.tar
 
       - name: Upload Docker Image
         uses: actions/upload-artifact@v4
@@ -74,7 +74,7 @@ jobs:
 
       - name: Pack NuGet Package
         run: |
-          nuget pack CA.nuspec -Version 8.2.0
+          nuget pack CA.nuspec -Version 8.2.1
 
       - name: Upload NuGet Package
         uses: actions/upload-artifact@v4
@@ -114,8 +114,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v8.2.0
-          release_name: Release v8.2.0
+          tag_name: v8.2.1
+          release_name: Release v8.2.1
           body: |
             ${{ github.event.head_commit.message }}
           draft: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: Compress Full Build Output into ZIP
         run: |
-          powershell -Command "& {Compress-Archive -Path ${{ github.workspace }}/out/* -DestinationPath ${{ github.workspace }}/continuous-clearing-v8.2.0.zip}"
+          powershell -Command "& {Compress-Archive -Path ${{ github.workspace }}/out/* -DestinationPath ${{ github.workspace }}/continuous-clearing-v8.2.1.zip}"
 
       - name: Upload Full Build Output ZIP to Release
         uses: actions/upload-release-asset@v1
@@ -131,8 +131,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/continuous-clearing-v8.2.0.zip
-          asset_name: continuous-clearing-v8.2.0.zip
+          asset_path: ${{ github.workspace }}/continuous-clearing-v8.2.1.zip
+          asset_name: continuous-clearing-v8.2.1.zip
           asset_content_type: application/zip
 
       - name: Upload Docker Image(tar) to Release
@@ -141,8 +141,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./continuous-clearing-v8.2.0.tar
-          asset_name: continuous-clearing-v8.2.0.tar
+          asset_path: ./continuous-clearing-v8.2.1.tar
+          asset_name: continuous-clearing-v8.2.1.tar
           asset_content_type: application/x-tar
 
       - name: Upload NuGet Package to Release
@@ -151,8 +151,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./continuous-clearing.8.2.0.nupkg
-          asset_name: continuous-clearing.8.2.0.nupkg
+          asset_path: ./continuous-clearing.8.2.1.nupkg
+          asset_name: continuous-clearing.8.2.1.nupkg
           asset_content_type: application/octet-stream
 
       - name: Upload ReadmeOSS_nupkg file to Release 

--- a/CA.nuspec
+++ b/CA.nuspec
@@ -4,7 +4,7 @@
 <package >
   <metadata>
     <id>continuous-clearing</id>
-	<version>8.2.0</version>
+	<version>8.2.1</version>
     <authors>Siemens AG</authors>
     <owners>continuous-clearing contributors</owners>
     <projectUrl>https://github.com/siemens/continuous-clearing</projectUrl>

--- a/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
+++ b/src/ArtifactoryUploader/LCT.ArtifactoryUploader.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>ArtifactoryUploader</AssemblyName>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.APICommunications/LCT.APICommunications.csproj
+++ b/src/LCT.APICommunications/LCT.APICommunications.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -1072,8 +1072,8 @@ namespace LCT.Common.UTest
             // Arrange
             var components = new List<Components>
             {
-                new Components { Name = "CompA", Version = "1.0", ComponentID = "cid1" },
-                new Components { Name = "CompB", Version = "2.0", ComponentID = "cid2" }
+                new Components { Name = "CompA", Version = "1.0", ComponentId = "cid1" },
+                new Components { Name = "CompB", Version = "2.0", ComponentId = "cid2" }
             };
             string sw360Url = "http://sw360";
 

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -8,11 +8,13 @@ using CycloneDX.Models;
 using LCT.Common.Constants;
 using LCT.Common.Model;
 using log4net;
+using log4net.Appender;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using File = System.IO.File;
 
@@ -1064,7 +1066,77 @@ namespace LCT.Common.UTest
             // Should have added one property (internal) to the existing empty list
             Assert.AreEqual(1, processedComponent.Properties.Count);
         }
+        [Test]
+        public void LogDuplicateComponentsByPurlId_LogsExpectedOutput_MemoryAppender()
+        {
+            // Arrange
+            var components = new List<Components>
+            {
+                new Components { Name = "CompA", Version = "1.0", ComponentID = "cid1" },
+                new Components { Name = "CompB", Version = "2.0", ComponentID = "cid2" }
+            };
+            string sw360Url = "http://sw360";
 
+            // Set up MemoryAppender
+            var memoryAppender = new MemoryAppender();
+            var loggerField = typeof(CommonHelper).GetField("Logger", BindingFlags.Static | BindingFlags.NonPublic);
+            var logger = (ILog)loggerField.GetValue(null);
+
+            // Attach the appender to the logger's repository
+            var log = LogManager.GetLogger(typeof(CommonHelper));
+            ((log4net.Repository.Hierarchy.Logger)log.Logger).AddAppender(memoryAppender);
+
+            // Act
+            var logMethod = typeof(CommonHelper).GetMethod("LogDuplicateComponentsByPurlId", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(logMethod, "LogDuplicateComponentsByPurlId method not found in CommonHelper.");
+            logMethod.Invoke(null, new object[] { components, sw360Url });
+
+            // Get log events
+            var events = memoryAppender.GetEvents();
+            var messages = events.Select(e => e.RenderedMessage).ToList();
+
+            // Assert
+            Assert.IsTrue(messages.Any(m => m.Contains("not created in SW360 due to Invalid PuriIds")), "Missing expected summary log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("Component Name already exists in SW360")), "Missing expected warning log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("CompA")), "Missing CompA in log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("CompB")), "Missing CompB in log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("http://sw360/group/guest/components/-/component/detail/cid1")), "Missing CompA URL in log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("http://sw360/group/guest/components/-/component/detail/cid2")), "Missing CompB URL in log.");
+
+            // Clean up
+            ((log4net.Repository.Hierarchy.Logger)log.Logger).RemoveAppender(memoryAppender);
+        }
+
+        [Test]
+        public void LogDuplicateComponentsByPurlId_DoesNothing_WhenListIsEmpty_MemoryAppender()
+        {
+            // Arrange
+            var components = new List<Components>();
+            string sw360Url = "http://sw360";
+
+            // Set up MemoryAppender
+            var memoryAppender = new MemoryAppender();
+            var loggerField = typeof(CommonHelper).GetField("Logger", BindingFlags.Static | BindingFlags.NonPublic);
+            var logger = (ILog)loggerField.GetValue(null);
+
+            // Attach the appender to the logger's repository
+            var log = LogManager.GetLogger(typeof(CommonHelper));
+            ((log4net.Repository.Hierarchy.Logger)log.Logger).AddAppender(memoryAppender);
+
+            // Act
+            var logMethod = typeof(CommonHelper).GetMethod("LogDuplicateComponentsByPurlId", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(logMethod, "LogDuplicateComponentsByPurlId method not found in CommonHelper.");
+            logMethod.Invoke(null, new object[] { components, sw360Url });
+
+            // Get log events
+            var events = memoryAppender.GetEvents();
+
+            // Assert
+            Assert.IsTrue(events.Length == 0 || events.All(e => string.IsNullOrWhiteSpace(e.RenderedMessage)), "No logs should be written when the list is empty.");
+
+            // Clean up
+            ((log4net.Repository.Hierarchy.Logger)log.Logger).RemoveAppender(memoryAppender);
+        }
 
         #region SetComponentPropertiesAndHashes Tests
 

--- a/src/LCT.Common.UTests/CommonHelperTest.cs
+++ b/src/LCT.Common.UTests/CommonHelperTest.cs
@@ -1096,7 +1096,7 @@ namespace LCT.Common.UTest
             var messages = events.Select(e => e.RenderedMessage).ToList();
 
             // Assert
-            Assert.IsTrue(messages.Any(m => m.Contains("not created in SW360 due to Invalid PuriIds")), "Missing expected summary log.");
+            Assert.IsTrue(messages.Any(m => m.Contains("not created in SW360 due to Invalid Purl ids")), "Missing expected summary log.");
             Assert.IsTrue(messages.Any(m => m.Contains("Component Name already exists in SW360")), "Missing expected warning log.");
             Assert.IsTrue(messages.Any(m => m.Contains("CompA")), "Missing CompA in log.");
             Assert.IsTrue(messages.Any(m => m.Contains("CompB")), "Missing CompB in log.");

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -207,7 +207,7 @@ namespace LCT.Common
         {
             if (duplicateComponents.Count > 0)
             {
-                Logger.Logger.Log(null, Level.Alert, "* List of components or releases not created in SW360 due to Invalid PuriIds found in Components ExternalID field in sw360", null);
+                Logger.Logger.Log(null, Level.Alert, "* List of components or releases not created in SW360 due to Invalid Purl ids found in Components ExternalID field in sw360", null);
                 Logger.Logger.Log(null, Level.Alert, "  Component Name already exists in SW360 with a different package type PurlId. Manually update the component details.", null);
 
                 const int nameWidth = 45;
@@ -224,7 +224,7 @@ namespace LCT.Common
 
                 foreach (var item in duplicateComponents)
                 {
-                    string link = Sw360ComponentURL(sw360URL, item.ComponentID);
+                    string link = Sw360ComponentURL(sw360URL, item.ComponentId);
                     Logger.Logger.Log(null, Level.Alert, string.Format("| {0,-45} | {1,-25} | {2,-120} |", item.Name, item.Version, link), null);
                     Logger.Logger.Log(null, Level.Alert, separator, null);
                 }

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -158,7 +158,7 @@ namespace LCT.Common
             const string Name = "Name";
             const string Version = "Version";
             const string URL = "SW360 Release URL";
-            const string ComponentURL = "SW360 Component URL";
+
             if (componentInfo.Count > 0 || lstReleaseNotCreated.Count > 0)
             {
                 Logger.Logger.Log(null, Level.Alert, "Action Item required by the user:\n", null);
@@ -210,9 +210,9 @@ namespace LCT.Common
                 Logger.Logger.Log(null, Level.Alert, "* List of components or releases not created in SW360 due to Invalid PuriIds found in Components ExternalID field in sw360", null);
                 Logger.Logger.Log(null, Level.Alert, "  Component Name already exists in SW360 with a different package type PurlId. Manually update the component details.", null);
 
-                int nameWidth = 45;
-                int versionWidth = 25;
-                int urlWidth = 120;
+                const int nameWidth = 45;
+                const int versionWidth = 25;
+                const int urlWidth = 120;
                 int totalWidth = nameWidth + versionWidth + urlWidth + 10; 
 
                 string border = new string('=', totalWidth);

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -153,11 +153,12 @@ namespace LCT.Common
             }
         }
 
-        public static void WriteComponentsWithoutDownloadURLToKpi(List<ComparisonBomData> componentInfo, List<Components> lstReleaseNotCreated, string sw360URL)
+        public static void WriteComponentsWithoutDownloadURLToKpi(List<ComparisonBomData> componentInfo, List<Components> lstReleaseNotCreated, string sw360URL,List<Components> DuplicateComponentsByPurlId)
         {
             const string Name = "Name";
             const string Version = "Version";
             const string URL = "SW360 Release URL";
+            const string ComponentURL = "SW360 Component URL";
             if (componentInfo.Count > 0 || lstReleaseNotCreated.Count > 0)
             {
                 Logger.Logger.Log(null, Level.Alert, "Action Item required by the user:\n", null);
@@ -199,8 +200,38 @@ namespace LCT.Common
                 }
                 Logger.Info("\n");
             }
+            LogDuplicateComponentsByPurlId(DuplicateComponentsByPurlId, sw360URL);
+                                   
         }
+        private static void LogDuplicateComponentsByPurlId(List<Components> duplicateComponents, string sw360URL)
+        {
+            if (duplicateComponents.Count > 0)
+            {
+                Logger.Logger.Log(null, Level.Alert, "* List of components or releases not created in SW360 due to Invalid PuriIds found in Components ExternalID field in sw360", null);
+                Logger.Logger.Log(null, Level.Alert, "  Component Name already exists in SW360 with a different package type PurlId. Manually update the component details.", null);
 
+                int nameWidth = 45;
+                int versionWidth = 25;
+                int urlWidth = 120;
+                int totalWidth = nameWidth + versionWidth + urlWidth + 10; 
+
+                string border = new string('=', totalWidth);
+                string separator = new string('-', totalWidth);
+
+                Logger.Logger.Log(null, Level.Alert, border, null);
+                Logger.Logger.Log(null, Level.Alert, string.Format("| {0,-45} | {1,-25} | {2,-120} |", "Name", "Version", "SW360 Component URL"), null);
+                Logger.Logger.Log(null, Level.Alert, border, null);
+
+                foreach (var item in duplicateComponents)
+                {
+                    string link = Sw360ComponentURL(sw360URL, item.ComponentID);
+                    Logger.Logger.Log(null, Level.Alert, string.Format("| {0,-45} | {1,-25} | {2,-120} |", item.Name, item.Version, link), null);
+                    Logger.Logger.Log(null, Level.Alert, separator, null);
+                }
+
+                Logger.Info("\n");
+            }
+        }
         public static void WriteComponentsNotLinkedListInConsole(List<Components> components)
         {
             const string Name = "Name";
@@ -563,6 +594,11 @@ namespace LCT.Common
         private static string Sw360URL(string sw360Env, string releaseId)
         {
             string sw360URL = $"{sw360Env}{"/group/guest/components/-/component/release/detailRelease/"}{releaseId}";
+            return sw360URL;
+        }
+        private static string Sw360ComponentURL(string sw360Env, string componentId)
+        {
+            string sw360URL = $"{sw360Env}{"/group/guest/components/-/component/detail/"}{componentId}";
             return sw360URL;
         }
 

--- a/src/LCT.Common/CommonHelper.cs
+++ b/src/LCT.Common/CommonHelper.cs
@@ -213,7 +213,7 @@ namespace LCT.Common
                 const int nameWidth = 45;
                 const int versionWidth = 25;
                 const int urlWidth = 120;
-                int totalWidth = nameWidth + versionWidth + urlWidth + 10; 
+                const int totalWidth = nameWidth + versionWidth + urlWidth + 10; 
 
                 string border = new string('=', totalWidth);
                 string separator = new string('-', totalWidth);

--- a/src/LCT.Common/LCT.Common.csproj
+++ b/src/LCT.Common/LCT.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.Common/Model/Components.cs
+++ b/src/LCT.Common/Model/Components.cs
@@ -65,6 +65,12 @@ namespace LCT.Common.Model
         public string ExcludeComponent { get; set; }
         [JsonIgnore]
         public string ReleaseCreatedBy { get; set; }
+        [JsonIgnore]
+        public bool InValidComponentByPurlid { get; set; }=false;
+        [JsonIgnore]
+        public string ComponentLink { get; set; }
+        [JsonIgnore]
+        public string ComponentID { get; set; }       
 
     }
 }

--- a/src/LCT.Common/Model/Components.cs
+++ b/src/LCT.Common/Model/Components.cs
@@ -66,11 +66,11 @@ namespace LCT.Common.Model
         [JsonIgnore]
         public string ReleaseCreatedBy { get; set; }
         [JsonIgnore]
-        public bool InValidComponentByPurlid { get; set; }=false;
+        public bool InvalidComponentByPurlId { get; set; }=false;
         [JsonIgnore]
         public string ComponentLink { get; set; }
         [JsonIgnore]
-        public string ComponentID { get; set; }       
+        public string ComponentId { get; set; }       
 
     }
 }

--- a/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
+++ b/src/LCT.CycloneDxProcessor/LCT.CycloneDxProcessor.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/LCT.Facade/LCT.Facade.csproj
+++ b/src/LCT.Facade/LCT.Facade.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
+++ b/src/LCT.PackageIdentifier/LCT.PackageIdentifier.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>PackageIdentifier</AssemblyName>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -208,7 +208,7 @@ namespace LCT.SW360PackageCreator
             Logger.Debug($"SetContentsForComparisonBOM():Start");
             Logger.Logger.Log(null, Level.Notice, $"Collecting comparison BOM Data...", null);
             componentsAvailableInSw360 = await sw360Service.GetAvailableReleasesInSw360(lstComponentForBOM);
-            DuplicateComponentsByPirlId=await sw360Service.GetDuplicateComponentsByPurlId(lstComponentForBOM);
+            DuplicateComponentsByPirlId=sw360Service.GetDuplicateComponentsByPurlId();
             //Checking components count before getting status of individual comp details
             List<ComparisonBomData> comparisonBomData = await GetComparisionBomItems(lstComponentForBOM, sw360Service);
 

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -40,7 +40,7 @@ namespace LCT.SW360PackageCreator
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly List<Components> lstReleaseNotCreated = new List<Components>();
         List<Components> componentsAvailableInSw360 = new List<Components>();
-        List<Components> DuplicateComponentsByPirlId = new List<Components>();
+        List<Components> DuplicateComponentsByPurlId = new List<Components>();
         private const string SOURCE = "SOURCE";
         private readonly IDictionary<string, IPackageDownloader> _packageDownloderList = packageDownloderList;
 
@@ -208,7 +208,7 @@ namespace LCT.SW360PackageCreator
             Logger.Debug($"SetContentsForComparisonBOM():Start");
             Logger.Logger.Log(null, Level.Notice, $"Collecting comparison BOM Data...", null);
             componentsAvailableInSw360 = await sw360Service.GetAvailableReleasesInSw360(lstComponentForBOM);
-            DuplicateComponentsByPirlId=sw360Service.GetDuplicateComponentsByPurlId();
+            DuplicateComponentsByPurlId = sw360Service.GetDuplicateComponentsByPurlId();
             //Checking components count before getting status of individual comp details
             List<ComparisonBomData> comparisonBomData = await GetComparisionBomItems(lstComponentForBOM, sw360Service);
 
@@ -577,7 +577,7 @@ namespace LCT.SW360PackageCreator
             // Removes common components
             sourceNotAvailable.RemoveAll(src => lstReleaseNotCreated.Any(rls => src.Name == rls.Name && src.Version == rls.Version));
 
-            CommonHelper.WriteComponentsWithoutDownloadURLToKpi(sourceNotAvailable, lstReleaseNotCreated, appSetting.SW360.URL,DuplicateComponentsByPirlId);
+            CommonHelper.WriteComponentsWithoutDownloadURLToKpi(sourceNotAvailable, lstReleaseNotCreated, appSetting.SW360.URL,DuplicateComponentsByPurlId);
         }
 
         private static string GetComponentAvailabilityStatus(List<Components> componentsAvailable, Components component)

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -40,6 +40,7 @@ namespace LCT.SW360PackageCreator
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly List<Components> lstReleaseNotCreated = new List<Components>();
         List<Components> componentsAvailableInSw360 = new List<Components>();
+        List<Components> DuplicateComponentsByPirlId = new List<Components>();
         private const string SOURCE = "SOURCE";
         private readonly IDictionary<string, IPackageDownloader> _packageDownloderList = packageDownloderList;
 
@@ -207,7 +208,7 @@ namespace LCT.SW360PackageCreator
             Logger.Debug($"SetContentsForComparisonBOM():Start");
             Logger.Logger.Log(null, Level.Notice, $"Collecting comparison BOM Data...", null);
             componentsAvailableInSw360 = await sw360Service.GetAvailableReleasesInSw360(lstComponentForBOM);
-
+            DuplicateComponentsByPirlId=await sw360Service.GetDuplicateComponentsByPurlId(lstComponentForBOM);
             //Checking components count before getting status of individual comp details
             List<ComparisonBomData> comparisonBomData = await GetComparisionBomItems(lstComponentForBOM, sw360Service);
 
@@ -576,7 +577,7 @@ namespace LCT.SW360PackageCreator
             // Removes common components
             sourceNotAvailable.RemoveAll(src => lstReleaseNotCreated.Any(rls => src.Name == rls.Name && src.Version == rls.Version));
 
-            CommonHelper.WriteComponentsWithoutDownloadURLToKpi(sourceNotAvailable, lstReleaseNotCreated, appSetting.SW360.URL);
+            CommonHelper.WriteComponentsWithoutDownloadURLToKpi(sourceNotAvailable, lstReleaseNotCreated, appSetting.SW360.URL,DuplicateComponentsByPirlId);
         }
 
         private static string GetComponentAvailabilityStatus(List<Components> componentsAvailable, Components component)

--- a/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
+++ b/src/LCT.SW360PackageCreator/LCT.SW360PackageCreator.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>SW360PackageCreator</AssemblyName>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 		<RootNamespace>LCT.SW360PackageCreator</RootNamespace>
 	</PropertyGroup>
 

--- a/src/LCT.SW360PackageCreator/PackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/PackageDownloader.cs
@@ -97,15 +97,7 @@ namespace LCT.SW360PackageCreator
             string correctVersion = string.Empty;
             Result result = ListTagsOfComponent(component);
 
-            string[] taglist;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                taglist = result?.StdOut?.Split("\r\n") ?? Array.Empty<string>();
-            }
-            else
-            {
-                taglist = result?.StdOut?.Split("\n") ?? Array.Empty<string>();
-            }
+            string[] taglist = GetTagListFromResult(result);
             string baseVersion = GetBaseVersion(component.Version);
 
             foreach (string item in taglist)
@@ -145,8 +137,23 @@ namespace LCT.SW360PackageCreator
             }
             Logger.Debug($"componentName - given version:{component.Version}, correctVersion:{correctVersion}");
             return correctVersion;
-        }       
-        
+        }
+        private static string[] GetTagListFromResult(Result result)
+        {
+            if (result == null || string.IsNullOrEmpty(result.StdOut))
+            {
+                return [];
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return result.StdOut.Split(new[] { "\r\n" }, StringSplitOptions.None);
+            }
+            else
+            {
+                return result.StdOut.Split(new[] { "\n" }, StringSplitOptions.None);
+            }
+        }
         private static string GetBaseVersion(string version)
         {
             try

--- a/src/LCT.SW360PackageCreator/PackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/PackageDownloader.cs
@@ -27,6 +27,8 @@ namespace LCT.SW360PackageCreator
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly List<DownloadedSourceInfo> m_downloadedSourceInfos = new List<DownloadedSourceInfo>();
         private const string Source = "source";
+        private static readonly string[] WindowsLineSeparators = ["\r\n"];
+        private static readonly string[] UnixLineSeparators = ["\n"];
 
         public async Task<string> DownloadPackage(ComparisonBomData component, string localPathforDownload)
         {
@@ -147,11 +149,11 @@ namespace LCT.SW360PackageCreator
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return result.StdOut.Split(new[] { "\r\n" }, StringSplitOptions.None);
+                return result.StdOut.Split(WindowsLineSeparators, StringSplitOptions.None);
             }
             else
             {
-                return result.StdOut.Split(new[] { "\n" }, StringSplitOptions.None);
+                return result.StdOut.Split(UnixLineSeparators, StringSplitOptions.None);
             }
         }
         private static string GetBaseVersion(string version)

--- a/src/LCT.Services.UTest/Sw360ServiceTest.cs
+++ b/src/LCT.Services.UTest/Sw360ServiceTest.cs
@@ -594,9 +594,9 @@ namespace LCT.Services.UTest
             var result = (bool)ValidateProjectTypePurlMethod.Invoke(null, new object[] { sw360Component, component });
 
             Assert.IsFalse(result);
-            Assert.IsTrue(component.InValidComponentByPurlid);
+            Assert.IsTrue(component.InvalidComponentByPurlId);
             Assert.AreEqual("http://test/component/123", component.ComponentLink);
-            Assert.AreEqual("123", component.ComponentID);
+            Assert.AreEqual("123", component.ComponentId);
 
             // Check that it was added to the invalid list
             var list = (List<Components>)InvalidComponentsField.GetValue(null);
@@ -616,9 +616,9 @@ namespace LCT.Services.UTest
 
             HandleMismatchedPurlIdMethod.Invoke(null, new object[] { sw360Component, component });
 
-            Assert.IsTrue(component.InValidComponentByPurlid);
+            Assert.IsTrue(component.InvalidComponentByPurlId);
             Assert.AreEqual("http://test/component/456", component.ComponentLink);
-            Assert.AreEqual("456", component.ComponentID);
+            Assert.AreEqual("456", component.ComponentId);
 
             var list = (List<Components>)InvalidComponentsField.GetValue(null);
             Assert.IsTrue(list.Contains(component));

--- a/src/LCT.Services.UTest/Sw360ServiceTest.cs
+++ b/src/LCT.Services.UTest/Sw360ServiceTest.cs
@@ -36,6 +36,11 @@ namespace LCT.Services.UTest
             typeof(Sw360Service).GetField("InvalidComponentsIdentifiedByPurlId", BindingFlags.Static | BindingFlags.NonPublic);
         private static readonly MethodInfo RemoveInvalidComponentsByPurlIdMethod =
            typeof(Sw360Service).GetMethod("RemoveInvalidComponentsByPurlId", BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly MethodInfo AddToAvailableListMethod =
+           typeof(Sw360Service).GetMethod("AddToAvailableList", BindingFlags.Static | BindingFlags.NonPublic);
+
+        private static readonly FieldInfo AvailableComponentListField =
+            typeof(Sw360Service).GetField("availableComponentList", BindingFlags.Static | BindingFlags.NonPublic);
 
         [SetUp]
         public void Setup()
@@ -684,6 +689,36 @@ namespace LCT.Services.UTest
 
             Assert.AreEqual(1, components.Count);
             Assert.AreEqual("libapt-pkg6.0", components[0].Name);
+        }
+        [Test]
+        public void AddToAvailableList_AddsComponentWithCorrectProperties()
+        {
+            // Arrange
+            var sw360Release = new Sw360Releases
+            {
+                Name = "TestLib",
+                Version = "2.1.0",
+                // Simulate Links property with Self.Href
+                Links = new Links { Self = new Self { Href = "http://sw360/release/123" } }
+            };
+            var component = new Components
+            {
+                ReleaseExternalId = "rel-ext-1",
+                ComponentExternalId = "comp-ext-1"
+            };
+
+            // Act
+            AddToAvailableListMethod.Invoke(null, new object[] { sw360Release, component });
+
+            // Assert
+            var list = (List<Components>)AvailableComponentListField.GetValue(null);
+            Assert.AreEqual(1, list.Count);
+            var added = list[0];
+            Assert.AreEqual("TestLib", added.Name);
+            Assert.AreEqual("2.1.0", added.Version);
+            Assert.AreEqual("http://sw360/release/123", added.ReleaseLink);
+            Assert.AreEqual("rel-ext-1", added.ReleaseExternalId);
+            Assert.AreEqual("comp-ext-1", added.ComponentExternalId);
         }
     }
 }

--- a/src/LCT.Services/Interface/ISW360Service.cs
+++ b/src/LCT.Services/Interface/ISW360Service.cs
@@ -29,5 +29,6 @@ namespace LCT.Services.Interface
         Task<Sw360AttachmentHash> GetAttachmentDownloadLink(string releaseAttachmentUrl);
 
         Task<string> GetUploadDescriptionfromSW360(string componentName, string componetVersion, string sw360url);
+        Task<List<Components>> GetDuplicateComponentsByPurlId(List<Components> listOfComponentsToBom);
     }
 }

--- a/src/LCT.Services/Interface/ISW360Service.cs
+++ b/src/LCT.Services/Interface/ISW360Service.cs
@@ -29,6 +29,6 @@ namespace LCT.Services.Interface
         Task<Sw360AttachmentHash> GetAttachmentDownloadLink(string releaseAttachmentUrl);
 
         Task<string> GetUploadDescriptionfromSW360(string componentName, string componetVersion, string sw360url);
-        Task<List<Components>> GetDuplicateComponentsByPurlId(List<Components> listOfComponentsToBom);
+        List<Components> GetDuplicateComponentsByPurlId();
     }
 }

--- a/src/LCT.Services/LCT.Services.csproj
+++ b/src/LCT.Services/LCT.Services.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/LCT.Services/Sw360Service.cs
+++ b/src/LCT.Services/Sw360Service.cs
@@ -411,15 +411,15 @@ namespace LCT.Services
         private static bool ValidateProjectTypePurl(Sw360Components sw360Component, Components component)
         {
             if (string.IsNullOrEmpty(component?.ProjectType)
-                || !Dataconstant.PurlCheck().TryGetValue(component.ProjectType.ToUpperInvariant(), out string projectPurlId))
+                || !Dataconstant.PurlCheck().TryGetValue(component.ProjectType.ToUpperInvariant(), out string projectPurlCheckId))
             {
                 return false;
             }
 
-            Logger.Debug($"GetAvailableComponenentsList(): Validating with PURL ID: {projectPurlId}");
+            Logger.Debug($"GetAvailableComponenentsList(): Validating with PURL ID: {projectPurlCheckId}");
 
-            bool hasMatchingExternalId = sw360Component.ExternalIds.Package_Url?.Contains(projectPurlId, StringComparison.OrdinalIgnoreCase) == true
-                || sw360Component.ExternalIds.Purl_Id?.Contains(projectPurlId, StringComparison.OrdinalIgnoreCase) == true;
+            bool hasMatchingExternalId = sw360Component.ExternalIds.Package_Url?.Contains(projectPurlCheckId, StringComparison.OrdinalIgnoreCase) == true
+                || sw360Component.ExternalIds.Purl_Id?.Contains(projectPurlCheckId, StringComparison.OrdinalIgnoreCase) == true;
 
             if (!hasMatchingExternalId)
             {
@@ -436,9 +436,9 @@ namespace LCT.Services
             Logger.Debug($"GetAvailableComponenentsList(): Component Name '{component.Name}' PURL ID mismatched with SW360 component PURL ID");
             Logger.Warn($"Component Name '{component.Name}' already exists in SW360 with different package type PURL ID. Skipping this component.");
 
-            component.InValidComponentByPurlid = true;
+            component.InvalidComponentByPurlId = true;
             component.ComponentLink = sw360Component.Links?.Self?.Href;
-            component.ComponentID = CommonHelper.GetSubstringOfLastOccurance(component.ComponentLink, "/");
+            component.ComponentId = CommonHelper.GetSubstringOfLastOccurance(component.ComponentLink, "/");
             InvalidComponentsIdentifiedByPurlId.Add(component);
         }
 

--- a/src/LCT.Services/Sw360Service.cs
+++ b/src/LCT.Services/Sw360Service.cs
@@ -42,6 +42,7 @@ namespace LCT.Services
         private readonly ISW360ApicommunicationFacade m_SW360ApiCommunicationFacade;
         private readonly ISW360CommonService m_SW360CommonService;
         private static List<Components> availableComponentList = new List<Components>();
+        private static readonly List<Components> InvalidComponentsIdentifiedByPurlId = new List<Components>();
         public Sw360Service(ISW360ApicommunicationFacade sw360ApiCommunicationFacade, IEnvironmentHelper _environmentHelper)
         {
             m_SW360ApiCommunicationFacade = sw360ApiCommunicationFacade;
@@ -53,6 +54,10 @@ namespace LCT.Services
             m_SW360ApiCommunicationFacade = sw360ApiCommunicationFacade;
             m_SW360CommonService = sw360CommonService;
             environmentHelper = _environmentHelper;
+        }
+        public async Task<List<Components>> GetDuplicateComponentsByPurlId(List<Components> listOfComponentsToBom)
+        {
+            return InvalidComponentsIdentifiedByPurlId;
         }
 
         public async Task<List<Components>> GetAvailableReleasesInSw360(List<Components> listOfComponentsToBom)
@@ -309,7 +314,7 @@ namespace LCT.Services
             foreach (Components component in listOfComponentsToBom)
             {
                 if (await CheckReleaseExistenceByExternalId(component) ||
-                       CheckAvailabilityByNameAndVersion(sw360Releases, component))
+                       CheckAvailabilityByNameAndVersion(sw360Releases, component, sw360ComponentList))
                 {
                     Logger.Debug($"GetAvailableComponenentsList():  Release Exist : Release name - {component.Name}, version - {component.Version}");
                 }
@@ -323,38 +328,130 @@ namespace LCT.Services
                     // Do Nothing or to be implemented
                 }
             }
-
+            if (InvalidComponentsIdentifiedByPurlId.Count != 0)
+            {
+                listOfComponentsToBom.RemoveAll(component =>
+                    InvalidComponentsIdentifiedByPurlId.Any(invalid =>
+                        invalid.Name?.Trim().Equals(component.Name?.Trim(), StringComparison.OrdinalIgnoreCase) == true &&
+                        invalid.Version?.Trim().Equals(component.Version?.Trim(), StringComparison.OrdinalIgnoreCase) == true &&
+                        invalid.ReleaseExternalId?.Equals(component.ReleaseExternalId) == true
+                    ));
+            }
             return availableComponentList;
         }
 
-        private static bool CheckAvailabilityByNameAndVersion(IList<Sw360Releases> sw360Releases, Components component)
+        private static bool CheckAvailabilityByNameAndVersion(IList<Sw360Releases> sw360Releases, Components component, IList<Sw360Components> sw360ComponentList)
         {
-            //checking for release existance with name and version
-            bool isReleaseAvailable = false;
-            Sw360Releases sw360Release =
-                sw360Releases.FirstOrDefault(x => x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
+            Logger.Debug($"CheckAvailabilityByNameAndVersion(): Starting check for component '{component?.Name}' version '{component?.Version}'");
+
+            var sw360Release = FindMatchingRelease(sw360Releases, component);
+            if (sw360Release == null)
+            {
+                return false;
+            }
+
+            var sw360Component = FindMatchingComponent(sw360ComponentList, component);
+            if (sw360Component == null)
+            {
+                return false;
+            }
+
+            return ValidateAndProcessComponent(sw360Release, sw360Component, component);
+        }
+
+        private static Sw360Releases FindMatchingRelease(IList<Sw360Releases> sw360Releases, Components component)
+        {
+            // Find regular version match
+            var sw360Release = sw360Releases.FirstOrDefault(x =>
+                x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
                 && x.Version?.Trim().ToLowerInvariant() == component?.Version?.Trim().ToLowerInvariant());
 
+            // Check for Debian specific version if needed
             if (sw360Release == null && component.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["DEBIAN"]))
             {
                 string debianVersion = $"{component?.Version?.Trim().ToLowerInvariant() ?? string.Empty}.debian";
-                sw360Release = sw360Releases.FirstOrDefault(x => x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
-                && x.Version?.Trim().ToLowerInvariant() == debianVersion);
+                sw360Release = sw360Releases.FirstOrDefault(x =>
+                    x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant()
+                    && x.Version?.Trim().ToLowerInvariant() == debianVersion);
             }
 
-            if (sw360Release != null)
+            return sw360Release;
+        }
+
+        private static Sw360Components FindMatchingComponent(IList<Sw360Components> sw360ComponentList, Components component)
+        {
+            return sw360ComponentList.FirstOrDefault(x =>
+                x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant());
+        }
+
+        private static bool ValidateAndProcessComponent(Sw360Releases sw360Release, Sw360Components sw360Component, Components component)
+        {
+            // If no external IDs exist, add to available list
+            if (string.IsNullOrEmpty(sw360Component?.ExternalIds?.Package_Url)
+                && string.IsNullOrEmpty(sw360Component?.ExternalIds?.Purl_Id))
             {
-                availableComponentList.Add(new Components()
-                {
-                    Name = sw360Release.Name,
-                    Version = sw360Release.Version,
-                    ReleaseLink = sw360Release.Links?.Self?.Href,
-                    ReleaseExternalId = component.ReleaseExternalId,
-                    ComponentExternalId = component.ComponentExternalId
-                });
-                isReleaseAvailable = true;
+                AddToAvailableList(sw360Release, component);
+                return true;
             }
-            return isReleaseAvailable;
+
+            // Log external IDs for debugging
+            Logger.Debug($"GetAvailableComponenentsList(): Component Name - {component.Name}, Version - {component.Version} " +
+                        $"validating Externalids list - {sw360Component.ExternalIds?.Package_Url},{sw360Component.ExternalIds?.Purl_Id}");
+
+            // Validate project type and PURL
+            if (!ValidateProjectTypePurl(sw360Component, component))
+            {
+                return false;
+            }
+
+            AddToAvailableList(sw360Release, component);
+            return true;
+        }
+
+        private static bool ValidateProjectTypePurl(Sw360Components sw360Component, Components component)
+        {
+            if (string.IsNullOrEmpty(component?.ProjectType)
+                || !Dataconstant.PurlCheck().TryGetValue(component.ProjectType.ToUpperInvariant(), out string projectPurlId))
+            {
+                return false;
+            }
+
+            Logger.Debug($"GetAvailableComponenentsList(): Validating with PURL ID: {projectPurlId}");
+
+            bool hasMatchingExternalId = sw360Component.ExternalIds.Package_Url?.Contains(projectPurlId, StringComparison.OrdinalIgnoreCase) == true
+                || sw360Component.ExternalIds.Purl_Id?.Contains(projectPurlId, StringComparison.OrdinalIgnoreCase) == true;
+
+            if (!hasMatchingExternalId)
+            {
+                HandleMismatchedPurlId(sw360Component, component);
+                return false;
+            }
+
+            Logger.Debug($"GetAvailableComponenentsList(): Component Name'{component.Name}' PURL check ID matched with SW360 component PURL ID");
+            return true;
+        }
+
+        private static void HandleMismatchedPurlId(Sw360Components sw360Component, Components component)
+        {
+            Logger.Debug($"GetAvailableComponenentsList(): Component Name '{component.Name}' PURL ID mismatched with SW360 component PURL ID");
+            Logger.Warn($"Component Name '{component.Name}' already exists in SW360 with different package type PURL ID. Skipping this component.");
+
+            component.InValidComponentByPurlid = true;
+            component.ComponentLink = sw360Component.Links?.Self?.Href;
+            component.ComponentID = CommonHelper.GetSubstringOfLastOccurance(component.ComponentLink, "/");
+            InvalidComponentsIdentifiedByPurlId.Add(component);
+        }
+
+        private static void AddToAvailableList(Sw360Releases sw360Release, Components component)
+        {
+            availableComponentList.Add(new Components
+            {
+                Name = sw360Release.Name,
+                Version = sw360Release.Version,
+                ReleaseLink = sw360Release.Links?.Self?.Href,
+                ReleaseExternalId = component.ReleaseExternalId,
+                ComponentExternalId = component.ComponentExternalId
+            });
         }
 
         private async Task<IList<Sw360Components>> GetAvailableComponenentsListFromSw360()

--- a/src/LCT.Telemetry/LCT.Telemetry.csproj
+++ b/src/LCT.Telemetry/LCT.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-		<Version>8.2.0</Version>
+		<Version>8.2.1</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/SW360IntegrationTest/NPM/ComponentCreatorInitial.cs
+++ b/src/SW360IntegrationTest/NPM/ComponentCreatorInitial.cs
@@ -147,7 +147,7 @@ namespace SW360IntegrationTest.NPM
                 new AuthenticationHeaderValue(TestConstant.TestSw360TokenType, TestConstant.TestSw360TokenValue);
             string expectedname = "rxjs";
             string expectedversion = "6.5.4";
-            string expecteddownloadurl = "https://github.com/reactivex/rxjs.git";
+            string expecteddownloadurl = "https://github.com/reactivex/rxjs/tree/6.5.4";
             string expectedexternalid = "pkg:npm/rxjs@6.5.4";
             string expectedclearingState = "NEW_CLEARING";
             //url formation for retrieving component details

--- a/src/SW360IntegrationTest/Nuget/ComponentCreatorInitialNuget.cs
+++ b/src/SW360IntegrationTest/Nuget/ComponentCreatorInitialNuget.cs
@@ -148,7 +148,7 @@ namespace SW360IntegrationTest.Nuget
                 new AuthenticationHeaderValue(testParameters.SW360AuthTokenType, testParameters.SW360AuthTokenValue);
             string expectedname = "Newtonsoft.Json";
             string expectedversion = "12.0.3";
-            string expecteddownloadurl = "https://github.com/JamesNK/Newtonsoft.Json.git";
+            string expecteddownloadurl = "https://github.com/JamesNK/Newtonsoft.Json/tree/12.0.3";
             string expectedexternalid = "pkg:nuget/Newtonsoft.Json@12.0.3";
             //url formation for retrieving component details
             string url = TestConstant.Sw360ReleaseApi + TestConstant.componentNameUrl + "Newtonsoft.Json";


### PR DESCRIPTION
Bug Fix:
1.When creating release  user wants to know accurate information in newly created release. Changed source code folder name and Source download URL updated in SW360 .
2.Different package ecosystems can contain components with the same name. To accurately identify each valid component, we use the package URL (purl) ID. Component release and update details are then created and updated in SW360.