### PR TITLE
fix: Bugfix for Identify maven packages from jfrog repository

### DIFF
--- a/src/AritfactoryUploader.UTest/UploadToArtifactoryTest.cs
+++ b/src/AritfactoryUploader.UTest/UploadToArtifactoryTest.cs
@@ -28,7 +28,7 @@ namespace AritfactoryUploader.UTest
         [Test]
         [TestCase("NPM", "?to=/destination-repo//")]
         [TestCase("NUGET", "source-repo/package-name.1.0.0.nupkg?to=/destination-repo/package-name.1.0.0.nupkg")]
-        [TestCase("MAVEN", "source-repo/package-name/1.0.0?to=/destination-repo/package-name/1.0.0")]
+        [TestCase("MAVEN", "source-repo/?to=/destination-repo/")]
         [TestCase("CONAN", "source-repo/?to=/destination-repo/")]
         [TestCase("POETRY", "?to=/destination-repo/")]
         [TestCase("DEBIAN", "source-repo//package-name_1.0.0*?to=/destination-repo//package-name_1.0.0*")]
@@ -152,7 +152,7 @@ namespace AritfactoryUploader.UTest
         [Test]
         [TestCase("NPM", "?to=/destination-repo//")]
         [TestCase("NUGET", "source-repo/package-name.1.0.0.nupkg?to=/destination-repo/package-name.1.0.0.nupkg")]
-        [TestCase("MAVEN", "source-repo/package-name/1.0.0?to=/destination-repo/package-name/1.0.0")]
+        [TestCase("MAVEN", "source-repo/?to=/destination-repo/")]
         [TestCase("CONAN", "source-repo/?to=/destination-repo/")]
         [TestCase("POETRY", "?to=/destination-repo/")]
         [TestCase("DEBIAN", "source-repo//package-name_1.0.0*?to=/destination-repo//package-name_1.0.0*")]
@@ -217,12 +217,23 @@ namespace AritfactoryUploader.UTest
                     }
                 }
             };
+            commonAppSettings.Maven = new Config()
+            {
+                Artifactory = new Artifactory()
+                {
+                    ThirdPartyRepos = new List<ThirdPartyRepo>()
+                    {
+                        new() { Name = "maven-test" }
+                    }
+                }
+            };
             commonAppSettings.Directory.LogFolder = outFolder;
 
             //Act
             List<ComponentsToArtifactory> uploadList = await UploadToArtifactory.GetComponentsToBeUploadedToArtifactory(componentLists, commonAppSettings, displayPackagesInfo);
             // Assert
-            Assert.That(3, Is.EqualTo(uploadList.Count), "Checks for 2  no of components to upload");
+            Assert.That(4, Is.EqualTo(uploadList.Count), "Checks for 2  no of components to upload");
+            Assert.That("com/github/ulisesbocchio/jasypt-spring-boot-starter/3.0.5", Is.EqualTo(uploadList[3].Path),"checks for path of maven component");
         }
         [Test]
         public async Task GetComponentsToBeUploadedToArtifactory_GivenNotApprovedComponentList_ReturnsUploadList()
@@ -305,6 +316,16 @@ namespace AritfactoryUploader.UTest
                     }
                 }
             };
+            commonAppSettings.Maven = new Config()
+            {
+                Artifactory = new Artifactory()
+                {
+                    ThirdPartyRepos = new List<ThirdPartyRepo>()
+                    {
+                        new() { Name = "maven-test" }
+                    }
+                }
+            };
             commonAppSettings.Directory.LogFolder = outFolder;
 
 
@@ -312,7 +333,7 @@ namespace AritfactoryUploader.UTest
             List<ComponentsToArtifactory> uploadList = await UploadToArtifactory.GetComponentsToBeUploadedToArtifactory(componentLists, commonAppSettings, displayPackagesInfo);
 
             // Assert
-            Assert.That(4, Is.EqualTo(uploadList.Count), "Checks for 3 no of components to upload");
+            Assert.That(5, Is.EqualTo(uploadList.Count), "Checks for 3 no of components to upload");
         }
         [Test]
         public async Task GetSrcRepoDetailsForPyPiOrConanPackages_WhenPypiRepoExists_ReturnsArtifactoryRepoName()
@@ -602,6 +623,23 @@ namespace AritfactoryUploader.UTest
             comp4.Properties.Add(propinternal);
             comp4.Properties.Add(prop3);
             componentLists.Add(comp4);
+
+            Property prop4 = new Property
+            {
+                Name = Dataconstant.Cdx_ClearingState,
+                Value = "APPROVED"
+            };
+            Component comp5 = new Component
+            {
+                Name = "jasypt-spring-boot-starter",
+                Version = "3.0.5",
+                Purl = "pkg:maven/com.github.ulisesbocchio/jasypt-spring-boot-starter@3.0.5",
+                Group= "com.github.ulisesbocchio",
+                Properties = new List<Property>()
+            };
+            comp5.Properties.Add(propinternal);
+            comp5.Properties.Add(prop4);
+            componentLists.Add(comp5);
             return componentLists;
         }
     }

--- a/src/ArtifactoryUploader/UploadToArtifactory.cs
+++ b/src/ArtifactoryUploader/UploadToArtifactory.cs
@@ -13,6 +13,7 @@ using LCT.APICommunications.Model.AQL;
 using LCT.ArtifactoryUploader.Model;
 using LCT.Common;
 using LCT.Common.Constants;
+using LCT.Common.Model;
 using LCT.Services.Interface;
 using log4net;
 using System;
@@ -43,7 +44,7 @@ namespace LCT.ArtifactoryUploader
                     AqlResult aqlResult = await GetSrcRepoDetailsForComponent(item);
                     ComponentsToArtifactory components = new ComponentsToArtifactory()
                     {
-                        Name = !string.IsNullOrEmpty(item.Group) ? $"{item.Group}/{item.Name}" : item.Name,
+                        Name = !string.IsNullOrEmpty(item.Group) ? $"{item.Group}/{item.Name}" : item.Name,                        
                         PackageName = item.Name,
                         Version = item.Version,
                         Purl = item.Purl,
@@ -55,7 +56,7 @@ namespace LCT.ArtifactoryUploader
                         Token = appSettings.Jfrog.Token,
                         JfrogApi = appSettings.Jfrog.URL
                     };
-
+                   
                     if (aqlResult != null)
                     {
                         components.SrcRepoPathWithFullName = aqlResult.Repo + Dataconstant.ForwardSlash + aqlResult.Path + Dataconstant.ForwardSlash + aqlResult.Name;
@@ -67,7 +68,7 @@ namespace LCT.ArtifactoryUploader
                         components.PypiOrNpmCompName = string.Empty;
                     }
 
-                    components.Path = GetPackagePath(components, aqlResult);
+                    components.Path = GetPackagePath(components, aqlResult,item);
                     components.CopyPackageApiUrl = GetCopyURL(components);
                     components.MovePackageApiUrl = GetMoveURL(components);
                     components.JfrogPackageName = GetJfrogPackageName(components);
@@ -177,7 +178,7 @@ namespace LCT.ArtifactoryUploader
             return string.Empty;
         }
 
-        private static string GetPackagePath(ComponentsToArtifactory component, AqlResult aqlResult)
+        private static string GetPackagePath(ComponentsToArtifactory component, AqlResult aqlResult,Component item)
         {
             switch (component.ComponentType)
             {
@@ -206,7 +207,9 @@ namespace LCT.ArtifactoryUploader
                     }
 
                 case "MAVEN":
-                    return $"{component.Name}/{component.Version}";
+                    string groupWithSlash = !string.IsNullOrEmpty(item.Group) ? item.Group.Replace('.', '/') : string.Empty;
+                    string mavenPath= !string.IsNullOrEmpty(groupWithSlash) ? $"{groupWithSlash}/{item.Name}" : item.Name;
+                    return $"{mavenPath}/{component.Version}";
 
                 case "DEBIAN":
                     return $"pool/main/{component.Name[0]}/{component.Name}";
@@ -230,8 +233,8 @@ namespace LCT.ArtifactoryUploader
             }
             else if (component.ComponentType == "MAVEN")
             {
-                url = $"{component.JfrogApi}{ApiConstant.CopyPackageApi}{component.SrcRepoName}/{component.Name}/{component.Version}" +
-               $"?to=/{component.DestRepoName}/{component.Name}/{component.Version}";
+                url = $"{component.JfrogApi}{ApiConstant.CopyPackageApi}{component.SrcRepoName}/{component.Path}" +
+               $"?to=/{component.DestRepoName}/{component.Path}";
             }
             else if (component.ComponentType == "POETRY")
             {
@@ -273,8 +276,8 @@ namespace LCT.ArtifactoryUploader
             }
             else if (component.ComponentType == "MAVEN")
             {
-                url = $"{component.JfrogApi}{ApiConstant.MovePackageApi}{component.SrcRepoName}/{component.Name}/{component.Version}" +
-               $"?to=/{component.DestRepoName}/{component.Name}/{component.Version}";
+                url = $"{component.JfrogApi}{ApiConstant.MovePackageApi}{component.SrcRepoName}/{component.Path}" +
+               $"?to=/{component.DestRepoName}/{component.Path}";
             }
             else if (component.ComponentType == "POETRY")
             {

--- a/src/LCT.Common/CommonAppSettings.cs
+++ b/src/LCT.Common/CommonAppSettings.cs
@@ -6,10 +6,12 @@
 
 using LCT.Common.Constants;
 using LCT.Common.Model;
+using log4net;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 
 namespace LCT.Common
 {
@@ -147,6 +149,8 @@ namespace LCT.Common
     }
     public class Directory
     {
+        static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly EnvironmentHelper environmentHelper = new EnvironmentHelper();
         private string m_InputFolder;
         private string m_OutputFolder;
         private string m_LogFolder;
@@ -159,16 +163,23 @@ namespace LCT.Common
             }
             set
             {
-                if (!AppDomain.CurrentDomain.FriendlyName.Contains("SW360PackageCreator") &&
-                    !AppDomain.CurrentDomain.FriendlyName.Contains("ArtifactoryUploader"))
+                try
                 {
-                    var folderAction = new FolderAction();
-                    folderAction.ValidateFolderPath(value);
-                    m_InputFolder = value;
+                    if (!AppDomain.CurrentDomain.FriendlyName.Contains("SW360PackageCreator") &&
+                    !AppDomain.CurrentDomain.FriendlyName.Contains("ArtifactoryUploader"))
+                    {
+                        var folderAction = new FolderAction();
+                        folderAction.ValidateFolderPath(value);
+                        m_InputFolder = value;
+                    }
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    Logger.Error($"Input file folder not found : {value}");
+                    environmentHelper.CallEnvironmentExit(-1);
                 }
             }
         }
-
         public string OutputFolder
         {
             get

--- a/src/LCT.SW360PackageCreator/ComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/ComponentCreator.cs
@@ -656,7 +656,7 @@ namespace LCT.SW360PackageCreator
             }
             else
             {
-                if (!string.IsNullOrEmpty(item.ReleaseID) && (!string.IsNullOrEmpty(item.DownloadUrl) || item.DownloadUrl.Equals(Dataconstant.DownloadUrlNotFound)))
+                if (!string.IsNullOrEmpty(item.ReleaseID) && !string.IsNullOrEmpty(item.DownloadUrl) && item.DownloadUrl != Dataconstant.DownloadUrlNotFound)
                 {
                     await TriggeringFossologyUploadAndUpdateAdditionalData(item, sw360CreatorService, appSettings);
                 }

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -110,6 +110,8 @@ namespace LCT.SW360PackageCreator
             else if (component.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["POETRY"]))
             {
                 downloadPath = await GetAttachmentUrlList(component, localPathforDownload);
+                downloadPath = ConvertZipToTarGzIfNeeded(downloadPath);
+
             }
             else if (component.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["CONAN"]))
             {
@@ -133,7 +135,18 @@ namespace LCT.SW360PackageCreator
 
             return downloadPath;
         }
-
+        private static string ConvertZipToTarGzIfNeeded(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                return filePath;
+            if (filePath.EndsWith(FileConstant.ZipFileExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                string tarGzFilePath = Path.ChangeExtension(filePath, FileConstant.TargzFileExtension);
+                File.Copy(filePath, tarGzFilePath, true);
+                return tarGzFilePath;
+            }
+            return filePath;
+        }
         private static async Task DownloadDependencyList(ComparisonBomData component)
         {
             string localPathforDownload = $"{Path.GetTempPath()}ClearingTool\\DownloadedFiles/";

--- a/src/LCT.SW360PackageCreator/URLHelper.cs
+++ b/src/LCT.SW360PackageCreator/URLHelper.cs
@@ -830,7 +830,7 @@ namespace LCT.SW360PackageCreator
                 {
                     var url = fileinfo["url"];
 
-                    if (!string.IsNullOrEmpty(url.ToString()) && url.ToString().EndsWith(FileConstant.TargzFileExtension))
+                    if (!string.IsNullOrEmpty(url.ToString()) && (url.ToString().EndsWith(FileConstant.TargzFileExtension) || url.ToString().EndsWith(FileConstant.ZipFileExtension)))
                     {
                         SourceURL = url.ToString();
                     }

--- a/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
+++ b/src/SW360IntegrationTest/Alpine/ComponentCreatorInitialAlpine.cs
@@ -9,7 +9,9 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -157,8 +159,15 @@ namespace SW360IntegrationTest.Alpine
             string version = responseDataForRelease.Version;
             string downloadurl = responseDataForRelease.SourceDownloadurl;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
 
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             Assert.AreEqual(expectedname, name, "Test Project Name");
             Assert.AreEqual(expectedversion, version, "Test Project  Version");
             Assert.AreEqual(expectedexternalid, externalid, "Test component external id");

--- a/src/SW360IntegrationTest/Conan/ComponentCreatorInitialConan.cs
+++ b/src/SW360IntegrationTest/Conan/ComponentCreatorInitialConan.cs
@@ -2,7 +2,9 @@
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -120,7 +122,44 @@ namespace SW360IntegrationTest.Conan
             Assert.IsTrue(responseData.Embedded.Sw360components.Count == 1);
 
         }
+        [Test, Order(4)]
+        public async Task ReleaseCreation__AfterSuccessfulExeRun_ReturnsClearingStateAsNewClearing()
+        {
+            //Setting the httpclient
+            var httpClient = new HttpClient() { };
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(testParameters.SW360AuthTokenType, testParameters.SW360AuthTokenValue);
+            string expectedname = "rapidjson";
+            string expectedversion = "1.1.0";
+            string expecteddownloadurl = "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz";
+            string expectedexternalid = "pkg:conan/rapidjson@1.1.0";
+            //url formation for retrieving component details
+            string url = TestConstant.Sw360ReleaseApi + TestConstant.componentNameUrl + "rapidjson";
+            string responseBody = await httpClient.GetStringAsync(url);//GET method         
+            var responseData = JsonConvert.DeserializeObject<ReleaseIdOfComponent>(responseBody);
+            string urlofreleaseid = responseData.Embedded.Sw360Releases[0].Links.Self.Href;
+            string responseForRelease = await httpClient.GetStringAsync(urlofreleaseid);//GET method for fetching the release details
+            var responseDataForRelease = JsonConvert.DeserializeObject<Releases>(responseForRelease);
 
+            string name = responseDataForRelease.Name;
+            string version = responseDataForRelease.Version;
+            string downloadurl = responseDataForRelease.SourceDownloadurl;
+            string externalid = responseDataForRelease.ExternalIds.Package_Url;
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
+
+            //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
+            Assert.AreEqual(expectedname, name, "Test Project Name");
+            Assert.AreEqual(expectedversion, version, "Test Project  Version");
+            Assert.AreEqual(expecteddownloadurl, downloadurl, "Test download Url of Entity Framework");
+            Assert.AreEqual(expectedexternalid, externalid, "Test component external id");
+        }
         private string CCTComparisonBomTestFile { get; set; }
         private string OutFolder { get; set; }
     }

--- a/src/SW360IntegrationTest/Debian/ComponentCreatorInitialDebian.cs
+++ b/src/SW360IntegrationTest/Debian/ComponentCreatorInitialDebian.cs
@@ -9,7 +9,9 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -158,8 +160,15 @@ namespace SW360IntegrationTest.Debian
             string version = responseDataForRelease.Version;
             string downloadurl = responseDataForRelease.SourceDownloadurl;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
 
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             Assert.AreEqual(expectedname, name, "Test Project Name");
             Assert.AreEqual(expectedversion, version, "Test Project  Version");
             Assert.AreEqual(expecteddownloadurl, downloadurl, "Test download Url of Entity Framework");

--- a/src/SW360IntegrationTest/Maven/ComponentCreatorInitialMaven.cs
+++ b/src/SW360IntegrationTest/Maven/ComponentCreatorInitialMaven.cs
@@ -9,7 +9,9 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -162,8 +164,15 @@ namespace SW360IntegrationTest.Maven
             string downloadurl = responseDataForRelease.SourceDownloadurl;
             string clearingState = responseDataForRelease.ClearingState;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
+            string releaseLink=responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound=releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
 
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             Assert.AreEqual(expectedname, name, "Test Project Name");
             Assert.AreEqual(expectedversion, version, "Test Project  Version");
             Assert.AreEqual(expecteddownloadurl, downloadurl, "Test download Url of Entity Framework");

--- a/src/SW360IntegrationTest/NPM/ComponentCreatorInitial.cs
+++ b/src/SW360IntegrationTest/NPM/ComponentCreatorInitial.cs
@@ -9,7 +9,9 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -163,8 +165,15 @@ namespace SW360IntegrationTest.NPM
             string downloadurl = responseDataForRelease.SourceDownloadurl;
             string clearingState = responseDataForRelease.ClearingState;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
 
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             if (responseData.Embedded.Sw360Releases.Count > 0)
             {
                 //In Case Multiple Releases found just checking for Name & other details.

--- a/src/SW360IntegrationTest/Nuget/ComponentCreatorInitialNuget.cs
+++ b/src/SW360IntegrationTest/Nuget/ComponentCreatorInitialNuget.cs
@@ -9,6 +9,7 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -164,7 +165,15 @@ namespace SW360IntegrationTest.Nuget
             string clearingState = responseDataForRelease.ClearingState;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
 
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
+
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             Assert.AreEqual(expectedname, name, "Test Project Name");
             Assert.AreEqual(expectedversion, version, "Test Project  Version");
             Assert.AreEqual(expecteddownloadurl, downloadurl, "Test download Url of Entity Framework");

--- a/src/SW360IntegrationTest/Python/ComponentCreatorInitialPython.cs
+++ b/src/SW360IntegrationTest/Python/ComponentCreatorInitialPython.cs
@@ -10,7 +10,9 @@ using CycloneDX.Models;
 using LCT.APICommunications.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -161,7 +163,15 @@ namespace SW360IntegrationTest.Python
             string clearingState = responseDataForRelease.ClearingState;
             string externalid = responseDataForRelease.ExternalIds.Package_Url;
 
+            string releaseLink = responseDataForRelease.Links.Self.Href;
+            string releaseResponseBody = await httpClient.GetStringAsync(releaseLink);//GET method
+            var releasesInfo = JsonConvert.DeserializeObject<ReleasesInfo>(releaseResponseBody);
+
+            var releaseAttachments = releasesInfo?.Embedded?.Sw360attachments ?? new List<Sw360Attachments>();
+            bool AttachmentFound = releaseAttachments.Any(x => x.AttachmentType.Equals("SOURCE"));
+
             //Assert
+            Assert.IsTrue(AttachmentFound, "Expected a SOURCE attachment to be present in the release.");
             Assert.AreEqual(expectedname, name, "Test Project Name");
             Assert.AreEqual(expectedversion, version, "Test Project  Version");
             Assert.AreEqual(expecteddownloadurl, downloadurl, "Test download Url of Entity Framework");


### PR DESCRIPTION
1.Identify Maven packages from jfrog repository in antifactory uploader.
2.Identify Source code for "azure storage blob" and upload in SW360.
3.Handled correctly if source code not found for release ,Fossology process won't trigger.
4.Handled correctly DirectoryNotfound exception  while empty folder given in Input folder for package identifier.

Added UT and IT