### PR TITLE
feat: Code clean up in package identifier and package creator

### DIFF
--- a/src/LCT.Common.UTests/CommonAppSettingsTests.cs
+++ b/src/LCT.Common.UTests/CommonAppSettingsTests.cs
@@ -18,7 +18,7 @@ namespace LCT.Common.UTest
         {
 
             // Override to always throw DirectoryNotFoundException
-            protected new void ValidateFolderPath(string value)
+            protected static void ValidateFolderPath(string value)
             {
                 throw new DirectoryNotFoundException("Test exception");
             }
@@ -32,10 +32,11 @@ namespace LCT.Common.UTest
             bool exitCalled = false;
             envHelperMock.Setup(e => e.CallEnvironmentExit(It.IsAny<int>())).Callback(() => exitCalled = true);
 
-            var testDirectory = new TestDirectory(envHelperMock.Object);
-
-            // Act
-            testDirectory.InputFolder = "nonexistent_path";
+            var testDirectory = new TestDirectory(envHelperMock.Object)
+            {
+                // Act
+                InputFolder = "nonexistent_path"
+            };
 
             // Assert
             Assert.IsTrue(exitCalled, "Environment exit should be called on DirectoryNotFoundException.");

--- a/src/LCT.Facade/SW360ApicommunicationFacade.cs
+++ b/src/LCT.Facade/SW360ApicommunicationFacade.cs
@@ -16,161 +16,331 @@ namespace LCT.Facade
 {
 
     /// <summary>
-    ///SW3360 Api Communication Facade class
+    /// SW360 Api Communication Facade class
     /// </summary>
     public class SW360ApicommunicationFacade : ISW360ApicommunicationFacade
     {
+        #region Fields
         private readonly ISw360ApiCommunication m_sw360ApiCommunication;
+        #endregion
 
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SW360ApicommunicationFacade"/> class.
+        /// </summary>
+        /// <param name="sw360ConnectionSettings">The SW360 connection settings.</param>
         public SW360ApicommunicationFacade(SW360ConnectionSettings sw360ConnectionSettings)
         {
             m_sw360ApiCommunication = new SW360Apicommunication(sw360ConnectionSettings);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SW360ApicommunicationFacade"/> class.
+        /// </summary>
+        /// <param name="sw360ApiCommunication">The SW360 API communication instance.</param>
         public SW360ApicommunicationFacade(ISw360ApiCommunication sw360ApiCommunication)
         {
             m_sw360ApiCommunication = sw360ApiCommunication;
         }
+        #endregion
 
+        #region Methods
+        /// <summary>
+        /// Asynchronously gets all projects from SW360.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation that returns the projects as a JSON string.</returns>
         public Task<string> GetProjects()
         {
             return m_sw360ApiCommunication.GetProjects();
         }
 
+        /// <summary>
+        /// Asynchronously gets all SW360 users.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation that returns the users as a JSON string.</returns>
         public Task<string> GetSw360Users()
         {
             return m_sw360ApiCommunication.GetSw360Users();
         }
 
+        /// <summary>
+        /// Asynchronously gets projects by name from SW360.
+        /// </summary>
+        /// <param name="projectName">The project name to search for.</param>
+        /// <returns>A task representing the asynchronous operation that returns the projects as a JSON string.</returns>
         public Task<string> GetProjectsByName(string projectName)
         {
             return m_sw360ApiCommunication.GetProjectsByName(projectName);
         }
 
+        /// <summary>
+        /// Asynchronously gets projects by tag from SW360.
+        /// </summary>
+        /// <param name="projectTag">The project tag to search for.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetProjectsByTag(string projectTag)
         {
             return m_sw360ApiCommunication.GetProjectsByTag(projectTag);
         }
 
+        /// <summary>
+        /// Asynchronously gets a project by ID from SW360.
+        /// </summary>
+        /// <param name="projectId">The project identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetProjectById(string projectId)
         {
             return m_sw360ApiCommunication.GetProjectById(projectId);
         }
 
+        /// <summary>
+        /// Asynchronously gets all releases from SW360.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation that returns the releases as a JSON string.</returns>
         public Task<string> GetReleases()
         {
             return m_sw360ApiCommunication.GetReleases();
         }
+        
+        /// <summary>
+        /// Asynchronously triggers the FOSSology process for a release.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="sw360link">The SW360 link.</param>
+        /// <returns>A task representing the asynchronous operation that returns the process status as a JSON string.</returns>
         public Task<string> TriggerFossologyProcess(string releaseId, string sw360link)
         {
             return m_sw360ApiCommunication.TriggerFossologyProcess(releaseId, sw360link);
         }
+        
+        /// <summary>
+        /// Asynchronously checks the FOSSology process status.
+        /// </summary>
+        /// <param name="link">The link to check the status.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> CheckFossologyProcessStatus(string link)
         {
             return m_sw360ApiCommunication.CheckFossologyProcessStatus(link);
         }
+        
+        /// <summary>
+        /// Asynchronously gets all components from SW360.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation that returns the components as a JSON string.</returns>
         public Task<string> GetComponents()
         {
             return m_sw360ApiCommunication.GetComponents();
         }
 
+        /// <summary>
+        /// Asynchronously gets a release by ID from SW360.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetReleaseById(string releaseId)
         {
             return m_sw360ApiCommunication.GetReleaseById(releaseId);
         }
 
+        /// <summary>
+        /// Asynchronously gets a release by link from SW360.
+        /// </summary>
+        /// <param name="releaseLink">The release link.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetReleaseByLink(string releaseLink)
         {
             return m_sw360ApiCommunication.GetReleaseByLink(releaseLink);
         }
 
+        /// <summary>
+        /// Asynchronously links releases to a project in SW360.
+        /// </summary>
+        /// <param name="httpContent">The HTTP content containing release information.</param>
+        /// <param name="sw360ProjectId">The SW360 project identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public async Task<HttpResponseMessage> LinkReleasesToProject(HttpContent httpContent, string sw360ProjectId)
         {
             return await m_sw360ApiCommunication.LinkReleasesToProject(httpContent, sw360ProjectId);
         }
 
+        /// <summary>
+        /// Asynchronously creates a component in SW360.
+        /// </summary>
+        /// <param name="createComponentContent">The component creation data.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public async Task<HttpResponseMessage> CreateComponent(CreateComponent createComponentContent)
         {
             return await m_sw360ApiCommunication.CreateComponent(createComponentContent);
         }
 
+        /// <summary>
+        /// Asynchronously creates a release in SW360.
+        /// </summary>
+        /// <param name="createReleaseContent">The release creation data.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public async Task<HttpResponseMessage> CreateRelease(Releases createReleaseContent)
         {
             return await m_sw360ApiCommunication.CreateRelease(createReleaseContent);
         }
 
+        /// <summary>
+        /// Asynchronously gets the release of a component by component ID.
+        /// </summary>
+        /// <param name="componentId">The component identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release data as a JSON string.</returns>
         public Task<string> GetReleaseOfComponentById(string componentId)
         {
             return m_sw360ApiCommunication.GetReleaseOfComponentById(componentId);
         }
 
+        /// <summary>
+        /// Asynchronously gets release attachments from SW360.
+        /// </summary>
+        /// <param name="releaseAttachmentsUrl">The release attachments URL.</param>
+        /// <returns>A task representing the asynchronous operation that returns the attachments as a JSON string.</returns>
         public Task<string> GetReleaseAttachments(string releaseAttachmentsUrl)
         {
             return m_sw360ApiCommunication.GetReleaseAttachments(releaseAttachmentsUrl);
         }
 
+        /// <summary>
+        /// Asynchronously gets attachment information from SW360.
+        /// </summary>
+        /// <param name="attachmentUrl">The attachment URL.</param>
+        /// <returns>A task representing the asynchronous operation that returns the attachment information as a JSON string.</returns>
         public Task<string> GetAttachmentInfo(string attachmentUrl)
         {
             return m_sw360ApiCommunication.GetAttachmentInfo(attachmentUrl);
         }
 
+        /// <summary>
+        /// Downloads an attachment using WebClient.
+        /// </summary>
+        /// <param name="attachmentDownloadLink">The attachment download link.</param>
+        /// <param name="fileName">The file name to save the attachment.</param>
         public void DownloadAttachmentUsingWebClient(string attachmentDownloadLink, string fileName)
         {
             m_sw360ApiCommunication.DownloadAttachmentUsingWebClient(attachmentDownloadLink, fileName);
         }
 
+        /// <summary>
+        /// Asynchronously updates a release in SW360.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="httpContent">The HTTP content containing the update data.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public async Task<HttpResponseMessage> UpdateRelease(string releaseId, HttpContent httpContent)
         {
             return await m_sw360ApiCommunication.UpdateRelease(releaseId, httpContent);
         }
 
+        /// <summary>
+        /// Asynchronously updates a component in SW360.
+        /// </summary>
+        /// <param name="componentId">The component identifier.</param>
+        /// <param name="httpContent">The HTTP content containing the update data.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public async Task<HttpResponseMessage> UpdateComponent(string componentId, HttpContent httpContent)
         {
             return await m_sw360ApiCommunication.UpdateComponent(componentId, httpContent);
         }
 
+        /// <summary>
+        /// Attaches component source to SW360.
+        /// </summary>
+        /// <param name="attachReport">The attachment report data.</param>
+        /// <param name="comparisonBomData">The comparison BOM data.</param>
+        /// <returns>The attachment result.</returns>
         public string AttachComponentSourceToSW360(AttachReport attachReport, ComparisonBomData comparisonBomData)
         {
             return m_sw360ApiCommunication.AttachComponentSourceToSW360(attachReport, comparisonBomData);
         }
 
+        /// <summary>
+        /// Asynchronously gets a release by component name from SW360.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release data as a JSON string.</returns>
         public Task<string> GetReleaseByCompoenentName(string componentName)
         {
             return m_sw360ApiCommunication.GetReleaseByCompoenentName(componentName);
         }
 
+        /// <summary>
+        /// Asynchronously gets component details by URL from SW360.
+        /// </summary>
+        /// <param name="componentLink">The component link.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetComponentDetailsByUrl(string componentLink)
         {
 
             return m_sw360ApiCommunication.GetComponentDetailsByUrl(componentLink);
         }
 
+        /// <summary>
+        /// Asynchronously gets a component by name from SW360.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <returns>A task representing the asynchronous operation that returns the component data as a JSON string.</returns>
         public Task<string> GetComponentByName(string componentName)
         {
             return m_sw360ApiCommunication.GetComponentByName(componentName);
         }
+        
+        /// <summary>
+        /// Asynchronously gets a component using name from SW360.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetComponentUsingName(string componentName)
         {
             return m_sw360ApiCommunication.GetComponentUsingName(componentName);
         }
 
+        /// <summary>
+        /// Asynchronously updates a linked release in SW360.
+        /// </summary>
+        /// <param name="projectId">The project identifier.</param>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="updateLinkedRelease">The linked release update data.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> UpdateLinkedRelease(string projectId, string releaseId, UpdateLinkedRelease updateLinkedRelease)
         {
             return m_sw360ApiCommunication.UpdateLinkedRelease(projectId, releaseId, updateLinkedRelease);
         }
 
+        /// <summary>
+        /// Asynchronously gets a release by external ID from SW360.
+        /// </summary>
+        /// <param name="purlId">The PURL identifier.</param>
+        /// <param name="externalIdKey">The external ID key (optional).</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetReleaseByExternalId(string purlId, string externalIdKey = "")
         {
             return m_sw360ApiCommunication.GetReleaseByExternalId(purlId, externalIdKey);
         }
 
+        /// <summary>
+        /// Asynchronously gets a component by external ID from SW360.
+        /// </summary>
+        /// <param name="purlId">The PURL identifier.</param>
+        /// <param name="externalIdKey">The external ID key (optional).</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetComponentByExternalId(string purlId, string externalIdKey = "")
         {
             return m_sw360ApiCommunication.GetComponentByExternalId(purlId, externalIdKey);
         }
+        
+        /// <summary>
+        /// Asynchronously gets all releases with all data from SW360.
+        /// </summary>
+        /// <param name="page">The page number.</param>
+        /// <param name="pageEntries">The number of entries per page.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         public Task<HttpResponseMessage> GetAllReleasesWithAllData(int page, int pageEntries)
         {
             return m_sw360ApiCommunication.GetAllReleasesWithAllData(page, pageEntries);
         }
-    }
-}
+        #endregion
+     }
+ }

--- a/src/LCT.PackageIdentifier.UTest/CargoProcessorTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/CargoProcessorTests.cs
@@ -240,7 +240,6 @@ namespace LCT.PackageIdentifier.UTest
             var aqlResultList = new List<AqlResult>();
             var component = new Component { Name = "Test", Version = "1.0" };
             var bomHelper = new Mock<IBomHelper>();
-            string jfrogPackageName, jfrogRepoPath;
             var method = typeof(CargoProcessor).GetMethod("GetArtifactoryRepoName", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
 
             var repoName = (string)method.Invoke(null, new object[] { aqlResultList, component, bomHelper.Object, null, null });

--- a/src/LCT.PackageIdentifier.UTest/DisplayInformationTests.cs
+++ b/src/LCT.PackageIdentifier.UTest/DisplayInformationTests.cs
@@ -67,7 +67,6 @@ namespace LCT.PackageIdentifier.UTest
             Assert.AreEqual(string.Empty, result);
         }
         private CommonAppSettings appSettings;
-        private CatoolInfo caToolInformation;
         private MemoryAppender memoryAppender;
 
         [SetUp]

--- a/src/LCT.PackageIdentifier/AlpineProcesser.cs
+++ b/src/LCT.PackageIdentifier/AlpineProcesser.cs
@@ -26,13 +26,27 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class AlpineProcessor(ICycloneDXBomParser cycloneDXBomParser, ISpdxBomParser spdxBomParser) : IParser
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ICycloneDXBomParser _cycloneDXBomParser = cycloneDXBomParser;
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
         private static Bom ListUnsupportedComponentsForBom = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
+        #endregion
 
-        #region public method
+        #region Properties
+        #endregion
 
+        #region Constructors
+        // Primary constructor parameters are declared on the class.
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Parses Alpine package files from the configured input folder and builds a BOM.
+        /// </summary>
+        /// <param name="appSettings">Application settings with input and processing options.</param>
+        /// <param name="unSupportedBomList">Reference BOM that will be populated with unsupported components.</param>
+        /// <returns>BOM built from discovered Alpine packages.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<string> configFiles;
@@ -77,12 +91,26 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Removes components excluded in settings from the provided BOM.
+        /// </summary>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="cycloneDXBOM">BOM to filter.</param>
+        /// <returns>Filtered BOM.</returns>
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             return CommonHelper.RemoveExcludedComponentsFromBom(appSettings, cycloneDXBOM,
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Asynchronously retrieves repository details for the provided components and returns a modified list.
+        /// </summary>
+        /// <param name="componentsForBOM">List of components to enrich.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="jFrogService">JFrog service to query (may be null).</param>
+        /// <param name="bomhelper">BOM helper utilities.</param>
+        /// <returns>Asynchronously returns the modified list of components.</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings,
                                                           IJFrogService jFrogService,
                                                           IBomHelper bomhelper)
@@ -97,6 +125,14 @@ namespace LCT.PackageIdentifier
             return modifiedBOM;
         }
 
+        /// <summary>
+        /// Asynchronously identifies internal components using JFrog and BOM helper; returns input unchanged in current implementation.
+        /// </summary>
+        /// <param name="componentData">Component identification data to analyze.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="jFrogService">JFrog service to query.</param>
+        /// <param name="bomhelper">BOM helper utilities.</param>
+        /// <returns>Asynchronously returns the (possibly modified) component identification data.</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData,
             CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
@@ -104,10 +140,13 @@ namespace LCT.PackageIdentifier
             return componentData;
         }
 
-        #endregion
-
-        #region private methods
-
+        /// <summary>
+        /// Parses a CycloneDX SBOM file and returns a list of AlpinePackage entries.
+        /// </summary>
+        /// <param name="filePath">Path to the CycloneDX/ SPDX file.</param>
+        /// <param name="dependenciesForBOM">List to collect BOM dependencies.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <returns>List of parsed AlpinePackage instances.</returns>
         public List<AlpinePackage> ParseCycloneDX(string filePath, List<Dependency> dependenciesForBOM, CommonAppSettings appSettings)
         {
             List<AlpinePackage> alpinePackages = new List<AlpinePackage>();
@@ -115,6 +154,13 @@ namespace LCT.PackageIdentifier
             return alpinePackages;
         }
 
+        /// <summary>
+        /// Extracts package details from a BOM file and populates provided collections with packages and dependencies.
+        /// </summary>
+        /// <param name="filePath">Path to the BOM file.</param>
+        /// <param name="alpinePackages">Reference list to append discovered Alpine packages.</param>
+        /// <param name="dependenciesForBOM">List to collect dependencies discovered in the BOM.</param>
+        /// <param name="appSettings">Application settings.</param>
         private void ExtractDetailsForJson(string filePath, ref List<AlpinePackage> alpinePackages, List<Dependency> dependenciesForBOM, CommonAppSettings appSettings)
         {
             Bom listUnsupportedComponents = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
@@ -151,6 +197,10 @@ namespace LCT.PackageIdentifier
             ListUnsupportedComponentsForBom.Dependencies.AddRange(listUnsupportedComponents.Dependencies);
         }
 
+        /// <summary>
+        /// Removes duplicate components from the provided list and updates KPI data.
+        /// </summary>
+        /// <param name="listofComponents">Reference to the component list to deduplicate.</param>
         private static void GetDistinctComponentList(ref List<AlpinePackage> listofComponents)
         {
             int initialCount = listofComponents.Count;
@@ -160,6 +210,12 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.DuplicateComponents = initialCount - listofComponents.Count;
         }
 
+        /// <summary>
+        /// Builds a release external id (purl) for the specified name and version.
+        /// </summary>
+        /// <param name="name">Package name.</param>
+        /// <param name="version">Package version.</param>
+        /// <returns>Release external id as a PURL string.</returns>
         private static string GetReleaseExternalId(string name, string version)
         {
             version = WebUtility.UrlEncode(version);
@@ -168,6 +224,11 @@ namespace LCT.PackageIdentifier
             return $"{Dataconstant.PurlCheck()["ALPINE"]}{Dataconstant.ForwardSlash}{name}@{version}?arch=source";
         }
 
+        /// <summary>
+        /// Extracts the distro query portion from an Alpine package PURL if present.
+        /// </summary>
+        /// <param name="alpinePackage">Alpine package to inspect.</param>
+        /// <returns>Distro query string including leading token, or empty string if not found.</returns>
         private static string GetDistro(AlpinePackage alpinePackage)
         {
             var distroIndex = alpinePackage.PurlID.LastIndexOf("distro");
@@ -178,6 +239,11 @@ namespace LCT.PackageIdentifier
             return alpinePackage.PurlID[distroIndex..];
         }
 
+        /// <summary>
+        /// Forms a list of CycloneDX Component objects from parsed Alpine packages, adding PURLs and properties.
+        /// </summary>
+        /// <param name="listOfComponents">List of parsed Alpine packages.</param>
+        /// <returns>List of components ready for BOM insertion.</returns>
         private static List<Component> FormComponentReleaseExternalID(List<AlpinePackage> listOfComponents)
         {
             List<Component> listComponentForBOM = new List<Component>();
@@ -198,6 +264,12 @@ namespace LCT.PackageIdentifier
             }
             return listComponentForBOM;
         }
+
+        /// <summary>
+        /// Adds properties to a CycloneDX component based on SPDX information or discovery metadata.
+        /// </summary>
+        /// <param name="prop">Parsed Alpine package information.</param>
+        /// <param name="component">Component to enrich.</param>
         private static void AddComponentProperties(AlpinePackage prop, Component component)
         {
             if (prop.SpdxComponentDetails.SpdxComponent)
@@ -213,6 +285,13 @@ namespace LCT.PackageIdentifier
                 component.Properties.Add(identifierType);
             }
         }
+
+        /// <summary>
+        /// Sets SPDX related details on an AlpinePackage when the source file is an SPDX file.
+        /// </summary>
+        /// <param name="filePath">Source file path.</param>
+        /// <param name="package">Alpine package to update.</param>
+        /// <param name="componentInfo">Component information parsed from the BOM.</param>
         private static void SetSpdxComponentDetails(string filePath, AlpinePackage package, Component componentInfo)
         {
             if (filePath.EndsWith(FileConstant.SPDXFileExtension))
@@ -223,6 +302,9 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        #endregion
+
+        #region Events
         #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/BomCreator.cs
+++ b/src/LCT.PackageIdentifier/BomCreator.cs
@@ -37,29 +37,46 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class BomCreator : IBomCreator
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         public readonly static BomKpiData bomKpiData = new();
         ComponentIdentification componentData;
         private readonly ICycloneDXBomParser CycloneDXBomParser;
         private readonly ISpdxBomParser SpdxBomParser;
-        public IJFrogService JFrogService { get; set; }
-        public IBomHelper BomHelper { get; set; }
-
         private readonly IFrameworkPackages _frameworkPackages;
         private readonly ICompositionBuilder _compositionBuilder;
         private readonly IRuntimeIdentifier _runtimeIdentifier;
 
         public static Jfrog jfrog { get; set; } = new Jfrog();
         public static SW360 sw360 { get; set; } = new SW360();
+        #endregion
+
+        #region Properties
+        public IJFrogService JFrogService { get; set; }
+        public IBomHelper BomHelper { get; set; }
+        #endregion
+
+        #region Constructors
         public BomCreator(ICycloneDXBomParser cycloneDXBomParser, IFrameworkPackages frameworkPackages, ICompositionBuilder compositionBuilder, ISpdxBomParser spdxBomParser, IRuntimeIdentifier runtimeIdentifier)
         {
             CycloneDXBomParser = cycloneDXBomParser;
-            _frameworkPackages = frameworkPackages;
+            _frameworkPackages = frameworkPackages; 
             _compositionBuilder = compositionBuilder;
             SpdxBomParser = spdxBomParser;
             _runtimeIdentifier = runtimeIdentifier;
         }
+        #endregion
+       
 
+        /// <summary>
+        /// Asynchronously generates a CycloneDX BOM from configured inputs and writes outputs (BOM, KPI files).
+        /// </summary>
+        /// <param name="appSettings">Application settings used for generation.</param>
+        /// <param name="bomHelper">BOM helper utilities.</param>
+        /// <param name="fileOperations">File operations helper used to write outputs.</param>
+        /// <param name="projectReleases">Project releases data used to enrich metadata.</param>
+        /// <param name="caToolInformation">CA tool information for telemetry/metadata.</param>
+        /// <returns>Asynchronously completes when generation finishes.</returns>
         public async Task GenerateBom(CommonAppSettings appSettings,
                                       IBomHelper bomHelper,
                                       IFileOperations fileOperations,
@@ -124,11 +141,25 @@ namespace LCT.PackageIdentifier
             Logger.Debug($"GenerateBom():End");
         }
 
+        /// <summary>
+        /// Writes contents to BOM by delegating to CycloneDX writer.
+        /// </summary>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="bomKpiData">KPI data structure to update.</param>
+        /// <param name="listOfComponentsToBom">BOM to write.</param>
+        /// <param name="defaultProjectName">Default project name used in file naming.</param>
         private static void WritecontentsToBOM(CommonAppSettings appSettings, BomKpiData bomKpiData, Bom listOfComponentsToBom, string defaultProjectName)
         {
             WriteContentToCycloneDxBOM(appSettings, listOfComponentsToBom, ref bomKpiData, defaultProjectName);
         }
 
+        /// <summary>
+        /// Writes a CycloneDX BOM file to the output folder, optionally merging with existing BOMs when configured.
+        /// </summary>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="listOfComponentsToBom">BOM object containing components and metadata.</param>
+        /// <param name="bomKpiData">KPI data reference that can be modified.</param>
+        /// <param name="defaultProjectName">Default project name used for file naming.</param>
         private static void WriteContentToCycloneDxBOM(CommonAppSettings appSettings, Bom listOfComponentsToBom, ref BomKpiData bomKpiData, string defaultProjectName)
         {
             FileOperations fileOperations = new FileOperations();
@@ -154,6 +185,11 @@ namespace LCT.PackageIdentifier
 
         }
 
+        /// <summary>
+        /// Asynchronously selects and invokes the appropriate package parser based on project type.
+        /// </summary>
+        /// <param name="appSettings">Application settings which include ProjectType.</param>
+        /// <returns>Asynchronously returns the generated BOM from the selected parser.</returns>
         private async Task<Bom> CallPackageParser(CommonAppSettings appSettings)
         {
             IParser parser;
@@ -194,6 +230,12 @@ namespace LCT.PackageIdentifier
             return new Bom();
         }
 
+        /// <summary>
+        /// Asynchronously runs component identification and enrichment using the provided parser.
+        /// </summary>
+        /// <param name="appSettings">Application settings used by the parser.</param>
+        /// <param name="parser">Parser that will parse package files and identify components.</param>
+        /// <returns>Asynchronously returns the composed BOM.</returns>
         private async Task<Bom> ComponentIdentification(CommonAppSettings appSettings, IParser parser)
         {
             ComponentIdentification lstOfComponents;
@@ -246,6 +288,12 @@ namespace LCT.PackageIdentifier
             bom.Dependencies.AddRange(unSupportedBomList.Dependencies);
             return bom;
         }
+
+        /// <summary>
+        /// Asynchronously checks connectivity to JFrog using the configured JFrog service.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing JFrog configuration.</param>
+        /// <returns>Asynchronously returns true when connection is successful or JFrog is not configured; otherwise false.</returns>
         public async Task<bool> CheckJFrogConnection(CommonAppSettings appSettings)
         {
             if (appSettings.Jfrog != null)
@@ -276,5 +324,9 @@ namespace LCT.PackageIdentifier
             return true;
 
         }
+        
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/BomHelper.cs
+++ b/src/LCT.PackageIdentifier/BomHelper.cs
@@ -33,16 +33,33 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class BomHelper : IBomHelper
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
 
-        #region public methods
+        #region Properties
+        #endregion
 
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Builds a URL that links to the project summary page in SW360.
+        /// </summary>
+        /// <param name="projectId">SW360 project identifier.</param>
+        /// <param name="sw360Url">Base SW360 URL.</param>
+        /// <returns>Full URL to the project's summary page.</returns>
         public string GetProjectSummaryLink(string projectId, string sw360Url)
         {
             Logger.Debug("starting method GetProjectSummaryLink");
             return $"{sw360Url}{ApiConstant.Sw360ProjectUrlApiSuffix}{projectId}";
         }
 
+        /// <summary>
+        /// Writes BOM KPI data to the console in a formatted table.
+        /// </summary>
+        /// <param name="bomKpiData">KPI data collected during BOM creation.</param>
         public void WriteBomKpiDataToConsole(BomKpiData bomKpiData)
         {
             KpiNames identifierKpiNames = IdentifyKpiNames(bomKpiData);
@@ -79,6 +96,12 @@ namespace LCT.PackageIdentifier
             CommonHelper.ProjectSummaryLink = bomKpiData.ProjectSummaryLink;
             LoggerHelper.WriteToConsoleTable(printList, printTimingList, bomKpiData.ProjectSummaryLink, Dataconstant.Identifier, identifierKpiNames);
         }
+
+        /// <summary>
+        /// Validates related signature/certificate files for an SPDX file and logs naming issues.
+        /// </summary>
+        /// <param name="filepath">Path to the SPDX file.</param>
+        /// <param name="appSettings">Application settings containing input folder info.</param>
         public static void NamingConventionOfSPDXFile(string filepath, CommonAppSettings appSettings)
         {
             string filename = Path.GetFileName(filepath);
@@ -99,6 +122,13 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Checks whether the related certificate/signature files exist in the input folder.
+        /// </summary>
+        /// <param name="inputFolder">Input folder path to search.</param>
+        /// <param name="relatedExtensions">Array of related file names to check.</param>
+        /// <param name="foundFiles">Dictionary to populate with found file paths keyed by name.</param>
+        /// <param name="missingFiles">List to populate with missing file names.</param>
         private static void CheckFileExistence(string inputFolder, string[] relatedExtensions,
             Dictionary<string, string> foundFiles, List<string> missingFiles)
         {
@@ -116,6 +146,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Logs errors for missing certificate/signature files using a helpful message.
+        /// </summary>
+        /// <param name="missingFiles">List of missing related files.</param>
+        /// <param name="filename">Base SPDX filename.</param>
         private static void HandleMissingFiles(List<string> missingFiles, string filename)
         {
             foreach (var missingFile in missingFiles)
@@ -131,6 +166,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Validates the found signature and certificate files for the SPDX file and logs warnings on failure.
+        /// </summary>
+        /// <param name="filepath">Path to the SPDX file.</param>
+        /// <param name="filename">SPDX file name.</param>
+        /// <param name="foundFiles">Dictionary of discovered related files.</param>
         private static void ValidateFoundFiles(string filepath, string filename, Dictionary<string, string> foundFiles)
         {
             string sigFilePath = foundFiles.TryGetValue($"{filename}.sig", out string sigFile) ? sigFile : string.Empty;
@@ -143,6 +184,13 @@ namespace LCT.PackageIdentifier
                 Logger.Warn($"Currently processing the SPDX file '{filename}' without signature verification.");
             }
         }
+
+        /// <summary>
+        /// Executes 'npm view' to retrieve the shasum for the specified package version.
+        /// </summary>
+        /// <param name="name">Package name.</param>
+        /// <param name="version">Package version.</param>
+        /// <returns>SHA sum string or empty string if unavailable.</returns>
         public static string GetHashCodeUsingNpmView(string name, string version)
         {
             string hashCode;
@@ -177,6 +225,12 @@ namespace LCT.PackageIdentifier
             return hashCode?.Trim() ?? string.Empty;
         }
 
+        /// <summary>
+        /// Executes Maven dependency:list to generate a dependency output file. (Obsolete)
+        /// </summary>
+        /// <param name="bomFilePath">Path to the POM or BOM file.</param>
+        /// <param name="depFilePath">Output dependency file path.</param>
+        /// <returns>Result containing process stdout/stderr.</returns>
         [Obsolete("not used")]
         [ExcludeFromCodeCoverage]
         public static Result GetDependencyList(string bomFilePath, string depFilePath)
@@ -208,6 +262,11 @@ namespace LCT.PackageIdentifier
 
         }
 
+        /// <summary>
+        /// Builds a display name for a component including group if available.
+        /// </summary>
+        /// <param name="item">CycloneDX component instance.</param>
+        /// <returns>Full name (group/name) or name if no group present.</returns>
         public string GetFullNameOfComponent(Component item)
         {
             if (!string.IsNullOrEmpty(item.Group))
@@ -220,6 +279,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Asynchronously retrieves AQL results for components from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">Array of repository names to query.</param>
+        /// <param name="jFrogService">JFrog service to execute queries.</param>
+        /// <returns>Asynchronously returns a list of AQL results aggregated from all repos.</returns>
         public async Task<List<AqlResult>> GetListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService)
         {
             List<AqlResult> aqlResultList = new();
@@ -234,6 +299,13 @@ namespace LCT.PackageIdentifier
 
             return aqlResultList;
         }
+
+        /// <summary>
+        /// Asynchronously retrieves NPM-style component information from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">Array of repository names.</param>
+        /// <param name="jFrogService">JFrog service to execute queries.</param>
+        /// <returns>Asynchronously returns aggregated AQL results for NPM components.</returns>
         public async Task<List<AqlResult>> GetNpmListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService)
         {
             List<AqlResult> aqlResultList = new();
@@ -248,6 +320,13 @@ namespace LCT.PackageIdentifier
 
             return aqlResultList;
         }
+
+        /// <summary>
+        /// Asynchronously retrieves Cargo-style component information from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">Array of repository names.</param>
+        /// <param name="jFrogService">JFrog service to execute queries.</param>
+        /// <returns>Asynchronously returns aggregated AQL results for Cargo components.</returns>
         public async Task<List<AqlResult>> GetCargoListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService)
         {
             List<AqlResult> aqlResultList = new();
@@ -262,6 +341,13 @@ namespace LCT.PackageIdentifier
 
             return aqlResultList;
         }
+
+        /// <summary>
+        /// Asynchronously retrieves PyPI-style component information from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">Array of repository names.</param>
+        /// <param name="jFrogService">JFrog service to execute queries.</param>
+        /// <returns>Asynchronously returns aggregated AQL results for PyPI components.</returns>
         public async Task<List<AqlResult>> GetPypiListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService)
         {
             List<AqlResult> aqlResultList = new();
@@ -277,6 +363,15 @@ namespace LCT.PackageIdentifier
             return aqlResultList;
         }
 
+        /// <summary>
+        /// Parses a CycloneDX or SPDX BOM file and returns a Bom instance. Unsupported components are accumulated.
+        /// </summary>
+        /// <param name="filePath">Path to the BOM file.</param>
+        /// <param name="spdxBomParser">SPDX parser instance.</param>
+        /// <param name="cycloneDXBomParser">CycloneDX parser instance.</param>
+        /// <param name="appSettings">Application settings used for SPDX validation.</param>
+        /// <param name="listUnsupportedComponents">Reference list where unsupported components will be added.</param>
+        /// <returns>Parsed Bom object.</returns>
         public static Bom ParseBomFile(string filePath, ISpdxBomParser spdxBomParser, ICycloneDXBomParser cycloneDXBomParser, CommonAppSettings appSettings, ref Bom listUnsupportedComponents)
         {
             if (filePath.EndsWith(FileConstant.SPDXFileExtension))
@@ -292,6 +387,12 @@ namespace LCT.PackageIdentifier
                 return cycloneDXBomParser.ParseCycloneDXBom(filePath);
             }
         }
+
+        /// <summary>
+        /// Maps BomKpiData properties to human readable KPI names used for printing.
+        /// </summary>
+        /// <param name="bomKpiData">KPI data instance to map.</param>
+        /// <returns>Structure with KPI display name mappings.</returns>
         private static KpiNames IdentifyKpiNames(BomKpiData bomKpiData)
         {
             KpiNames identifierKpiNames = new KpiNames();
@@ -315,6 +416,13 @@ namespace LCT.PackageIdentifier
             return identifierKpiNames;
         }
 
+        /// <summary>
+        /// Filters and returns components that match the specified purl prefix for a project type.
+        /// </summary>
+        /// <param name="componentsForBOM">List of components to evaluate.</param>
+        /// <param name="purlPrefix">PURL prefix to match (project type specific).</param>
+        /// <param name="projectType">Project type label used in logging.</param>
+        /// <returns>List of components that match the exclusion criteria.</returns>
         public static List<Component> GetExcludedComponentsList(List<Component> componentsForBOM, string purlPrefix, string projectType)
         {
             List<Component> components = new List<Component>();
@@ -336,6 +444,11 @@ namespace LCT.PackageIdentifier
             }
             return components;
         }
+
+        /// <summary>
+        /// Removes duplicate components from the list based on name, version and PURL, updating KPI counts.
+        /// </summary>
+        /// <param name="listofComponents">Reference to the list of components to deduplicate.</param>
         public static void GetDistinctComponentList(ref List<Component> listofComponents)
         {
             int initialCount = listofComponents.Count;
@@ -346,12 +459,22 @@ namespace LCT.PackageIdentifier
 
         }
 
+        /// <summary>
+        /// Removes components excluded by settings from the provided BOM and updates KPI counters.
+        /// </summary>
+        /// <param name="appSettings">Application settings with exclude lists.</param>
+        /// <param name="cycloneDXBOM">BOM to filter.</param>
+        /// <returns>Filtered BOM.</returns>
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             return CommonHelper.RemoveExcludedComponentsFromBom(appSettings, cycloneDXBOM,
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Adds standard properties for components that were manually added to the BOM.
+        /// </summary>
+        /// <param name="componentsForBOM">List of manually added components to update.</param>
         public static void GetDetailsforManuallyAddedComp(List<Component> componentsForBOM)
         {
             foreach (var component in componentsForBOM)
@@ -367,6 +490,9 @@ namespace LCT.PackageIdentifier
                 component.Properties = properties;
             }
         }
+        #endregion
+
+        #region Events
         #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/BomValidator.cs
+++ b/src/LCT.PackageIdentifier/BomValidator.cs
@@ -16,12 +16,32 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public static class BomValidator
     {
+        #region Fields
+        #endregion
+
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Asynchronously validates application settings by querying SW360 for the project name and delegating to CommonHelper validation.
+        /// </summary>
+        /// <param name="appSettings">Application settings to validate.</param>
+        /// <param name="bomService">SW360 project service used to retrieve project information.</param>
+        /// <param name="projectReleases">Project releases information used during validation.</param>
+        /// <returns>Asynchronously returns an integer validation code (e.g. -1 on failure).</returns>
         public static async Task<int> ValidateAppSettings(CommonAppSettings appSettings, ISw360ProjectService bomService, ProjectReleases projectReleases)
         {
             string sw360ProjectName = await bomService.GetProjectNameByProjectIDFromSW360(appSettings.SW360.ProjectID, appSettings.SW360.ProjectName, projectReleases);
 
             return CommonHelper.ValidateSw360Project(sw360ProjectName, projectReleases?.ClearingState, projectReleases?.Name, appSettings);
         }
+        #endregion
 
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/CargoProcessor.cs
+++ b/src/LCT.PackageIdentifier/CargoProcessor.cs
@@ -29,12 +29,28 @@ namespace LCT.PackageIdentifier
 {
     public class CargoProcessor(ICycloneDXBomParser cycloneDXBomParser, ISpdxBomParser spdxBomParser) : CycloneDXBomParser, IParser
     {
+        #region Fields
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ICycloneDXBomParser _cycloneDXBomParser = cycloneDXBomParser;
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
         private static Bom ListUnsupportedComponentsForBom = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
-        #region public methods
+        #endregion
+
+        #region Properties
+        #endregion
+
+        #region Constructors
+        // Primary constructor parameters are declared on the class.
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Parses input Cargo files and builds a BOM representing discovered components and dependencies.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and configuration.</param>
+        /// <param name="unSupportedBomList">Reference BOM to be filled with unsupported components.</param>
+        /// <returns>Constructed CycloneDX Bom.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<Component> componentsForBOM;
@@ -59,6 +75,14 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Asynchronously identifies which components are internal by comparing against JFrog AQL results.
+        /// </summary>
+        /// <param name="componentData">Component identification data that contains components to check.</param>
+        /// <param name="appSettings">Application settings containing repository configuration.</param>
+        /// <param name="jFrogService">JFrog service to query for components.</param>
+        /// <param name="bomhelper">BOM helper with repository query helpers.</param>
+        /// <returns>Asynchronously returns the updated component identification data with internal components separated.</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData, CommonAppSettings appSettings,
             IJFrogService jFrogService, IBomHelper bomhelper)
         {
@@ -75,6 +99,14 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Asynchronously enriches components with JFrog repository details (repo name, filename, path, hashes).
+        /// </summary>
+        /// <param name="componentsForBOM">List of components to enrich.</param>
+        /// <param name="appSettings">Application settings that may contain repository lists.</param>
+        /// <param name="jFrogService">JFrog service for queries.</param>
+        /// <param name="bomhelper">BOM helper utilities.</param>
+        /// <returns>Asynchronously returns a modified list of components with JFrog details.</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
             string[] repoList = CommonHelper.GetRepoList(appSettings);
@@ -92,10 +124,15 @@ namespace LCT.PackageIdentifier
 
 
 
-        #endregion
-
-        #region private methods
-
+        /// <summary>
+        /// Processes a single Cargo component, selects the artifactory repo and sets properties/hashes.
+        /// </summary>
+        /// <param name="component">Component to process.</param>
+        /// <param name="aqlResultList">AQL results from JFrog used to find matches.</param>
+        /// <param name="bomhelper">BOM helper utilities.</param>
+        /// <param name="appSettings">Application settings for repo configuration.</param>
+        /// <param name="projectType">Property representing the project type to be added.</param>
+        /// <returns>Processed component with properties set.</returns>
         private static Component ProcessCargoComponent(Component component, List<AqlResult> aqlResultList, IBomHelper bomhelper, CommonAppSettings appSettings, Property projectType)
         {
             string repoName = GetArtifactoryRepoName(aqlResultList, component, bomhelper, out string jfrogPackageNameWhlExten, out string jfrogRepoPath);
@@ -115,6 +152,11 @@ namespace LCT.PackageIdentifier
             return componentVal;
         }
 
+        /// <summary>
+        /// Updates KPI counters based on which repository a component was found in.
+        /// </summary>
+        /// <param name="repoValue">Repository name where component was found.</param>
+        /// <param name="appSettings">Application settings containing repo configuration.</param>
         private static void UpdateCargoKpiDataBasedOnRepo(string repoValue, CommonAppSettings appSettings)
         {
             if (repoValue == appSettings.Cargo.DevDepRepo)
@@ -145,6 +187,15 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Determines the artifactory repository name for a component by analyzing AQL results and heuristics.
+        /// </summary>
+        /// <param name="aqlResultList">List of AQL results to search.</param>
+        /// <param name="component">Component to find in artifactory.</param>
+        /// <param name="bomHelper">Bom helper instance for naming utilities.</param>
+        /// <param name="jfrogPackageName">Outputs the found JFrog package name.</param>
+        /// <param name="jfrogRepoPath">Outputs the JFrog repository path for the package.</param>
+        /// <returns>Repository name or NotFound indicator.</returns>
         private static string GetArtifactoryRepoName(List<AqlResult> aqlResultList,
                                                      Component component,
                                                      IBomHelper bomHelper,
@@ -189,6 +240,13 @@ namespace LCT.PackageIdentifier
 
             return repoName;
         }
+        /// <summary>
+        /// Finds the JFrog stored name for a Cargo component based on crate properties in AQL results.
+        /// </summary>
+        /// <param name="name">Component name.</param>
+        /// <param name="version">Component version.</param>
+        /// <param name="aqlResultList">AQL results to search.</param>
+        /// <returns>JFrog stored name or a sentinel when not found.</returns>
         private static string GetJfrogNameOfCargoComponent(string name, string version, List<AqlResult> aqlResultList)
         {
             string nameVerison = string.Empty;
@@ -200,6 +258,11 @@ namespace LCT.PackageIdentifier
             }
             return nameVerison;
         }
+        /// <summary>
+        /// Builds a repository path string from an AQL result entry.
+        /// </summary>
+        /// <param name="aqlResult">AQL result entry.</param>
+        /// <returns>Formatted repository path including repo, path and name.</returns>
         private static string GetJfrogRepoPath(AqlResult aqlResult)
         {
             if (string.IsNullOrEmpty(aqlResult.Path) || aqlResult.Path.Equals("."))
@@ -210,6 +273,11 @@ namespace LCT.PackageIdentifier
             return $"{aqlResult.Repo}/{aqlResult.Path}/{aqlResult.Name}";
         }
 
+        /// <summary>
+        /// Parses input files to populate the BOM object with components and dependencies.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and config.</param>
+        /// <param name="bom">Reference to the BOM to populate.</param>
         private void ParsingInputFileForBOM(CommonAppSettings appSettings, ref Bom bom)
         {
             var configFiles = FolderScanner.FileScanner(appSettings.Directory.InputFolder, appSettings.Cargo);
@@ -225,6 +293,15 @@ namespace LCT.PackageIdentifier
             BomFileDataProcess(ref bom, componentsForBOM, dependencies, templateBomFilePaths, appSettings);
         }
 
+        /// <summary>
+        /// Processes a single input file and dispatches to the appropriate parser depending on extension.
+        /// </summary>
+        /// <param name="filepath">Input file path.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="componentsForBOM">Component list to append to.</param>
+        /// <param name="dependencies">Dependency list to append to.</param>
+        /// <param name="templateBomFilePaths">List to collect SBOM template paths.</param>
         private void InputfilesProcess(
             string filepath,
             CommonAppSettings appSettings,
@@ -252,6 +329,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Parses a Cargo metadata.json file and adds components/dependencies to the provided lists.
+        /// </summary>
+        /// <param name="filepath">Path to the metadata.json file.</param>
+        /// <param name="componentsForBOM">Component list to append to.</param>
+        /// <param name="dependencies">Dependency list to append to.</param>
         private static void ParseCargoFile(string filepath, List<Component> componentsForBOM, List<Dependency> dependencies)
         {
             Logger.Debug($"ParsingInputFileForBOM():Found metadata.json: {filepath}");
@@ -263,6 +346,14 @@ namespace LCT.PackageIdentifier
             dependencies.AddRange(deps);
         }
 
+        /// <summary>
+        /// Parses an SPDX file, validates signature convention, and extracts components and dependencies.
+        /// </summary>
+        /// <param name="filepath">SPDX file path.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="componentsForBOM">Component list to append to.</param>
+        /// <param name="dependencies">Dependency list to append to.</param>
         private void ParseSpdxFile(
             string filepath,
             CommonAppSettings appSettings,
@@ -283,6 +374,13 @@ namespace LCT.PackageIdentifier
             ListUnsupportedComponentsForBom.Dependencies.AddRange(listUnsupportedComponents.Dependencies);
         }
 
+        /// <summary>
+        /// Parses a CycloneDX file and extracts components to the BOM, adding Siemens direct property where needed.
+        /// </summary>
+        /// <param name="filepath">Path to the CycloneDX file.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="componentsForBOM">Component list to append to.</param>
         private void ParseCycloneDxFile(
             string filepath,
             CommonAppSettings appSettings,
@@ -300,6 +398,14 @@ namespace LCT.PackageIdentifier
             componentsForBOM.AddRange(bom.Components);
         }
 
+        /// <summary>
+        /// Finalizes BOM file data processing: deduplicates, merges dependencies, applies templates and filters.
+        /// </summary>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="componentsForBOM">Collected components.</param>
+        /// <param name="dependencies">Collected dependencies.</param>
+        /// <param name="templateBomFilePaths">Template BOM files found.</param>
+        /// <param name="appSettings">Application settings.</param>
         private void BomFileDataProcess(
             ref Bom bom,
             List<Component> componentsForBOM,
@@ -330,6 +436,12 @@ namespace LCT.PackageIdentifier
             bom.Dependencies = bom.Dependencies?.GroupBy(x => new { x.Ref }).Select(y => y.First()).ToList();
         }
 
+        /// <summary>
+        /// Reads Cargo metadata JSON and transforms it into CycloneDX components and dependencies.
+        /// </summary>
+        /// <param name="metadataJsonPath">Path to cargo metadata JSON file.</param>
+        /// <param name="components">Component output list.</param>
+        /// <param name="dependencies">Dependency output list.</param>
         private static void GetPackagesFromCargoMetadataJson(string metadataJsonPath, List<Component> components, List<Dependency> dependencies)
         {
             try
@@ -370,6 +482,12 @@ namespace LCT.PackageIdentifier
             }
 
         }
+        /// <summary>
+        /// Marks components as direct dependencies by inspecting the resolve root node.
+        /// </summary>
+        /// <param name="packageDetails">Parsed cargo package details.</param>
+        /// <param name="components">List of components to annotate.</param>
+        /// <param name="idToPurl">Mapping from package id to PURL.</param>
         public static void AddDirectDependencyProperty(CargoPackageDetails packageDetails, List<Component> components, Dictionary<string, string> idToPurl)
         {
             var directDependencyPurls = new List<string>();
@@ -398,6 +516,14 @@ namespace LCT.PackageIdentifier
                 component.Properties = properties;
             }
         }
+        /// <summary>
+        /// Parses cargo packages excluding workspace members and populates component and id maps.
+        /// </summary>
+        /// <param name="packageDetails">Parsed cargo package details.</param>
+        /// <param name="components">Component output list.</param>
+        /// <param name="idToComponent">Mapping from id to component.</param>
+        /// <param name="idToPurl">Mapping from id to purl.</param>
+        /// <param name="excludeIds">List of ids to exclude (workspace members).</param>
         private static void ParseCargoPackagesExcluding(CargoPackageDetails packageDetails, List<Component> components, Dictionary<string, Component> idToComponent, Dictionary<string, string> idToPurl, List<string> excludeIds)
         {
             if (packageDetails.Packages == null)
@@ -425,6 +551,9 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Analyzes dependency kinds for cargo nodes, excluding workspace ids, and adds CycloneDX dependencies.
+        /// </summary>
         private static void AnalyzeCargoDependencyKindsExcluding(
     CargoPackageDetails packageDetails,
     Dictionary<string, string> idToPurl,
@@ -446,7 +575,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
-
+        /// <summary>
+        /// Processes dependency entries for a resolve node and accumulates dev/build kinds by purl.
+        /// </summary>
+        /// <param name="node">Resolve node.</param>
+        /// <param name="idToPurl">Mapping from id to purl.</param>
+        /// <param name="purlToDevDependencyKinds">Mapping to accumulate kinds by purl.</param>
         private static void ProcessNodeDeps(
             CargoPackageDetails.Node node,
             Dictionary<string, string> idToPurl,
@@ -466,6 +600,13 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Validates a dep object and returns its PURL if resolvable.
+        /// </summary>
+        /// <param name="dep">Dependency entry.</param>
+        /// <param name="idToPurl">Mapping from id to purl.</param>
+        /// <param name="depPurl">Out param receiving resolved purl.</param>
+        /// <returns>True when dep is valid and mapped to a PURL; otherwise false.</returns>
         private static bool IsValidDep(CargoPackageDetails.Dep dep, Dictionary<string, string> idToPurl, out string depPurl)
         {
             depPurl = null;
@@ -474,6 +615,12 @@ namespace LCT.PackageIdentifier
             return idToPurl.TryGetValue(dep.Pkg, out depPurl);
         }
 
+        /// <summary>
+        /// Retrieves or creates the list of dependency kinds for a given purl.
+        /// </summary>
+        /// <param name="depPurl">Dependency purl key.</param>
+        /// <param name="purlToDevDependencyKinds">Map of purl to kinds.</param>
+        /// <returns>The list of kinds associated with the purl.</returns>
         private static List<string> GetOrCreateKindList(string depPurl, Dictionary<string, List<string>> purlToDevDependencyKinds)
         {
             if (!purlToDevDependencyKinds.TryGetValue(depPurl, out var dependencyKindList))
@@ -484,6 +631,11 @@ namespace LCT.PackageIdentifier
             return dependencyKindList;
         }
 
+        /// <summary>
+        /// Adds dependency kind strings from a Dep object to the provided list.
+        /// </summary>
+        /// <param name="dep">Dependency entry.</param>
+        /// <param name="dependencyKindList">List to append kinds to.</param>
         private static void AddDepKinds(CargoPackageDetails.Dep dep, List<string> dependencyKindList)
         {
             if (dep.DepKinds != null && dep.DepKinds.Count > 0)
@@ -499,6 +651,9 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Creates CycloneDX dependency entries for a node excluding workspace ids.
+        /// </summary>
         private static void AddCycloneDXDependencyExcluding(CargoPackageDetails.Node node, Dictionary<string, Component> idToComponent, string parentId, List<Dependency> dependencies, List<string> excludeIds)
         {
 
@@ -518,6 +673,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Adds an ExternalReference of type Distribution based on package repository info.
+        /// </summary>
+        /// <param name="component">Component to enrich.</param>
+        /// <param name="pkg">Cargo package data containing repository URL.</param>
         private static void AddSourceUrlExternalReference(Component component, CargoPackageDetails.Package pkg)
         {
             string sourceUrl = pkg.Repository;
@@ -532,6 +692,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Marks components as development/build dependencies based on analyzed kinds and updates KPI counters.
+        /// </summary>
+        /// <param name="components">Component list to annotate.</param>
+        /// <param name="purlToDevKinds">Mapping from purl to kinds.</param>
         private static void MarkCargoDevelopmentProperties(List<Component> components, Dictionary<string, List<string>> purlToDevKinds)
         {
             foreach (var component in components)
@@ -564,6 +729,12 @@ namespace LCT.PackageIdentifier
                 }
             }
         }
+        /// <summary>
+        /// Checks whether a given component exists in the provided AQL results (internal).
+        /// </summary>
+        /// <param name="aqlResultList">AQL results to search.</param>
+        /// <param name="component">Component to check.</param>
+        /// <returns>True when an internal match exists; otherwise false.</returns>
         private static bool IsInternalCargoComponent(List<AqlResult> aqlResultList, Component component)
         {
             if (aqlResultList.Exists(x => x.Properties.Any(p => p.Key == "crate.name" && p.Value == component.Name) && x.Properties.Any(p => p.Key == "crate.version" && p.Value == component.Version)))
@@ -574,6 +745,10 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Adds a discovered identifier property to every component in the list.
+        /// </summary>
+        /// <param name="components">Components to update.</param>
         private static void AddingIdentifierType(List<Component> components)
         {
             foreach (var component in components)
@@ -588,6 +763,10 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Adds Siemens direct dependency property to components based on BOM dependency refs.
+        /// </summary>
+        /// <param name="bom">BOM to update.</param>
         public static void AddSiemensDirectProperty(ref Bom bom)
         {
             List<string> cargoDirectDependencies = new List<string>();
@@ -610,6 +789,9 @@ namespace LCT.PackageIdentifier
 
             bom.Components = bomComponentsList;
         }
+        #endregion
+
+        #region Events
         #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/CommonIdentiferHelper.cs
+++ b/src/LCT.PackageIdentifier/CommonIdentiferHelper.cs
@@ -14,7 +14,22 @@ namespace LCT.PackageIdentifier
 {
     public static class CommonIdentiferHelper
     {
+        #region Fields
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
+        #endregion
+
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Returns the repository name for a prioritized order (release, devdep, dev) from AQL results.
+        /// </summary>
+        /// <param name="aqlResults">List of AQL results to inspect.</param>
+        /// <returns>Repository name matching the preferred order or a sentinel when not found.</returns>
         public static string GetRepodetailsFromPerticularOrder(List<AqlResult> aqlResults)
         {
             if (aqlResults == null)
@@ -39,6 +54,12 @@ namespace LCT.PackageIdentifier
                 return aqlResults.FirstOrDefault()?.Repo ?? NotFoundInRepo;
             }
         }
+
+        /// <summary>
+        /// Builds the BOM file name based on SW360 project settings or falls back to the basic SBOM name.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing SW360 configuration.</param>
+        /// <returns>Filename to use for the BOM output.</returns>
         public static string GetBomFileName(CommonAppSettings appSettings)
         {
             string bomFileName;
@@ -53,6 +74,12 @@ namespace LCT.PackageIdentifier
 
             return bomFileName;
         }
+
+        /// <summary>
+        /// Returns the default project name to use in file naming based on SW360 configuration or a fallback.
+        /// </summary>
+        /// <param name="appSettings">Application settings which may contain SW360 project info.</param>
+        /// <returns>Project name string for use as default.</returns>
         public static string GetDefaultProjectName(CommonAppSettings appSettings)
         {
             string projectName;
@@ -67,5 +94,9 @@ namespace LCT.PackageIdentifier
 
             return projectName;
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/CompositionBuilder.cs
+++ b/src/LCT.PackageIdentifier/CompositionBuilder.cs
@@ -20,10 +20,16 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class CompositionBuilder : ICompositionBuilder
     {
+        #region Fields
         private readonly ComponentConfig _config;
         private readonly string _basePurl;
         private RuntimeInfo _runtimeInfo;
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositionBuilder"/> class.
         /// </summary>
@@ -33,12 +39,16 @@ namespace LCT.PackageIdentifier
             _config = config ?? new ComponentConfig();
             _basePurl = Dataconstant.PurlCheck()["NUGET"];
         }
+        #endregion
 
+        #region Methods
         /// <summary>
         /// Adds compositions to the provided BOM based on the framework packages.
         /// </summary>
         /// <param name="bom">The BOM to which compositions will be added.</param>
         /// <param name="frameworkPackages">Framework packages grouped by framework moniker.</param>
+        /// <param name="runtimeInfo">Runtime information used to determine runtime package versions.</param>
+        /// <returns>void.</returns>
         public void AddCompositionsToBom(Bom bom, Dictionary<string, Dictionary<string, NuGetVersion>> frameworkPackages, RuntimeInfo runtimeInfo)
         {
             _runtimeInfo = runtimeInfo;
@@ -122,6 +132,10 @@ namespace LCT.PackageIdentifier
                 _ => version
             };
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 
     /// <summary>

--- a/src/LCT.PackageIdentifier/ConanProcessor.cs
+++ b/src/LCT.PackageIdentifier/ConanProcessor.cs
@@ -33,15 +33,27 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class ConanProcessor(ICycloneDXBomParser cycloneDXBomParser, ISpdxBomParser spdxBomParser) : CycloneDXBomParser, IParser
     {
-        #region fields
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ICycloneDXBomParser _cycloneDXBomParser = cycloneDXBomParser;
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
         private static Bom ListUnsupportedComponentsForBom = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
-
         #endregion
 
-        #region public methods
+        #region Properties
+        #endregion
+
+        #region Constructors
+        // Primary constructor parameters are declared on the class.
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Parses Conan dep.json input files and produces a CycloneDX BOM for the project.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and project type.</param>
+        /// <param name="unSupportedBomList">Reference BOM that will be filled with unsupported components found during parsing.</param>
+        /// <returns>Constructed CycloneDX BOM representing discovered components and dependencies.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<Component> componentsForBOM;
@@ -74,6 +86,14 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Asynchronously identifies internal Conan components by comparing BOM components to JFrog AQL results.
+        /// </summary>
+        /// <param name="componentData">Component identification input containing comparison BOM data.</param>
+        /// <param name="appSettings">Application settings with repository configuration.</param>
+        /// <param name="jFrogService">JFrog service used to query AQL results.</param>
+        /// <param name="bomhelper">BOM helper providing repository query helpers.</param>
+        /// <returns>Asynchronously returns the updated component identification data with internal components separated.</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData, CommonAppSettings appSettings,
             IJFrogService jFrogService, IBomHelper bomhelper)
         {
@@ -90,6 +110,14 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Asynchronously enriches the given components with JFrog repository details and returns the modified list.
+        /// </summary>
+        /// <param name="componentsForBOM">List of components to enrich with JFrog details.</param>
+        /// <param name="appSettings">Application settings providing repo lists and configuration.</param>
+        /// <param name="jFrogService">JFrog service used to query AQL results.</param>
+        /// <param name="bomhelper">BOM helper utilities for repository queries.</param>
+        /// <returns>Asynchronously returns a new list of components with repository properties and hashes set.</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
             // get the  component list from Jfrog for given repo + internal repo
@@ -107,9 +135,14 @@ namespace LCT.PackageIdentifier
             return modifiedBOM;
         }
 
-        #endregion
-
-        #region private methods
+        /// <summary>
+        /// Updates a single component's properties (repo, path, project type) and populates hashes if available.
+        /// </summary>
+        /// <param name="component">Component to update.</param>
+        /// <param name="aqlResultList">AQL results used to find repository entries and hashes.</param>
+        /// <param name="appSettings">Application settings for repo configuration.</param>
+        /// <param name="projectType">Property representing the project type to attach to the component.</param>
+        /// <returns>Updated component instance.</returns>
         private static Component UpdateComponentDetails(Component component, List<AqlResult> aqlResultList, CommonAppSettings appSettings, Property projectType)
         {
             string repoName = GetArtifactoryRepoName(aqlResultList, component, out string jfrogRepoPath);
@@ -138,6 +171,11 @@ namespace LCT.PackageIdentifier
             return component;
         }
 
+        /// <summary>
+        /// Updates KPI counters depending on repository type (devdep, third-party, release or not found).
+        /// </summary>
+        /// <param name="appSettings">Application settings containing repository names.</param>
+        /// <param name="repoValue">Repository name that the component was found in.</param>
         private static void UpdateBomKpiData(CommonAppSettings appSettings, string repoValue)
         {
             if (repoValue == appSettings.Conan.DevDepRepo)
@@ -158,6 +196,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Converts AQL hash result into a CycloneDX Hash list.
+        /// </summary>
+        /// <param name="hashes">AQL result containing MD5, SHA1 and SHA256 values.</param>
+        /// <returns>List of CycloneDX Hash objects.</returns>
         private static List<Hash> GetComponentHashes(AqlResult hashes)
         {
             return new List<Hash>
@@ -168,6 +211,11 @@ namespace LCT.PackageIdentifier
     };
         }
 
+        /// <summary>
+        /// Writes a file enumerating components that have multiple versions detected in the project.
+        /// </summary>
+        /// <param name="componentsWithMultipleVersions">List of components that have multiple versions.</param>
+        /// <param name="appSettings">Application settings used to determine output paths.</param>
         public static void CreateFileForMultipleVersions(List<Component> componentsWithMultipleVersions, CommonAppSettings appSettings)
         {
             MultipleVersions multipleVersions = new MultipleVersions();
@@ -213,6 +261,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Scans input folder, parses supported files and populates the BOM with components and dependencies.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and type-specific config.</param>
+        /// <param name="bom">Reference BOM to populate.</param>
         private void ParsingInputFileForBOM(CommonAppSettings appSettings, ref Bom bom)
         {
             List<string> configFiles;
@@ -280,6 +333,12 @@ namespace LCT.PackageIdentifier
             bom.Dependencies = bom.Dependencies?.GroupBy(x => new { x.Ref }).Select(y => y.First()).ToList();
         }
 
+        /// <summary>
+        /// Parses a Conan dep.json file and returns a list of CycloneDX components derived from it.
+        /// </summary>
+        /// <param name="filepath">Path to the dep.json file.</param>
+        /// <param name="dependencies">Reference list that will be populated with dependency relationships.</param>
+        /// <returns>List of components extracted from the dep.json file.</returns>
         private static List<Component> ParseDepJson(string filepath, ref List<Dependency> dependencies)
         {
             List<Component> StartingComponentForBOM = new List<Component>();
@@ -322,6 +381,12 @@ namespace LCT.PackageIdentifier
             return StartingComponentForBOM;
         }
 
+        /// <summary>
+        /// Extracts components from node packages and updates the dev-dependency counter.
+        /// </summary>
+        /// <param name="StartingComponentForBOM">Reference list to add components to.</param>
+        /// <param name="noOfDevDependent">Reference counter for development dependencies.</param>
+        /// <param name="nodePackages">List of node id / ConanPackage pairs.</param>
         private static void GetPackagesForBom(ref List<Component> StartingComponentForBOM, ref int noOfDevDependent,
             List<KeyValuePair<string, ConanPackage>> nodePackages)
         {
@@ -389,6 +454,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Determines whether a Conan package represents a development dependency.
+        /// </summary>
+        /// <param name="package">Conan package to evaluate.</param>
+        /// <param name="noOfDevDependent">Reference counter incremented when a dev dependency is found.</param>
+        /// <returns>True if package is a development dependency; otherwise false.</returns>
         public static bool IsDevDependency(ConanPackage package, ref int noOfDevDependent)
         {
             // For Conan 2.0, dev dependencies are identified by context = "build"
@@ -402,6 +473,12 @@ namespace LCT.PackageIdentifier
             return isDev;
         }
 
+        /// <summary>
+        /// Builds CycloneDX dependency relationships from Conan node package information.
+        /// </summary>
+        /// <param name="componentsForBOM">List of components for which to build dependencies.</param>
+        /// <param name="nodePackages">Node package map from the dep.json graph.</param>
+        /// <param name="dependencies">List to populate with CycloneDX Dependency objects.</param>
         private static void GetDependencyDetails(List<Component> componentsForBOM,
             List<KeyValuePair<string, ConanPackage>> nodePackages, List<Dependency> dependencies)
         {
@@ -436,6 +513,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Filters and returns valid Conan components by verifying PURL prefix and required fields.
+        /// </summary>
+        /// <param name="componentsForBOM">Components to validate.</param>
+        /// <returns>Filtered list of valid components for Conan projects.</returns>
         private static List<Component> GetExcludedComponentsList(List<Component> componentsForBOM)
         {
             List<Component> components = new List<Component>();
@@ -455,6 +537,11 @@ namespace LCT.PackageIdentifier
             return components;
         }
 
+        /// <summary>
+        /// Adds identification-related properties to components depending on the identification source.
+        /// </summary>
+        /// <param name="components">Components to update.</param>
+        /// <param name="identifiedBy">Identifier source name (e.g., "PackageFile" or manual).</param>
         private static void AddingIdentifierType(List<Component> components, string identifiedBy)
         {
             foreach (var component in components)
@@ -483,6 +570,10 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Removes duplicate components (same name/version/purl) and updates KPI counters accordingly.
+        /// </summary>
+        /// <param name="listofComponents">Reference list of components to deduplicate.</param>
         private static void GetDistinctComponentList(ref List<Component> listofComponents)
         {
             int initialCount = listofComponents.Count;
@@ -492,12 +583,22 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.DuplicateComponents = initialCount - listofComponents.Count;
         }
 
+        /// <summary>
+        /// Removes components excluded via application settings and adjusts KPI counters.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing exclusion lists.</param>
+        /// <param name="cycloneDXBOM">BOM to filter.</param>
+        /// <returns>Filtered BOM.</returns>
         private static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             return CommonHelper.RemoveExcludedComponentsFromBom(appSettings, cycloneDXBOM,
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Ensures manually added components have standard properties set (development flag and identifier type).
+        /// </summary>
+        /// <param name="componentsForBOM">List of manually added components to update.</param>
         private static void GetDetailsforManuallyAddedComp(List<Component> componentsForBOM)
         {
             foreach (var component in componentsForBOM)
@@ -514,6 +615,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Determines whether the specified component exists in the provided AQL results (internal).
+        /// </summary>
+        /// <param name="aqlResultList">AQL results to search.</param>
+        /// <param name="component">Component to locate.</param>
+        /// <returns>True if an internal match is found; otherwise false.</returns>
         private static bool IsInternalConanComponent(List<AqlResult> aqlResultList, Component component)
         {
             string jfrogcomponentPath = $"{component.Name}/{component.Version}";
@@ -526,6 +633,13 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Determines the artifactory repository name and repository path for a Conan component based on AQL results.
+        /// </summary>
+        /// <param name="aqlResultList">List of AQL query results.</param>
+        /// <param name="component">Component for which to locate a repository.</param>
+        /// <param name="jfrogRepoPath">Output path within the JFrog repository when found.</param>
+        /// <returns>Repository name or a sentinel if not found.</returns>
         public static string GetArtifactoryRepoName(List<AqlResult> aqlResultList, Component component, out string jfrogRepoPath)
         {
             string jfrogcomponentPath = $"{component.Name}/{component.Version}";
@@ -542,6 +656,9 @@ namespace LCT.PackageIdentifier
 
             return repoName;
         }
+        #endregion
+
+        #region Events
         #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
+++ b/src/LCT.PackageIdentifier/CycloneBomProcessor.cs
@@ -18,8 +18,25 @@ namespace LCT.PackageIdentifier
     public static class CycloneBomProcessor
     {
 
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Adds metadata and definitions to the comparison BOM.
+        /// </summary>
+        /// <param name="bom">BOM to update.</param>
+        /// <param name="appSettings">Application settings used to populate metadata.</param>
+        /// <param name="projectReleases">Project releases used for metadata versioning.</param>
+        /// <param name="caToolInformation">CA tool information for tool metadata.</param>
+        /// <returns>The updated BOM containing metadata and definitions.</returns>
         public static Bom SetMetadataInComparisonBOM(Bom bom,
                                                      CommonAppSettings appSettings,
                                                      ProjectReleases projectReleases,
@@ -40,6 +57,13 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Creates the CycloneDX metadata object including tools, properties and component.
+        /// </summary>
+        /// <param name="appSettings">Application settings used to populate metadata component.</param>
+        /// <param name="projectReleases">Project release information used for version metadata.</param>
+        /// <param name="caToolInformation">CA tool information used to describe the tool.</param>
+        /// <returns>A populated Metadata instance.</returns>
         private static Metadata CreateMetadata(CommonAppSettings appSettings, ProjectReleases projectReleases, CatoolInfo caToolInformation)
         {
             Metadata metadata = new Metadata
@@ -54,6 +78,11 @@ namespace LCT.PackageIdentifier
             return metadata;
         }
 
+        /// <summary>
+        /// Builds the tool choices section describing the CA tool used to create the BOM.
+        /// </summary>
+        /// <param name="caToolInformation">CA tool information providing version details.</param>
+        /// <returns>ToolChoices containing tool component information.</returns>
         private static ToolChoices CreateToolChoices(CatoolInfo caToolInformation)
         {
             return new ToolChoices
@@ -82,6 +111,10 @@ namespace LCT.PackageIdentifier
             };
         }
 
+        /// <summary>
+        /// Creates a list of default properties included in metadata.
+        /// </summary>
+        /// <returns>List of property objects for metadata.</returns>
         private static List<Property> CreateProperties()
         {
             return new List<Property>
@@ -93,6 +126,13 @@ namespace LCT.PackageIdentifier
         }
     };
         }
+
+        /// <summary>
+        /// Creates the metadata component entry for the BOM using SW360 project info and release version.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing SW360 project information.</param>
+        /// <param name="projectReleases">Project release information containing a version.</param>
+        /// <returns>A Component instance used in metadata.</returns>
         private static Component CreateMetadataComponent(CommonAppSettings appSettings, ProjectReleases projectReleases)
         {
             return new Component
@@ -102,6 +142,11 @@ namespace LCT.PackageIdentifier
                 Type = Component.Classification.Application
             };
         }
+
+        /// <summary>
+        /// Constructs definitions used in the BOM such as standards and their metadata.
+        /// </summary>
+        /// <returns>Definitions object populated with standard information.</returns>
         private static Definitions AddDefinitionsToBom()
         {
             Definitions definitions = new Definitions
@@ -129,6 +174,14 @@ namespace LCT.PackageIdentifier
 
             return definitions;
         }
+
+        /// <summary>
+        /// Sets a collection of standard properties on a component and adds it to the output list.
+        /// </summary>
+        /// <param name="appSettings">Application settings to determine project type property.</param>
+        /// <param name="component">Component to update with properties.</param>
+        /// <param name="componentForBOM">Reference list where the component will be added.</param>
+        /// <param name="repo">Optional repository name to set as a property.</param>
         public static void SetProperties(CommonAppSettings appSettings, Component component, ref List<Component> componentForBOM, string repo = "Not Found in JFrogRepo")
         {
             component.Properties ??= new List<Property>();
@@ -144,5 +197,9 @@ namespace LCT.PackageIdentifier
             component.Description = null;
             componentForBOM.Add(component);
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/DebianProcessor.cs
+++ b/src/LCT.PackageIdentifier/DebianProcessor.cs
@@ -37,6 +37,12 @@ namespace LCT.PackageIdentifier
 
         #region public method
 
+        /// <summary>
+        /// Parse Package File
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="unSupportedBomList"></param>
+        /// <returns>The updated BOM containing metadata and definitions.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<string> configFiles;
@@ -83,6 +89,10 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Add Siemens Direct Property
+        /// </summary>
+        /// <param name="bom"></param>
         private static void AddSiemensDirectProperty(ref Bom bom)
         {
             List<string> debianDirectDependencies = [.. bom.Dependencies?.Select(x => x.Ref).ToList() ?? new List<string>()];
@@ -104,12 +114,26 @@ namespace LCT.PackageIdentifier
             bom.Components = bomComponentsList;
         }
 
+        /// <summary>
+        /// Remove Excluded Components
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="cycloneDXBOM"></param>
+        /// <returns>The updated BOM containing metadata and definitions.</returns>
         public static Bom RemoveExcludedComponents(CommonAppSettings appSettings, Bom cycloneDXBOM)
         {
             return CommonHelper.RemoveExcludedComponentsFromBom(appSettings, cycloneDXBOM,
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Gets JfrogRepoDetails Of A Component
+        /// </summary>
+        /// <param name="componentsForBOM"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="jFrogService"></param>
+        /// <param name="bomhelper"></param>
+        /// <returns>list of components</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings,
                                                           IJFrogService jFrogService,
                                                           IBomHelper bomhelper)
@@ -129,6 +153,14 @@ namespace LCT.PackageIdentifier
             return modifiedBOM;
         }
 
+        /// <summary>
+        /// Identification Of Internal Components
+        /// </summary>
+        /// <param name="componentData"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="jFrogService"></param>
+        /// <param name="bomhelper"></param>
+        /// <returns>list of components</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData,
             CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
@@ -153,6 +185,15 @@ namespace LCT.PackageIdentifier
         #endregion
 
         #region private methods
+        /// <summary>
+        /// Updates Component Details
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="aqlResultList"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="bomhelper"></param>
+        /// <param name="projectType"></param>
+        /// <returns>Components</returns>
         private static Component UpdateComponentDetails(Component component, List<AqlResult> aqlResultList, CommonAppSettings appSettings, IBomHelper bomhelper, Property projectType)
         {
             string repoName = GetArtifactoryRepoName(aqlResultList, component, bomhelper, out string jfrogRepoPackageName, out string jfrogRepoPath);
@@ -171,6 +212,11 @@ namespace LCT.PackageIdentifier
             return component;
         }
 
+        /// <summary>
+        /// Updates Bom KpiData
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="repoValue"></param>
         private static void UpdateBomKpiData(CommonAppSettings appSettings, string repoValue)
         {
             if (repoValue == appSettings.Debian.DevDepRepo)
@@ -190,12 +236,30 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.UnofficialComponents++;
             }
         }
+
+        /// <summary>
+        /// Parses Cyclone DX
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="bom"></param>
+        /// <param name="appSettings"></param>
+        /// <returns>list of package</returns>
         public List<DebianPackage> ParseCycloneDX(string filePath, ref Bom bom, CommonAppSettings appSettings)
         {
             List<DebianPackage> debianPackages = new List<DebianPackage>();
             bom = ExtractDetailsForJson(filePath, ref debianPackages, appSettings);
             return debianPackages;
         }
+
+        /// <summary>
+        /// Gets Artifactory RepoName
+        /// </summary>
+        /// <param name="aqlResultList"></param>
+        /// <param name="component"></param>
+        /// <param name="bomHelper"></param>
+        /// <param name="jfrogRepoPackageName"></param>
+        /// <param name="jfrogRepoPath"></param>
+        /// <returns>ArtifactoryRepoName</returns>
         public static string GetArtifactoryRepoName(List<AqlResult> aqlResultList,
                                                      Component component,
                                                      IBomHelper bomHelper,
@@ -244,6 +308,11 @@ namespace LCT.PackageIdentifier
             return repoName;
         }
 
+        /// <summary>
+        /// Gets JfrogRepoPath
+        /// </summary>
+        /// <param name="aqlResult"></param>
+        /// <returns></returns>
         private static string GetJfrogRepoPath(AqlResult aqlResult)
         {
             if (string.IsNullOrEmpty(aqlResult.Path) || aqlResult.Path.Equals("."))
@@ -254,6 +323,12 @@ namespace LCT.PackageIdentifier
             return $"{aqlResult.Repo}/{aqlResult.Path}/{aqlResult.Name}";
         }
 
+        /// <summary>
+        /// Gets Jfrogcomponent Name Version Combined
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componentVerison"></param>
+        /// <returns>version name</returns>
         private static string GetJfrogcomponentNameVersionCombined(string componentName, string componentVerison)
         {
             if (componentVerison.Contains(':'))
@@ -264,6 +339,13 @@ namespace LCT.PackageIdentifier
             return $"{componentName}_{componentVerison}";
         }
 
+        /// <summary>
+        /// Is Internal Debian Component
+        /// </summary>
+        /// <param name="aqlResultList"></param>
+        /// <param name="component"></param>
+        /// <param name="bomHelper"></param>
+        /// <returns>boolean value</returns>
         private static bool IsInternalDebianComponent(
             List<AqlResult> aqlResultList, Component component, IBomHelper bomHelper)
         {
@@ -286,6 +368,13 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Extract Details ForJson
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="debianPackages"></param>
+        /// <param name="appSettings"></param>
+        /// <returns>update BOM data</returns>
         private Bom ExtractDetailsForJson(string filePath, ref List<DebianPackage> debianPackages, CommonAppSettings appSettings)
         {
             Bom listUnsupportedComponents = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
@@ -320,6 +409,10 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Gets DistinctComponentList
+        /// </summary>
+        /// <param name="listofComponents"></param>
         private static void GetDistinctComponentList(ref List<DebianPackage> listofComponents)
         {
             int initialCount = listofComponents.Count;
@@ -329,6 +422,12 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.DuplicateComponents = initialCount - listofComponents.Count;
         }
 
+        /// <summary>
+        /// Gets Release ExternalId
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>release id</returns>
         private static string GetReleaseExternalId(string name, string version)
         {
             version = WebUtility.UrlEncode(version);
@@ -336,6 +435,12 @@ namespace LCT.PackageIdentifier
 
             return $"{Dataconstant.PurlCheck()["DEBIAN"]}{Dataconstant.ForwardSlash}{name}@{version}?arch=source";
         }
+
+        /// <summary>
+        /// Form Component ReleaseExternalID
+        /// </summary>
+        /// <param name="listOfComponents"></param>
+        /// <returns>lis of release id</returns>
         private static List<Component> FormComponentReleaseExternalID(List<DebianPackage> listOfComponents)
         {
             List<Component> listComponentForBOM = new List<Component>();
@@ -355,6 +460,11 @@ namespace LCT.PackageIdentifier
             }
             return listComponentForBOM;
         }
+        /// <summary>
+        /// Adds ComponentProperties
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="component"></param>
         private static void AddComponentProperties(DebianPackage prop, Component component)
         {
             if (prop.SpdxComponentDetails.SpdxComponent)
@@ -372,6 +482,13 @@ namespace LCT.PackageIdentifier
                 component.Properties = properties;
             }
         }
+
+        /// <summary>
+        /// Sets Spdx ComponentDetails
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="package"></param>
+        /// <param name="componentInfo"></param>
         private static void SetSpdxComponentDetails(string filePath, DebianPackage package, Component componentInfo)
         {
             if (filePath.EndsWith(FileConstant.SPDXFileExtension))

--- a/src/LCT.PackageIdentifier/DisplayInformation.cs
+++ b/src/LCT.PackageIdentifier/DisplayInformation.cs
@@ -9,7 +9,22 @@ namespace LCT.PackageIdentifier
 {
     public static class DisplayInformation
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
+
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Returns a comma separated list of include file patterns for the configured project type.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing project-type specific include lists.</param>
+        /// <returns>Comma separated include file patterns or an empty string.</returns>
         public static string DisplayIncludeFiles(CommonAppSettings appSettings)
         {
             string totalString = string.Empty;
@@ -41,6 +56,12 @@ namespace LCT.PackageIdentifier
 
             return totalString;
         }
+
+        /// <summary>
+        /// Returns a comma separated list of exclude file patterns for the configured project type.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing project-type specific exclude lists.</param>
+        /// <returns>Comma separated exclude file patterns or an empty string.</returns>
         public static string DisplayExcludeFiles(CommonAppSettings appSettings)
         {
             string totalString = string.Empty;
@@ -73,6 +94,11 @@ namespace LCT.PackageIdentifier
             return totalString;
         }
 
+        /// <summary>
+        /// Returns a comma separated list of components excluded via SW360 configuration.
+        /// </summary>
+        /// <param name="appSettings">Application settings that may contain SW360 exclusion configuration.</param>
+        /// <returns>Comma separated excluded components or an empty string.</returns>
         public static string DisplayExcludeComponents(CommonAppSettings appSettings)
         {
 
@@ -84,6 +110,11 @@ namespace LCT.PackageIdentifier
             return totalString;
         }
 
+        /// <summary>
+        /// Returns a comma separated list of internal Artifactory repositories for the configured project type.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing Artifactory repository lists.</param>
+        /// <returns>Comma separated internal repository names or an empty string.</returns>
         public static string GetInternalRepolist(CommonAppSettings appSettings)
         {
             string listOfInternalRepoList = string.Empty;
@@ -116,6 +147,12 @@ namespace LCT.PackageIdentifier
 
             return listOfInternalRepoList;
         }
+
+        /// <summary>
+        /// Logs warnings to indicate missing SW360 or JFrog configuration used during BOM generation.
+        /// </summary>
+        /// <param name="appSettings">Application settings to inspect for SW360 and JFrog configuration.</param>
+        /// <returns>void.</returns>
         public static void LogBomGenerationWarnings(CommonAppSettings appSettings)
         {
             if (appSettings.SW360 == null && appSettings.Jfrog == null)
@@ -131,5 +168,9 @@ namespace LCT.PackageIdentifier
                 Logger.Warn($"CycloneDX BoM file generated without using JFrog details.");
             }
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/DotnetRuntimeIdentifer.cs
+++ b/src/LCT.PackageIdentifier/DotnetRuntimeIdentifer.cs
@@ -24,8 +24,17 @@ namespace LCT.PackageIdentifier
 {
     public class DotnetRuntimeIdentifer : IRuntimeIdentifier
     {
+        #region Fields
         static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
         /// <summary>
         /// Registers the default MSBuild instance for use within the application if it has not already been registered.
         /// </summary>
@@ -158,7 +167,6 @@ namespace LCT.PackageIdentifier
             return filteredFiles;
         }
 
-        #region Private Methods
         /// <summary>
         /// Parses a .csproj project file and extracts runtime-related information, including target framework,
         /// self-contained status, runtime identifiers, and framework references.
@@ -211,9 +219,9 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Loads a project with default settings for configuration and platform.
         /// </summary>
-        /// <param name="projectFilePath"></param>
-        /// <param name="projectCollection"></param>
-        /// <returns></returns>
+        /// <param name="projectFilePath">Project file path to load.</param>
+        /// <param name="projectCollection">ProjectCollection to associate with the loaded project.</param>
+        /// <returns>Loaded <see cref="Project"/> instance.</returns>
         private static Project LoadProjectWithDefaultSettings(string projectFilePath, ProjectCollection projectCollection)
         {
             var globalProperties = new Dictionary<string, string>
@@ -228,8 +236,8 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Populates the <see cref="RuntimeInfo"/> object with project metadata such as path and name.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="project"></param>
+        /// <param name="info">RuntimeInfo instance to populate.</param>
+        /// <param name="project">Loaded MSBuild project to read metadata from.</param>
         private static void PopulateProjectInfo(RuntimeInfo info, Project project)
         {
             info.ProjectPath = project.FullPath;
@@ -237,10 +245,10 @@ namespace LCT.PackageIdentifier
         }
 
         /// <summary>
-        /// Processes the self-contained status of the project, determining whether it is self-contained
+        /// Processes the self-contained status of the project, determining whether it is self-contained.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="project"></param>
+        /// <param name="info">RuntimeInfo to update with self-contained values.</param>
+        /// <param name="project">Project to inspect for self-contained and runtime identifier properties.</param>
         private static void ProcessSelfContainedStatus(RuntimeInfo info, Project project)
         {
             string selfContainedEvaluated = project.GetPropertyValue("SelfContained");
@@ -266,11 +274,11 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Sets the reason for the self-contained status based on the evaluated value and project properties.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="isSelfContained"></param>
-        /// <param name="selfContainedExplicitlySet"></param>
-        /// <param name="hasRuntimeIdentifier"></param>
-        /// <param name="selfContainedValueParsed"></param>
+        /// <param name="info">RuntimeInfo to update the reason on.</param>
+        /// <param name="isSelfContained">Whether the project was evaluated as self-contained.</param>
+        /// <param name="selfContainedExplicitlySet">Whether the SelfContained property was explicitly set.</param>
+        /// <param name="hasRuntimeIdentifier">Whether a runtime identifier or identifiers were provided.</param>
+        /// <param name="selfContainedValueParsed">Whether the SelfContained evaluated value could be parsed to boolean.</param>
         private static void SetSelfContainedReason(RuntimeInfo info, bool isSelfContained, bool selfContainedExplicitlySet,
             bool hasRuntimeIdentifier, bool selfContainedValueParsed)
         {
@@ -301,8 +309,8 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Processes the runtime identifiers from the project file, extracting both single and multiple runtime identifiers.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="project"></param>
+        /// <param name="info">RuntimeInfo to populate with runtime identifiers.</param>
+        /// <param name="project">Project to inspect for RuntimeIdentifier and RuntimeIdentifiers properties.</param>
         private static void ProcessRuntimeIdentifiers(RuntimeInfo info, Project project)
         {
             string runtimeIdentifier = project.GetPropertyValue("RuntimeIdentifier");
@@ -318,8 +326,8 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Processes the framework references from the project file, extracting relevant information such as target framework and targeting pack version.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="project"></param>
+        /// <param name="info">RuntimeInfo to add discovered framework references to.</param>
+        /// <param name="project">Project to inspect for KnownFrameworkReference items.</param>
         private static void ProcessFrameworkReferences(RuntimeInfo info, Project project)
         {
             string targetFrameworkValue = project.GetPropertyValue("TargetFramework");
@@ -340,8 +348,8 @@ namespace LCT.PackageIdentifier
         /// <summary>
         /// Handles exceptions related to invalid project files, populating the provided <see cref="RuntimeInfo"/> with error details.
         /// </summary>
-        /// <param name="info"></param>
-        /// <param name="ex"></param>
+        /// <param name="info">RuntimeInfo to populate with error information.</param>
+        /// <param name="ex">InvalidProjectFileException thrown by MSBuild during project load.</param>
         private static void HandleProjectFileException(RuntimeInfo info, Microsoft.Build.Exceptions.InvalidProjectFileException ex)
         {
             info.ErrorMessage = $"Error loading project file: {ex.Message}";
@@ -440,6 +448,9 @@ namespace LCT.PackageIdentifier
 
             return excludePatterns.Any(pattern => filePath.Contains(pattern, StringComparison.OrdinalIgnoreCase));
         }
+        #endregion
+
+        #region Events
         #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/FrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/FrameworkPackages.cs
@@ -21,10 +21,25 @@ namespace LCT.PackageIdentifier
 {
     public class FrameworkPackages : IFrameworkPackages
     {
-        readonly Dictionary<string, Dictionary<string, NuGetVersion>> _foundFrameworkPackages = [];
+        #region Fields
+        readonly Dictionary<string, Dictionary<string, NuGetVersion>> _foundFrameworkPackages = new Dictionary<string, Dictionary<string, NuGetVersion>>();
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
 
-        #region public methods
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Discovers framework packages for the provided list of NuGet lock file paths.
+        /// </summary>
+        /// <param name="lockFilePaths">List of paths to project.assets.json (lock) files to analyze.</param>
+        /// <returns>
+        /// A dictionary keyed by framework identifier containing package name -> <see cref="NuGetVersion"/> mappings.
+        /// </returns>
         public Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths)
         {
             try
@@ -81,6 +96,12 @@ namespace LCT.PackageIdentifier
             return _foundFrameworkPackages;
         }
 
+        /// <summary>
+        /// Returns framework references declared in the lock file target and corresponding package spec.
+        /// </summary>
+        /// <param name="lockFile">Lock file containing PackageSpec and targets.</param>
+        /// <param name="target">Target within the lock file to inspect.</param>
+        /// <returns>An array of framework reference names, or empty array when none found.</returns>
         public string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target)
         {
             var frameworkInformation = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(x => x.FrameworkName.Equals(target.TargetFramework));
@@ -100,6 +121,10 @@ namespace LCT.PackageIdentifier
         #endregion
 
         #region private methods
+        /// <summary>
+        /// Loads the Microsoft.ComponentDetection.Detectors assembly and returns the FrameworkPackages type when available.
+        /// </summary>
+        /// <returns>Type of the FrameworkPackages detector or null when the assembly/type cannot be loaded.</returns>
         private static Type LoadAssembly()
         {
             try
@@ -118,6 +143,11 @@ namespace LCT.PackageIdentifier
             return null;
         }
 
+        /// <summary>
+        /// Locates the static public GetFrameworkPackages method on the detector type via reflection.
+        /// </summary>
+        /// <param name="frameworkPackagesType">Type to inspect for the method.</param>
+        /// <returns><see cref="MethodInfo"/> for GetFrameworkPackages or null when not found.</returns>
         private static MethodInfo GetFrameworkPackagesMethod(Type frameworkPackagesType)
         {
             var methods = frameworkPackagesType.GetMethods(BindingFlags.Static | BindingFlags.Public);
@@ -128,6 +158,13 @@ namespace LCT.PackageIdentifier
             return null;
         }
 
+        /// <summary>
+        /// Invokes the detected GetFrameworkPackages method and processes returned framework package objects.
+        /// </summary>
+        /// <param name="getFrameworkPackagesMethod">MethodInfo representing the method to invoke.</param>
+        /// <param name="targetFramework">Target framework to pass as the first argument.</param>
+        /// <param name="frameworkReferences">Framework references to pass as the second argument.</param>
+        /// <param name="lockFileTarget">LockFileTarget instance to pass as the third argument (may be null).</param>
         private void InvokeGetFrameworkPackagesMethod(MethodInfo getFrameworkPackagesMethod, NuGetFramework targetFramework, string[] frameworkReferences, LockFileTarget lockFileTarget)
         {
             object[] parameters = { targetFramework, frameworkReferences, lockFileTarget };
@@ -142,6 +179,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Extracts framework name and package dictionary from a frameworkPackage object returned by the detector and stores it.
+        /// </summary>
+        /// <param name="targetFramework">Target framework associated with the frameworkPackage.</param>
+        /// <param name="frameworkPackage">Framework package object returned by the detector.</param>
         private void ProcessFrameworkPackage(NuGetFramework targetFramework, object frameworkPackage)
         {
             var frameworkNameProperty = frameworkPackage.GetType().GetProperty("FrameworkName");

--- a/src/LCT.PackageIdentifier/Interface/IBomCreator.cs
+++ b/src/LCT.PackageIdentifier/Interface/IBomCreator.cs
@@ -18,13 +18,33 @@ namespace LCT.PackageIdentifier.Interface
     /// </summary>
     public interface IBomCreator
     {
+        /// <summary>
+        /// Gets or sets the JFrog service instance.
+        /// </summary>
         public IJFrogService JFrogService { get; set; }
 
+        /// <summary>
+        /// Gets or sets the BOM helper instance.
+        /// </summary>
         public IBomHelper BomHelper { get; set; }
 
+        /// <summary>
+        /// Asynchronously generates a Bill of Materials (BOM) for the specified project.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="bomHelper">The BOM helper instance.</param>
+        /// <param name="fileOperations">The file operations instance.</param>
+        /// <param name="projectReleases">The project releases information.</param>
+        /// <param name="caToolInformation">The CA tool information.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public Task GenerateBom(CommonAppSettings appSettings, IBomHelper bomHelper, IFileOperations fileOperations,
                                 ProjectReleases projectReleases, CatoolInfo caToolInformation);
 
+        /// <summary>
+        /// Asynchronously checks the connection to JFrog.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if the connection is successful; otherwise, false.</returns>
         public Task<bool> CheckJFrogConnection(CommonAppSettings appSettings);
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/IBomHelper.cs
+++ b/src/LCT.PackageIdentifier/Interface/IBomHelper.cs
@@ -18,13 +18,57 @@ namespace LCT.PackageIdentifier.Interface
     /// </summary>
     public interface IBomHelper
     {
+        /// <summary>
+        /// Writes BOM KPI data to the console.
+        /// </summary>
+        /// <param name="bomKpiData">The BOM KPI data to write.</param>
         public void WriteBomKpiDataToConsole(BomKpiData bomKpiData);
+        
+        /// <summary>
+        /// Gets the project summary link for the specified project.
+        /// </summary>
+        /// <param name="projectId">The project identifier.</param>
+        /// <param name="sw360Url">The SW360 URL.</param>
+        /// <returns>The project summary link.</returns>
         public string GetProjectSummaryLink(string projectId, string sw360Url);
+        
+        /// <summary>
+        /// Gets the full name of a component.
+        /// </summary>
+        /// <param name="item">The component.</param>
+        /// <returns>The full name of the component.</returns>
         public string GetFullNameOfComponent(Component item);
+        
+        /// <summary>
+        /// Asynchronously gets the list of components from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">The array of repository names.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of AQL results.</returns>
         public Task<List<AqlResult>> GetListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService);
+        
+        /// <summary>
+        /// Asynchronously gets the list of NPM components from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">The array of repository names.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of AQL results.</returns>
         public Task<List<AqlResult>> GetNpmListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService);
+        
+        /// <summary>
+        /// Asynchronously gets the list of PyPI components from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">The array of repository names.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of AQL results.</returns>
         public Task<List<AqlResult>> GetPypiListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService);
+        
+        /// <summary>
+        /// Asynchronously gets the list of Cargo components from the specified repositories.
+        /// </summary>
+        /// <param name="repoList">The array of repository names.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of AQL results.</returns>
         public Task<List<AqlResult>> GetCargoListOfComponentsFromRepo(string[] repoList, IJFrogService jFrogService);
-
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/ICompositionBuilder.cs
+++ b/src/LCT.PackageIdentifier/Interface/ICompositionBuilder.cs
@@ -11,8 +11,17 @@ using System.Collections.Generic;
 
 namespace LCT.PackageIdentifier.Interface
 {
+    /// <summary>
+    /// CompositionBuilder interface
+    /// </summary>
     public interface ICompositionBuilder
     {
+        /// <summary>
+        /// Adds compositions to the BOM based on framework packages and runtime information.
+        /// </summary>
+        /// <param name="bom">The BOM to add compositions to.</param>
+        /// <param name="frameworkPackages">The dictionary of framework packages organized by framework and package name with versions.</param>
+        /// <param name="runtimeInfo">The runtime information.</param>
         void AddCompositionsToBom(Bom bom, Dictionary<string, Dictionary<string, NuGetVersion>> frameworkPackages, RuntimeInfo runtimeInfo);
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
+++ b/src/LCT.PackageIdentifier/Interface/IFrameworkPackages.cs
@@ -10,10 +10,24 @@ using System.Collections.Generic;
 
 namespace LCT.PackageIdentifier.Interface
 {
+    /// <summary>
+    /// FrameworkPackages interface
+    /// </summary>
     public interface IFrameworkPackages
     {
+        /// <summary>
+        /// Gets framework packages from the specified lock file paths.
+        /// </summary>
+        /// <param name="lockFilePaths">The list of lock file paths to process.</param>
+        /// <returns>A dictionary of framework packages organized by framework and package name with versions.</returns>
         Dictionary<string, Dictionary<string, NuGetVersion>> GetFrameworkPackages(List<string> lockFilePaths);
 
+        /// <summary>
+        /// Gets framework references from a lock file target.
+        /// </summary>
+        /// <param name="lockFile">The lock file to process.</param>
+        /// <param name="target">The lock file target.</param>
+        /// <returns>An array of framework reference names.</returns>
         string[] GetFrameworkReferences(LockFile lockFile, LockFileTarget target);
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/IParser.cs
+++ b/src/LCT.PackageIdentifier/Interface/IParser.cs
@@ -18,9 +18,33 @@ namespace LCT.PackageIdentifier.Interface
     /// </summary>
     public interface IParser
     {
+        /// <summary>
+        /// Parses the package file and generates a BOM.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="unSupportedBomList">The BOM list for unsupported components.</param>
+        /// <returns>The parsed BOM.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList);
+        
+        /// <summary>
+        /// Asynchronously identifies internal components from the component data.
+        /// </summary>
+        /// <param name="componentData">The component identification data.</param>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <param name="bomhelper">The BOM helper instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns the updated component identification data.</returns>
         public Task<ComponentIdentification> IdentificationOfInternalComponents(
             ComponentIdentification componentData, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper);
+        
+        /// <summary>
+        /// Asynchronously gets JFrog repository details for the specified components.
+        /// </summary>
+        /// <param name="componentsForBOM">The list of components to get repository details for.</param>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="jFrogService">The JFrog service instance.</param>
+        /// <param name="bomhelper">The BOM helper instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns the list of components with repository details.</returns>
         public Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper);
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/IProcessor.cs
+++ b/src/LCT.PackageIdentifier/Interface/IProcessor.cs
@@ -12,10 +12,29 @@ using System.Threading.Tasks;
 
 namespace LCT.PackageIdentifier.Interface
 {
+    /// <summary>
+    /// Processor interface
+    /// </summary>
     public interface IProcessor
     {
+        /// <summary>
+        /// Asynchronously checks if components are internal components in JFrog Artifactory.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="artifactoryUpload">The Artifactory credentials.</param>
+        /// <param name="component">The component to check.</param>
+        /// <param name="repo">The repository name.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of components.</returns>
         public Task<List<Component>> CheckInternalComponentsInJfrogArtifactory(CommonAppSettings appSettings, ArtifactoryCredentials artifactoryUpload, Component component, string repo);
-        public Task<List<Component>> GetJfrogArtifactoryRepoInfo(CommonAppSettings appSettings, ArtifactoryCredentials artifactoryUpload, Component component, string repo);
 
+        /// <summary>
+        /// Asynchronously gets JFrog Artifactory repository information for a component.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="artifactoryUpload">The Artifactory credentials.</param>
+        /// <param name="component">The component to get information for.</param>
+        /// <param name="repo">The repository name.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of components.</returns>
+        public Task<List<Component>> GetJfrogArtifactoryRepoInfo(CommonAppSettings appSettings, ArtifactoryCredentials artifactoryUpload, Component component, string repo);
     }
 }

--- a/src/LCT.PackageIdentifier/Interface/IRuntimeIdentifier.cs
+++ b/src/LCT.PackageIdentifier/Interface/IRuntimeIdentifier.cs
@@ -9,9 +9,21 @@ using LCT.PackageIdentifier.Model;
 
 namespace LCT.PackageIdentifier.Interface
 {
+    /// <summary>
+    /// RuntimeIdentifier interface
+    /// </summary>
     public interface IRuntimeIdentifier
     {
+        /// <summary>
+        /// Registers the runtime identifier.
+        /// </summary>
         void Register();
+        
+        /// <summary>
+        /// Identifies the runtime information based on application settings.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <returns>The runtime information.</returns>
         RuntimeInfo IdentifyRuntime(CommonAppSettings appSettings);
     }
 }

--- a/src/LCT.PackageIdentifier/MavenProcessor.cs
+++ b/src/LCT.PackageIdentifier/MavenProcessor.cs
@@ -23,12 +23,27 @@ namespace LCT.PackageIdentifier
 {
     public class MavenProcessor(ICycloneDXBomParser cycloneDXBomParser, ISpdxBomParser spdxBomParser) : CycloneDXBomParser, IParser
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
         private readonly ICycloneDXBomParser _cycloneDXBomParser = cycloneDXBomParser;
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
         private static Bom ListUnsupportedComponentsForBom = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Parses Maven-related BOM files from input and constructs a combined CycloneDX BOM for comparison.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and Maven configuration.</param>
+        /// <param name="unSupportedBomList">Reference BOM to be populated with unsupported components discovered during parsing.</param>
+        /// <returns>Constructed CycloneDX BOM.</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<Component> componentsForBOM = new();
@@ -89,6 +104,11 @@ namespace LCT.PackageIdentifier
             RemoveTypeJarSuffix(bom);
             return bom;
         }
+
+        /// <summary>
+        /// Removes the ".jar" type suffix from component references and PURLs in the BOM.
+        /// </summary>
+        /// <param name="bom">BOM whose component and dependency references will be normalized.</param>
         private static void RemoveTypeJarSuffix(Bom bom)
         {
             const string suffix = Dataconstant.TypeJarSuffix;
@@ -104,6 +124,11 @@ namespace LCT.PackageIdentifier
                 RemoveTypeJarSuffixFromDependency(dependency);
             }
         }
+
+        /// <summary>
+        /// Recursively removes the ".jar" type suffix from dependency refs.
+        /// </summary>
+        /// <param name="dependency">Dependency node to normalize.</param>
         private static void RemoveTypeJarSuffixFromDependency(Dependency dependency)
         {
             const string suffix = Dataconstant.TypeJarSuffix;
@@ -121,6 +146,15 @@ namespace LCT.PackageIdentifier
                 }
             }
         }
+
+        /// <summary>
+        /// Processes each BOM file path and accumulates components and dependencies into provided lists.
+        /// </summary>
+        /// <param name="configFiles">List of configuration/BOM file paths to process.</param>
+        /// <param name="componentsForBOM">Primary component list to populate.</param>
+        /// <param name="componentsToBOM">Secondary component list used for dev dependency identification.</param>
+        /// <param name="dependenciesForBOM">Dependency list to populate.</param>
+        /// <param name="appSettings">Application settings used for SPDX validation and project type checks.</param>
         private void ProcessBomFiles(List<string> configFiles, List<Component> componentsForBOM, List<Component> componentsToBOM, List<Dependency> dependenciesForBOM, CommonAppSettings appSettings)
         {
             foreach (string filepath in configFiles)
@@ -158,6 +192,13 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Adds components and dependencies from a parsed BOM into the accumulator lists.
+        /// </summary>
+        /// <param name="bomList">Parsed BOM whose contents should be merged.</param>
+        /// <param name="componentsForBOM">Primary component accumulator.</param>
+        /// <param name="componentsToBOM">Secondary component accumulator.</param>
+        /// <param name="dependenciesForBOM">Dependency accumulator.</param>
         private static void AddComponentsToBom(Bom bomList, List<Component> componentsForBOM, List<Component> componentsToBOM, List<Dependency> dependenciesForBOM)
         {
             if (componentsForBOM.Count == 0)
@@ -175,6 +216,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Extracts SBOM template file paths from the provided file list.
+        /// </summary>
+        /// <param name="configFiles">List of file paths to inspect.</param>
+        /// <returns>List of template SBOM file paths.</returns>
         private static List<string> GetTemplateBomFilePaths(List<string> configFiles)
         {
             List<string> listOfTemplateBomfilePaths = new();
@@ -187,12 +233,23 @@ namespace LCT.PackageIdentifier
             }
             return listOfTemplateBomfilePaths;
         }
+        /// <summary>
+        /// Removes a suffix from a string value if present.
+        /// </summary>
+        /// <param name="value">Input string to process.</param>
+        /// <param name="suffix">Suffix to remove.</param>
+        /// <returns>String without the suffix when present.</returns>
         private static string RemoveSuffix(string value, string suffix)
         {
             return !string.IsNullOrEmpty(value) && value.EndsWith(suffix)
                 ? value[..^suffix.Length]
                 : value;
         }
+
+        /// <summary>
+        /// Adds or updates the Siemens-specific direct-dependency property on each component in the BOM.
+        /// </summary>
+        /// <param name="bom">BOM whose components will be annotated.</param>
         public static void AddSiemensDirectProperty(ref Bom bom)
         {
             List<string> mavenDirectDependencies = new List<string>();
@@ -212,6 +269,12 @@ namespace LCT.PackageIdentifier
             bom.Components = bomComponentsList;
         }
 
+        /// <summary>
+        /// Evaluates components across two BOM sets to identify development-only dependencies.
+        /// </summary>
+        /// <param name="componentsForBOM">Components from the primary BOM.</param>
+        /// <param name="componentsToBOM">Components from the secondary BOM.</param>
+        /// <param name="ListOfComponents">Reference list that will be filled with annotated components.</param>
         public static void DevDependencyIdentificationLogic(List<Component> componentsForBOM, List<Component> componentsToBOM, ref List<Component> ListOfComponents)
         {
 
@@ -223,6 +286,13 @@ namespace LCT.PackageIdentifier
 
         }
 
+        /// <summary>
+        /// Internal helper that marks components as development dependencies when they appear only in one BOM.
+        /// </summary>
+        /// <param name="ListOfComponents">Accumulator list to add processed components to.</param>
+        /// <param name="iterateBOM">The BOM list iterated over.</param>
+        /// <param name="checkBOM">The BOM list compared against to determine dev-only components.</param>
+        /// <returns>Updated accumulator list.</returns>
         private static List<Component> DevdependencyIdentification(List<Component> ListOfComponents, List<Component> iterateBOM, List<Component> checkBOM)
         {
             foreach (var item in iterateBOM)
@@ -247,6 +317,12 @@ namespace LCT.PackageIdentifier
             return ListOfComponents;
         }
 
+        /// <summary>
+        /// Sets identifier and development properties for a component and appends it to the provided list.
+        /// </summary>
+        /// <param name="componentsToBOM">Reference to the component list to add to.</param>
+        /// <param name="component">Component to annotate.</param>
+        /// <param name="devValue">String value indicating development dependency ("true"/"false").</param>
         private static void SetPropertiesforBOM(ref List<Component> componentsToBOM, Component component, string devValue)
         {
             Property identifierType = new() { Name = Dataconstant.Cdx_IdentifierType, Value = Dataconstant.Discovered };
@@ -284,6 +360,14 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Asynchronously enriches components with JFrog repository details (repo, file name, path, hashes).
+        /// </summary>
+        /// <param name="componentsForBOM">List of components to enrich.</param>
+        /// <param name="appSettings">Application settings with repo configuration.</param>
+        /// <param name="jFrogService">JFrog service used for queries.</param>
+        /// <param name="bomhelper">BOM helper providing repository query helpers.</param>
+        /// <returns>Asynchronously returns the modified components list.</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM,
                                                                    CommonAppSettings appSettings,
                                                                    IJFrogService jFrogService,
@@ -319,6 +403,14 @@ namespace LCT.PackageIdentifier
             return modifiedBOM;
         }
 
+        /// <summary>
+        /// Asynchronously identifies internal Maven components by querying configured internal repositories.
+        /// </summary>
+        /// <param name="componentData">Component identification structure containing comparison BOM data.</param>
+        /// <param name="appSettings">Application settings with Artifactory internal repos.</param>
+        /// <param name="jFrogService">JFrog service used to query AQL results.</param>
+        /// <param name="bomhelper">BOM helper utilities.</param>
+        /// <returns>Asynchronously returns updated component identification data with internal components set.</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(
            ComponentIdentification componentData, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
@@ -340,10 +432,10 @@ namespace LCT.PackageIdentifier
             return componentData;
         }
         /// <summary>
-        /// Updates KPI data based on the repository value
+        /// Updates KPI counters depending on which repository a component was found in.
         /// </summary>
-        /// <param name="repoValue">The repository value to check</param>
-        /// <param name="appSettings">Application settings containing repository configurations</param>
+        /// <param name="repoValue">Repository name discovered for the component.</param>
+        /// <param name="appSettings">Application settings used to map repo categories.</param>
         private static void UpdateKpiDataBasedOnRepo(string repoValue, CommonAppSettings appSettings)
         {
             if (repoValue == appSettings.Maven.DevDepRepo)
@@ -375,6 +467,14 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.UnofficialComponents++;
             }
         }
+
+        /// <summary>
+        /// Determines whether a Maven component is internal by inspecting AQL results and fallbacks.
+        /// </summary>
+        /// <param name="aqlResultList">List of AQL results to search.</param>
+        /// <param name="component">Component to check.</param>
+        /// <param name="bomHelper">BOM helper for generating full component names.</param>
+        /// <returns>True if component is found in internal results; otherwise false.</returns>
         private static bool IsInternalMavenComponent(List<AqlResult> aqlResultList, Component component, IBomHelper bomHelper)
         {
             string jfrogcomponentName = $"{component.Name}-{component.Version}";
@@ -394,6 +494,14 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Locates JFrog AQL entry for a Maven component and returns associated repo details and path.
+        /// </summary>
+        /// <param name="aqlResultList">AQL results to search.</param>
+        /// <param name="component">Component for which to locate artifact.</param>
+        /// <param name="bomHelper">BOM helper for full-name resolution fallback.</param>
+        /// <param name="jfrogRepoPath">Outputs the repo path when found.</param>
+        /// <returns>Found <see cref="AqlResult"/> or an empty item when none found.</returns>
         private static AqlResult GetJfrogArtifactoryRepoDetials(List<AqlResult> aqlResultList,
                                                                 Component component,
                                                                 IBomHelper bomHelper,
@@ -415,7 +523,7 @@ namespace LCT.PackageIdentifier
                 if (!fullNameVersion.Equals(jfrogcomponentName, StringComparison.OrdinalIgnoreCase))
                 {
                     aqlResults = aqlResultList.FindAll(x => x.Name.Equals(
-                        fullNameVersion, StringComparison.OrdinalIgnoreCase));
+                    fullNameVersion, StringComparison.OrdinalIgnoreCase));
 
                     repoName = CommonIdentiferHelper.GetRepodetailsFromPerticularOrder(aqlResults);
                 }
@@ -434,6 +542,11 @@ namespace LCT.PackageIdentifier
             return aqlResult;
         }
 
+        /// <summary>
+        /// Builds a JFrog repository path string from an AQL result entry.
+        /// </summary>
+        /// <param name="aqlResult">AQL result entry to format.</param>
+        /// <returns>Formatted repo path string.</returns>
         private static string GetJfrogRepoPath(AqlResult aqlResult)
         {
             if (string.IsNullOrEmpty(aqlResult.Path) || aqlResult.Path.Equals("."))
@@ -443,5 +556,9 @@ namespace LCT.PackageIdentifier
 
             return $"{aqlResult.Repo}/{aqlResult.Path}/{aqlResult.Name}";
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/AlpinePackage.cs
+++ b/src/LCT.PackageIdentifier/Model/AlpinePackage.cs
@@ -9,11 +9,35 @@ namespace LCT.PackageIdentifier.Model
 
     public class AlpinePackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the package name.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the package version.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Gets or sets the PURL identifier for the package.
+        /// </summary>
         public string PurlID { get; set; }
+
+        /// <summary>
+        /// Gets or sets SPDX component details associated with the package.
+        /// </summary>
         public SpdxComponentInfo SpdxComponentDetails { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/BomKpiData.cs
+++ b/src/LCT.PackageIdentifier/Model/BomKpiData.cs
@@ -15,60 +15,128 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class BomKpiData
     {
+        #region Properties
+        /// <summary>
+        /// Number of Debian components found in the input file.
+        /// </summary>
         [DisplayName(@"Debian Components In Input File")]
         public int DebianComponents { get; set; }
 
+        /// <summary>
+        /// Number of components found in package-lock.json (or equivalent) input file.
+        /// </summary>
         [DisplayName(@"Components In Input File")]
         public int ComponentsinPackageLockJsonFile { get; set; }
 
+        /// <summary>
+        /// Number of development (dev) dependent components.
+        /// </summary>
         [DisplayName(@"Development Components")]
         public int DevDependentComponents { get; set; }
 
+        /// <summary>
+        /// Number of bundled components.
+        /// </summary>
         [DisplayName(@"Bundled Components")]
         public int BundledComponents { get; set; }
 
+        /// <summary>
+        /// Number of duplicate components detected.
+        /// </summary>
         [DisplayName(@"Duplicate Components")]
         public int DuplicateComponents { get; set; }
 
+        /// <summary>
+        /// Number of internal components.
+        /// </summary>
         [DisplayName(@"Internal Components")]
         public int InternalComponents { get; set; }
 
+        /// <summary>
+        /// Number of packages present in third-party repositories.
+        /// </summary>
         [DisplayName(@"Packages present in 3rd party repo(s)")]
         public int ThirdPartyRepoComponents { get; set; }
 
+        /// <summary>
+        /// Number of packages present in dev dependency repositories.
+        /// </summary>
         [DisplayName(@"Packages present in devdep repo(s)")]
         public int DevdependencyComponents { get; set; }
 
+        /// <summary>
+        /// Number of packages present in release repositories.
+        /// </summary>
         [DisplayName(@"Packages present in release repo(s)")]
         public int ReleaseRepoComponents { get; set; }
 
+        /// <summary>
+        /// Number of packages not present in official repositories.
+        /// </summary>
         [DisplayName(@"Packages not present in official repo(s)")]
         public int UnofficialComponents { get; set; }
 
-
+        /// <summary>
+        /// Number of invalid components that were excluded.
+        /// </summary>
         [DisplayName(@"Invalid Components Excluded")]
         public int ComponentsExcluded { get; set; }
 
+        /// <summary>
+        /// Number of components manually excluded via SW360.
+        /// </summary>
         [DisplayName(@"Manually Excluded SW360")]
         public int ComponentsExcludedSW360 { get; set; }
 
+        /// <summary>
+        /// Number of components that include a SourceURL.
+        /// </summary>
         [DisplayName(@"Components With SourceURL")]
         public int ComponentsWithSourceURL { get; set; }
 
+        /// <summary>
+        /// Number of components included in the comparison BOM.
+        /// </summary>
         [DisplayName(@"Components in BoM")]
         public int ComponentsInComparisonBOM { get; set; }
 
+        /// <summary>
+        /// Time taken by the BOM creator, in seconds.
+        /// </summary>
         [DisplayName(@"Time taken by BoM Creator")]
         public double TimeTakenByBomCreator { get; set; }
 
+        /// <summary>
+        /// Number of components added from an SBOM template file.
+        /// </summary>
         [DisplayName(@"Components Added From SBoM Template")]
         public int ComponentsinSBOMTemplateFile { get; set; }
 
+        /// <summary>
+        /// Number of components updated from an SBOM template file.
+        /// </summary>
         [DisplayName(@"Components overwritten from SBoM Template")]
         public int ComponentsUpdatedFromSBOMTemplateFile { get; set; }
+
+        /// <summary>
+        /// Number of unsupported components imported from an SPDX file as baseline entries.
+        /// </summary>
         [DisplayName(@"Components from the SPDX imported as baseline entries")]
         public int UnsupportedComponentsFromSpdxFile { get; set; }
 
+        /// <summary>
+        /// Link to the project summary (if available).
+        /// </summary>
         public string ProjectSummaryLink { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/BundledComponents.cs
+++ b/src/LCT.PackageIdentifier/Model/BundledComponents.cs
@@ -11,7 +11,25 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class BundledComponents
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the component name.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the component version.
+        /// </summary>
         public string Version { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/CargoPackageDetails.cs
+++ b/src/LCT.PackageIdentifier/Model/CargoPackageDetails.cs
@@ -12,124 +12,252 @@ namespace LCT.PackageIdentifier.Model
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class CargoPackageDetails
     {
+        #region Properties
+        /// <summary>
+        /// List of packages returned by the cargo metadata output.
+        /// </summary>
         [JsonProperty("packages")]
         public List<Package> Packages { get; set; }
 
+        /// <summary>
+        /// Dependency resolve information including nodes and root.
+        /// </summary>
         [JsonProperty("resolve")]
         public Resolve ResolveInfo { get; set; }
+
+        /// <summary>
+        /// Workspace members identifiers.
+        /// </summary>
         [JsonProperty("workspace_members")]
         public List<string> Workspace_members { get; set; }
+
+        /// <summary>
+        /// Default workspace members identifiers.
+        /// </summary>
         [JsonProperty("workspace_default_members")]
         public List<string> Workspace_default_members { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public class Dep
         {
+            #region Properties
+            /// <summary>
+            /// Dependency name.
+            /// </summary>
             [JsonProperty("name")]
             public string Name { get; set; }
 
+            /// <summary>
+            /// Package id reference for the dependency.
+            /// </summary>
             [JsonProperty("pkg")]
             public string Pkg { get; set; }
 
+            /// <summary>
+            /// Kinds of dependency entries (e.g., normal, dev).
+            /// </summary>
             [JsonProperty("dep_kinds")]
             public List<DepKind> DepKinds { get; set; }
+            #endregion
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public class DepKind
         {
+            #region Properties
+            /// <summary>
+            /// Kind of dependency (for example "dev" or "normal").
+            /// </summary>
             [JsonProperty("kind")]
             public string Kind { get; set; }
 
+            /// <summary>
+            /// Target platform or crate for the dependency kind.
+            /// </summary>
             [JsonProperty("target")]
             public string Target { get; set; }
+            #endregion
         }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public class Node
         {
+            #region Properties
+            /// <summary>
+            /// Node identifier in the resolve graph.
+            /// </summary>
             [JsonProperty("id")]
             public string Id { get; set; }
 
+            /// <summary>
+            /// List of dependency ids for this node.
+            /// </summary>
             [JsonProperty("dependencies")]
             public List<string> Dependencies { get; set; }
 
+            /// <summary>
+            /// Detailed dependency entries for this node.
+            /// </summary>
             [JsonProperty("deps")]
             public List<Dep> Deps { get; set; }
 
+            /// <summary>
+            /// Enabled feature flags for this node.
+            /// </summary>
             [JsonProperty("features")]
             public List<string> Features { get; set; }
+            #endregion
         }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public class Package
         {
+            #region Properties
+            /// <summary>
+            /// Package name.
+            /// </summary>
             [JsonProperty("name")]
             public string Name { get; set; }
 
+            /// <summary>
+            /// Package version.
+            /// </summary>
             [JsonProperty("version")]
             public string Version { get; set; }
 
+            /// <summary>
+            /// Package id (unique within the metadata output).
+            /// </summary>
             [JsonProperty("id")]
             public string Id { get; set; }
 
+            /// <summary>
+            /// Declared license for the package.
+            /// </summary>
             [JsonProperty("license")]
             public string License { get; set; }
 
+            /// <summary>
+            /// License file path or details if provided.
+            /// </summary>
             [JsonProperty("license_file")]
             public object LicenseFile { get; set; }
 
+            /// <summary>
+            /// Package description.
+            /// </summary>
             [JsonProperty("description")]
             public string Description { get; set; }
 
+            /// <summary>
+            /// Source information, e.g., git repository reference.
+            /// </summary>
             [JsonProperty("source")]
             public string Source { get; set; }
 
+            /// <summary>
+            /// Path to the Cargo.toml manifest for the package.
+            /// </summary>
             [JsonProperty("manifest_path")]
             public string ManifestPath { get; set; }
 
+            /// <summary>
+            /// Publish information if present.
+            /// </summary>
             [JsonProperty("publish")]
             public object Publish { get; set; }
 
+            /// <summary>
+            /// List of package authors.
+            /// </summary>
             [JsonProperty("authors")]
             public List<string> Authors { get; set; }
 
+            /// <summary>
+            /// Package categories.
+            /// </summary>
             [JsonProperty("categories")]
             public List<string> Categories { get; set; }
 
+            /// <summary>
+            /// Keywords associated with the package.
+            /// </summary>
             [JsonProperty("keywords")]
             public List<string> Keywords { get; set; }
 
+            /// <summary>
+            /// Readme content or path.
+            /// </summary>
             [JsonProperty("readme")]
             public string Readme { get; set; }
 
+            /// <summary>
+            /// Repository URL for the package.
+            /// </summary>
             [JsonProperty("repository")]
             public string Repository { get; set; }
 
+            /// <summary>
+            /// Homepage URL for the package.
+            /// </summary>
             [JsonProperty("homepage")]
             public string Homepage { get; set; }
 
+            /// <summary>
+            /// Documentation URL for the package.
+            /// </summary>
             [JsonProperty("documentation")]
             public string Documentation { get; set; }
 
+            /// <summary>
+            /// Edition of Rust used by the package.
+            /// </summary>
             [JsonProperty("edition")]
             public string Edition { get; set; }
 
+            /// <summary>
+            /// Additional links information.
+            /// </summary>
             [JsonProperty("links")]
             public object Links { get; set; }
 
+            /// <summary>
+            /// Default run information if available.
+            /// </summary>
             [JsonProperty("default_run")]
             public object DefaultRun { get; set; }
 
+            /// <summary>
+            /// Rust toolchain version requirement.
+            /// </summary>
             [JsonProperty("rust_version")]
             public string RustVersion { get; set; }
+            #endregion
         }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public class Resolve
         {
+            #region Properties
+            /// <summary>
+            /// Nodes that make up the resolved dependency graph.
+            /// </summary>
             [JsonProperty("nodes")]
             public List<Node> Nodes { get; set; }
 
+            /// <summary>
+            /// Root package id in the resolve graph.
+            /// </summary>
             [JsonProperty("root")]
             public string Root { get; set; }
+            #endregion
         }
     }
 }

--- a/src/LCT.PackageIdentifier/Model/ComponentIdentification.cs
+++ b/src/LCT.PackageIdentifier/Model/ComponentIdentification.cs
@@ -13,8 +13,26 @@ namespace LCT.PackageIdentifier.Model
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class ComponentIdentification
     {
+        #region Properties
+        /// <summary>
+        /// Components from the comparison BOM used to match against the project.
+        /// </summary>
         public List<Component> comparisonBOMData { get; set; }
+
+        /// <summary>
+        /// Internal components discovered within the project.
+        /// </summary>
         public List<Component> internalComponents { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
 
     }
 }

--- a/src/LCT.PackageIdentifier/Model/ComponentsInfo.cs
+++ b/src/LCT.PackageIdentifier/Model/ComponentsInfo.cs
@@ -15,26 +15,71 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     internal class ComponentsInfo
     {
+        #region Properties
+        /// <summary>
+        /// Component type as defined in CycloneDX.
+        /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
 
+        /// <summary>
+        /// Publisher or vendor of the component.
+        /// </summary>
         [JsonProperty("publisher")]
         public string Publisher { get; set; }
 
+        /// <summary>
+        /// Component name.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Component version.
+        /// </summary>
         [JsonProperty("version")]
         public string Version { get; set; }
 
+        /// <summary>
+        /// Component scope (for example required or optional).
+        /// </summary>
         [JsonProperty("scope")]
         public string Scope { get; set; }
 
+        /// <summary>
+        /// External identifier (purl) from the release metadata.
+        /// </summary>
         [JsonProperty("purl")]
         public string ReleaseExternalId { get; set; }
+
+        /// <summary>
+        /// Component external identifier.
+        /// </summary>
         public string ComponentExternalId { get; set; }
+
+        /// <summary>
+        /// Package URL for the component.
+        /// </summary>
         public string PackageUrl { get; set; }
+
+        /// <summary>
+        /// Source URL for the component.
+        /// </summary>
         public string SourceUrl { get; set; }
+
+        /// <summary>
+        /// Download URL for the component binary or artifact.
+        /// </summary>
         public string DownloadUrl { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/ConanDependency.cs
+++ b/src/LCT.PackageIdentifier/Model/ConanDependency.cs
@@ -16,46 +16,99 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class ConanDependency
     {
+        #region Properties
+        /// <summary>
+        /// Reference identifier for the Conan dependency (ref field).
+        /// </summary>
         [JsonProperty("ref")]
         public string Ref { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Requirement string for the dependency.
+        /// </summary>
         [JsonProperty("require")]
         public string Require { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Indicates whether the dependency is required at run time.
+        /// </summary>
         [JsonProperty("run")]
         public bool? Run { get; set; }
 
+        /// <summary>
+        /// Indicates whether the dependency exposes libraries.
+        /// </summary>
         [JsonProperty("libs")]
         public bool? Libs { get; set; }
 
+        /// <summary>
+        /// Indicates whether the dependency should be skipped.
+        /// </summary>
         [JsonProperty("skip")]
         public bool? Skip { get; set; }
 
+        /// <summary>
+        /// Indicates whether this dependency is used for tests.
+        /// </summary>
         [JsonProperty("test")]
         public bool? Test { get; set; }
 
+        /// <summary>
+        /// Indicates whether this dependency should be forced.
+        /// </summary>
         [JsonProperty("force")]
         public bool? Force { get; set; }
 
+        /// <summary>
+        /// Indicates whether the dependency is direct.
+        /// </summary>
         [JsonProperty("direct")]
         public bool? Direct { get; set; }
 
+        /// <summary>
+        /// Indicates whether the dependency must be built.
+        /// </summary>
         [JsonProperty("build")]
         public bool? Build { get; set; }
 
+        /// <summary>
+        /// Transitive headers information (type depends on dep.json structure).
+        /// </summary>
         [JsonProperty("transitive_headers")]
         public object TransitiveHeaders { get; set; }
 
+        /// <summary>
+        /// Transitive libs information (type depends on dep.json structure).
+        /// </summary>
         [JsonProperty("transitive_libs")]
         public object TransitiveLibs { get; set; }
 
+        /// <summary>
+        /// Indicates whether headers are included for this dependency.
+        /// </summary>
         [JsonProperty("headers")]
         public bool? Headers { get; set; }
 
+        /// <summary>
+        /// Package id mode for this dependency.
+        /// </summary>
         [JsonProperty("package_id_mode")]
         public string PackageIdMode { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Visibility flag for the dependency.
+        /// </summary>
         [JsonProperty("visible")]
         public bool? Visible { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/ConanPackage.cs
+++ b/src/LCT.PackageIdentifier/Model/ConanPackage.cs
@@ -17,41 +17,86 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class ConanPackage
     {
+        #region Properties
+        /// <summary>
+        /// Package name.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Package version.
+        /// </summary>
         [JsonProperty("version")]
         public string Version { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Context of the package (for example 'host' or 'build').
+        /// </summary>
         [JsonProperty("context")]
         public string Context { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Indicates whether the package exposes libraries.
+        /// </summary>
         [JsonProperty("libs")]
         public bool? Libs { get; set; }
 
+        /// <summary>
+        /// Visibility flag for the package.
+        /// </summary>
         [JsonProperty("visible")]
         public bool? Visible { get; set; }
 
+        /// <summary>
+        /// Indicates whether the package is required at run time.
+        /// </summary>
         [JsonProperty("run")]
         public bool? Run { get; set; }
 
+        /// <summary>
+        /// Indicates whether the package must be built.
+        /// </summary>
         [JsonProperty("build")]
         public bool? Build { get; set; }
 
+        /// <summary>
+        /// Indicates whether the package is used for tests.
+        /// </summary>
         [JsonProperty("test")]
         public bool? Test { get; set; }
 
+        /// <summary>
+        /// Dependency list keyed by node id as found in the Conan graph.
+        /// </summary>
         [JsonProperty("dependencies")]
         public Dictionary<string, ConanDependency> Dependencies { get; set; } = new Dictionary<string, ConanDependency>();
+        #endregion
 
-        // Helper properties to make code more readable
+        #region Methods
+        /// <summary>
+        /// Gets a value indicating whether this package should be treated as a runtime dependency.
+        /// </summary>
         public bool IsRuntimeDependency => Context == "host" && Libs == true && Visible == true && Run == false;
+
+        /// <summary>
+        /// Gets a value indicating whether this package should be treated as a development dependency.
+        /// </summary>
         public bool IsDevDependency => Context == "build" || (Run == true && Build == true);
 
+        /// <summary>
+        /// Determines whether the dependency with the specified node id is a direct dependency.
+        /// </summary>
+        /// <param name="nodeId">Node id to check within the Dependencies dictionary.</param>
+        /// <returns>True if the dependency is present and marked as direct; otherwise false.</returns>
         public bool IsDirectDependency(string nodeId)
         {
             return Dependencies?.ContainsKey(nodeId) == true && Dependencies[nodeId].Direct == true;
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 
     /// <summary>
@@ -60,8 +105,22 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class ConanDepJson
     {
+        #region Properties
+        /// <summary>
+        /// Top level graph element of the Conan dep.json.
+        /// </summary>
         [JsonProperty("graph")]
         public ConanGraph Graph { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 
     /// <summary>
@@ -70,10 +129,27 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class ConanGraph
     {
+        #region Properties
+        /// <summary>
+        /// Nodes in the graph keyed by node id.
+        /// </summary>
         [JsonProperty("nodes")]
         public Dictionary<string, ConanPackage> Nodes { get; set; } = new Dictionary<string, ConanPackage>();
 
+        /// <summary>
+        /// Root mapping information for the graph.
+        /// </summary>
         [JsonProperty("root")]
         public Dictionary<string, string> Root { get; set; } = new Dictionary<string, string>();
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/CycloneDxBomData.cs
+++ b/src/LCT.PackageIdentifier/Model/CycloneDxBomData.cs
@@ -15,13 +15,33 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     internal class CycloneDxBomData
     {
+        #region Properties
+        /// <summary>
+        /// Format of the BOM (e.g. "CycloneDX").
+        /// </summary>
         [JsonProperty("bomFormat")]
         public string BomFormat { get; set; }
 
+        /// <summary>
+        /// Spec version used by the CycloneDX BOM.
+        /// </summary>
         [JsonProperty("specVersion")]
         public string SpecVersion { get; set; }
 
+        /// <summary>
+        /// Array of component information entries contained in the BOM.
+        /// </summary>
         [JsonProperty("components")]
         public ComponentsInfo[] ComponentsInfo { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/DebianPackage.cs
+++ b/src/LCT.PackageIdentifier/Model/DebianPackage.cs
@@ -14,21 +14,60 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class DebianPackage
     {
+        #region Properties
+        /// <summary>
+        /// Package name.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Package version.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Package PURL identifier.
+        /// </summary>
         public string PurlID { get; set; }
 
+        /// <summary>
+        /// Source URL for the Debian package.
+        /// </summary>
         public string SourceUrl { get; set; }
 
+        /// <summary>
+        /// Patch URLs associated with the package.
+        /// </summary>
         public string[] PatchURLs { get; set; }
 
+        /// <summary>
+        /// Download URL for the package artifact.
+        /// </summary>
         public string DownloadUrl { get; set; }
 
+        /// <summary>
+        /// Raw JSON text associated with this package, if available.
+        /// </summary>
         public string JsonText { get; set; }
 
+        /// <summary>
+        /// Indicates whether a retry is required for fetching package metadata.
+        /// </summary>
         public bool IsRetryRequired { get; set; }
+
+        /// <summary>
+        /// SPDX component details associated with this package.
+        /// </summary>
         public SpdxComponentInfo SpdxComponentDetails { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/MavenPackage.cs
+++ b/src/LCT.PackageIdentifier/Model/MavenPackage.cs
@@ -14,8 +14,30 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class MavenPackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the package identifier.
+        /// </summary>
         public string ID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package version.
+        /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package group identifier (groupId).
+        /// </summary>
         public string GroupID { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/NugetModel/BuildInfoComponent.cs
+++ b/src/LCT.PackageIdentifier/Model/NugetModel/BuildInfoComponent.cs
@@ -22,8 +22,11 @@ namespace LCT.PackageIdentifier.Model.NugetModel
     [ExcludeFromCodeCoverage]
     public abstract class BuildInfoComponent : IEquatable<BuildInfoComponent>
     {
+        #region Fields
         protected static readonly HashAlgorithm HashAlgorithm = SHA512.Create();
+        #endregion
 
+        #region Properties
         public string Name { get; set; }
 
         public string Version { get; set; }
@@ -46,15 +49,10 @@ namespace LCT.PackageIdentifier.Model.NugetModel
         public string Sha1 { get; set; }
         public string Sha256 { get; set; }
 
-        protected BuildInfoComponent(string id, string version)
-        {
-            Name = id;
-            Version = version;
-            Dependencies = new HashSet<BuildInfoComponent>();
-            Ancestors = new HashSet<BuildInfoComponent>();
-            TypeName = GetType().Name;
-        }
-
+        /// <summary>
+        /// Gets a stable identifier for this component based on name, version, scope and runtime type.
+        /// </summary>
+        /// <returns>Hashed identifier string for the component.</returns>
         public virtual string Id
         {
             get
@@ -63,14 +61,41 @@ namespace LCT.PackageIdentifier.Model.NugetModel
                 return GetHashFromString(input);
             }
         }
+        #endregion
 
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BuildInfoComponent"/> class.
+        /// </summary>
+        /// <param name="id">Component name or identifier.</param>
+        /// <param name="version">Component version.</param>
+        protected BuildInfoComponent(string id, string version)
+        {
+            Name = id;
+            Version = version;
+            Dependencies = new HashSet<BuildInfoComponent>();
+            Ancestors = new HashSet<BuildInfoComponent>();
+            TypeName = GetType().Name;
+        }
+        #endregion
 
+        #region Methods
+        /// <summary>
+        /// Computes a hex encoded hash for the given input string using the configured hash algorithm.
+        /// </summary>
+        /// <param name="input">String to hash.</param>
+        /// <returns>Hex encoded hash string.</returns>
         public static string GetHashFromString(string input)
         {
             byte[] byteHash = HashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input));
             return Convert.ToHexString(byteHash);
         }
 
+        /// <summary>
+        /// Returns all ancestor paths ending at this component. Each path is a list where the last element is this component.
+        /// </summary>
+        /// <param name="children">Optional list of child components accumulated so far; pass null to start a new path.</param>
+        /// <returns>List of ancestor paths, each path is a list of components.</returns>
         public IList<IList<BuildInfoComponent>> GetAncestors(IList<BuildInfoComponent> children)
         {
             List<IList<BuildInfoComponent>> ancestorsPathList = new();
@@ -106,6 +131,11 @@ namespace LCT.PackageIdentifier.Model.NugetModel
             return ancestorsPathList;
         }
 
+        /// <summary>
+        /// Determines whether the specified <see cref="BuildInfoComponent"/> is equal to the current one.
+        /// </summary>
+        /// <param name="other">The other component to compare.</param>
+        /// <returns>True if components are equal; otherwise false.</returns>
         public virtual bool Equals(BuildInfoComponent other)
         {
             if (other is null)
@@ -150,14 +180,27 @@ namespace LCT.PackageIdentifier.Model.NugetModel
                            StringComparison.InvariantCultureIgnoreCase);
         }
 
+        /// <summary>
+        /// Determines whether the specified object is equal to the current component.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current component.</param>
+        /// <returns>True if equal; otherwise false.</returns>
         public override bool Equals(object obj)
         {
             return Equals(obj as BuildInfoComponent);
         }
 
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>Integer hash code for the instance.</returns>
         public override int GetHashCode()
         {
             return 0;
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/NugetModel/Container.cs
+++ b/src/LCT.PackageIdentifier/Model/NugetModel/Container.cs
@@ -24,12 +24,35 @@ namespace LCT.PackageIdentifier.Model.NugetModel
     [ExcludeFromCodeCoverage]
     public class Container
     {
+        #region Properties
+        /// <summary>
+        /// Components contained in this container, keyed by component identifier.
+        /// </summary>
         public IDictionary<string, BuildInfoComponent> Components { get; set; } = new Dictionary<string, BuildInfoComponent>();
 
+        /// <summary>
+        /// Name of the container (for example a file name or logical group name).
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Type of the container (for example nuget).
+        /// </summary>
         public ContainerType Type { get; set; }
 
+        /// <summary>
+        /// Default scope applied to components in this container.
+        /// </summary>
         public ComponentScope Scope { get; set; } = ComponentScope.Required;
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/NugetModel/NugetComponent.cs
+++ b/src/LCT.PackageIdentifier/Model/NugetModel/NugetComponent.cs
@@ -12,10 +12,29 @@ namespace LCT.PackageIdentifier.Model.NugetModel
     [ExcludeFromCodeCoverage]
     public class NuGetComponent : BuildInfoComponent
     {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetComponent"/> class with the specified id and version.
+        /// </summary>
+        /// <param name="id">Component name or identifier.</param>
+        /// <param name="version">Component version.</param>
         public NuGetComponent(string id, string version) : base(id, version)
         {
         }
+        #endregion
 
+        #region Properties
+        /// <summary>
+        /// Gets the Package URL (purl) for this NuGet component.
+        /// </summary>
+        /// <returns>String representation of the package URL for the NuGet component.</returns>
         public override string PackageUrl => new PackageURL("nuget", null, Name, Version, null, null).ToString();
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/NugetPackage.cs
+++ b/src/LCT.PackageIdentifier/Model/NugetPackage.cs
@@ -15,13 +15,36 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class NugetPackage
     {
+        #region Properties
+        /// <summary>
+        /// Package identifier (usually the package id or name).
+        /// </summary>
         public string ID { get; set; }
 
+        /// <summary>
+        /// Package version.
+        /// </summary>
         public string Version { get; set; }
         public List<string> Dependencies { get; set; }
 
+        /// <summary>
+        /// File path to the package or the source file where the package was declared.
+        /// </summary>
         public string Filepath { get; set; }
-        public string IsDev { get; set; }
 
+        /// <summary>
+        /// Indicates whether the package is a development dependency.
+        /// </summary>
+        public string IsDev { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/PythonPackage.cs
+++ b/src/LCT.PackageIdentifier/Model/PythonPackage.cs
@@ -1,5 +1,4 @@
-﻿
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2025 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
@@ -13,13 +12,50 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class PythonPackage
     {
+        #region Properties
+        /// <summary>
+        /// Package URL identifier (PURL) for the Python package.
+        /// </summary>
         public string PurlID { get; set; }
-        public string Name { get; set; }
-        public string Version { get; set; }
-        public bool Isdevdependent { get; set; }
-        public string FoundType { get; set; }
-        public string Filepath { get; set; }
-        public SpdxComponentInfo SpdxComponentDetails { get; set; }
 
+        /// <summary>
+        /// Package name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Package version.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Indicates whether the package is a development dependency.
+        /// </summary>
+        public bool Isdevdependent { get; set; }
+
+        /// <summary>
+        /// The detected type/source of the package (for example "pip" or "poetry").
+        /// </summary>
+        public string FoundType { get; set; }
+
+        /// <summary>
+        /// File path where the package was found or declared.
+        /// </summary>
+        public string Filepath { get; set; }
+
+        /// <summary>
+        /// SPDX component information associated with this package.
+        /// </summary>
+        public SpdxComponentInfo SpdxComponentDetails { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/ReferenceDetails.cs
+++ b/src/LCT.PackageIdentifier/Model/ReferenceDetails.cs
@@ -14,9 +14,34 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class ReferenceDetails
     {
+        #region Fields
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets the library name referenced.
+        /// </summary>
         public string Library { get; set; }
+
+        /// <summary>
+        /// Gets or sets the library version.
+        /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the reference is private.
+        /// </summary>
         public bool Private { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
 
     }
 }

--- a/src/LCT.PackageIdentifier/Model/RuntimeInfo.cs
+++ b/src/LCT.PackageIdentifier/Model/RuntimeInfo.cs
@@ -10,22 +10,97 @@ namespace LCT.PackageIdentifier.Model
 {
     public class RuntimeInfo
     {
+        #region Fields
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets the full path to the project file or project folder.
+        /// </summary>
         public string ProjectPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logical project name.
+        /// </summary>
         public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the project will be published as self-contained.
+        /// </summary>
         public bool IsSelfContained { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether SelfContained was explicitly set in the project file.
+        /// </summary>
         public bool SelfContainedExplicitlySet { get; set; }
+
+        /// <summary>
+        /// Gets or sets the evaluated value for SelfContained after MSBuild evaluation.
+        /// </summary>
         public string SelfContainedEvaluated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason why SelfContained was evaluated to the given value.
+        /// </summary>
         public string SelfContainedReason { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of runtime identifiers (RIDs) for the project.
+        /// </summary>
         public List<string> RuntimeIdentifiers { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets framework reference information discovered in the project.
+        /// </summary>
         public List<FrameworkReferenceInfo> FrameworkReferences { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets a short error message encountered while determining runtime information.
+        /// </summary>
         public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets detailed error information or stack traces for diagnostics.
+        /// </summary>
         public string ErrorDetails { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 
     public class FrameworkReferenceInfo
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the target framework identifier (TFM) that this reference targets.
+        /// </summary>
         public string TargetFramework { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the framework reference.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the targeting pack used for this framework reference.
+        /// </summary>
         public string TargetingPackVersion { get; set; }
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Model/SpdxComponentInfo.cs
+++ b/src/LCT.PackageIdentifier/Model/SpdxComponentInfo.cs
@@ -10,9 +10,34 @@ namespace LCT.PackageIdentifier.Model
     [ExcludeFromCodeCoverage]
     public class SpdxComponentInfo
     {
+        #region Fields
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets a value indicating whether this component originates from an SPDX file.
+        /// </summary>
         public bool SpdxComponent { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the file path to the SPDX file that provided component information.
+        /// </summary>
         public string SpdxFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this component is a development-only dependency.
+        /// </summary>
         public bool DevComponent { get; set; } = false;
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        #endregion
+
+        #region Events
+        #endregion
 
     }
 }

--- a/src/LCT.PackageIdentifier/NpmProcessor.cs
+++ b/src/LCT.PackageIdentifier/NpmProcessor.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+﻿        // --------------------------------------------------------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2025 Siemens AG
 //
 //  SPDX-License-Identifier: MIT
@@ -33,6 +33,7 @@ namespace LCT.PackageIdentifier
     /// </summary>
     public class NpmProcessor(ICycloneDXBomParser cycloneDXBomParser, ISpdxBomParser spdxBomParser) : CycloneDXBomParser, IParser
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ICycloneDXBomParser _cycloneDXBomParser = cycloneDXBomParser;
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
@@ -45,7 +46,15 @@ namespace LCT.PackageIdentifier
         private const string NotFoundInRepo = "Not Found in JFrogRepo";
         private const string Requires = "requires";
         private const string Name = "name";
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<Component> componentsForBOM = new List<Component>();
@@ -82,6 +91,12 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Parses a package-lock.json file and returns CycloneDX components derived from it.
+        /// </summary>
+        /// <param name="filepath">Path to the package-lock.json file.</param>
+        /// <param name="appSettings">Application settings used for exclusions and KPIs.</param>
+        /// <returns>List of components parsed from the package-lock.json file.</returns>
         public static List<Component> ParsePackageLockJson(string filepath, CommonAppSettings appSettings)
         {
             List<BundledComponents> bundledComponents = new List<BundledComponents>();
@@ -142,6 +157,11 @@ namespace LCT.PackageIdentifier
             return lstComponentForBOM;
         }
 
+        /// <summary>
+        /// Returns a combined list of top-level dependencies and devDependencies from a package-lock.json file.
+        /// </summary>
+        /// <param name="filepath">Path to the package-lock.json file.</param>
+        /// <returns>List of JToken entries representing direct dependencies.</returns>
         private static List<JToken> GetDirectDependenciesList(string filepath)
         {
             string jsonContent = File.ReadAllText(filepath);
@@ -154,6 +174,11 @@ namespace LCT.PackageIdentifier
             return directDependencies;
         }
 
+        /// <summary>
+        /// Writes a file that documents components which appear with multiple versions.
+        /// </summary>
+        /// <param name="componentsWithMultipleVersions">List of components that have multiple versions detected.</param>
+        /// <param name="appSettings">Application settings used to determine output paths.</param>
         private static void CreateFileForMultipleVersions(List<Component> componentsWithMultipleVersions, CommonAppSettings appSettings)
         {
             MultipleVersions multipleVersions = new MultipleVersions();
@@ -198,6 +223,14 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Extracts components from the legacy "packages" section of certain package-lock.json versions.
+        /// </summary>
+        /// <param name="filepath">Source file path.</param>
+        /// <param name="bundledComponents">Accumulator for bundled components.</param>
+        /// <param name="lstComponentForBOM">Accumulator for components to include in BOM.</param>
+        /// <param name="noOfDevDependent">Reference counter for dev dependencies.</param>
+        /// <param name="depencyComponentList">Enumerable of JProperty dependency entries.</param>
         private static void GetPackagesForBom(string filepath, ref List<BundledComponents> bundledComponents, ref List<Component> lstComponentForBOM, ref int noOfDevDependent, IEnumerable<JProperty> depencyComponentList)
         {
             BomCreator.bomKpiData.ComponentsinPackageLockJsonFile += depencyComponentList.Count();
@@ -253,6 +286,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Sets the Group and Name properties on a component from an NPM package identifier.
+        /// </summary>
+        /// <param name="component">Component to update.</param>
+        /// <param name="packageName">Package identifier (may include scope).</param>
         private static void SetComponentGroupAndName(Component component, string packageName)
         {
             if (packageName.Contains('@'))
@@ -265,6 +303,12 @@ namespace LCT.PackageIdentifier
                 component.Name = packageName;
             }
         }
+        /// <summary>
+        /// Resolves the package name from parsed properties or from the node_modules path.
+        /// </summary>
+        /// <param name="properties">JObject of package properties.</param>
+        /// <param name="prop">JProperty representing the package entry.</param>
+        /// <returns>Package name string.</returns>
         private static string GetPackageName(JObject properties, JProperty prop)
         {
             string packageName;
@@ -278,6 +322,12 @@ namespace LCT.PackageIdentifier
             }
             return packageName;
         }
+        /// <summary>
+        /// Determines if a given component entry is a direct dependency.
+        /// </summary>
+        /// <param name="directDependencies">List of direct dependency tokens.</param>
+        /// <param name="prop">JProperty for the component to test.</param>
+        /// <returns>"true" if direct; otherwise "false".</returns>
         public static string GetIsDirect(List<JToken> directDependencies, JProperty prop)
         {
             string subvalue = CommonHelper.GetSubstringOfLastOccurance(prop.Name, $"node_modules/");
@@ -292,6 +342,12 @@ namespace LCT.PackageIdentifier
 
             return "false";
         }
+        /// <summary>
+        /// Adds a component to bundled components list when the "bundled" flag is present.
+        /// </summary>
+        /// <param name="bundledComponents">Accumulator for bundled components.</param>
+        /// <param name="prop">JProperty representing the package entry.</param>
+        /// <param name="components">Component instance to add.</param>
         private static void CheckAndAddToBundleComponents(List<BundledComponents> bundledComponents, JProperty prop, Component components)
         {
             if (prop.Value[Bundled] != null && (!bundledComponents.Any(x => x.Name == components.Name && x.Version.Equals(components.Version, StringComparison.OrdinalIgnoreCase))))
@@ -302,6 +358,16 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Recursively extracts components from nested dependency structures in package-lock.json.
+        /// </summary>
+        /// <param name="filepath">Source package-lock.json path.</param>
+        /// <param name="appSettings">Application settings for exclusion checks.</param>
+        /// <param name="bundledComponents">Accumulator for bundled components.</param>
+        /// <param name="lstComponentForBOM">Accumulator for components to add to the BOM.</param>
+        /// <param name="noOfDevDependent">Reference dev-dependency counter.</param>
+        /// <param name="depencyComponentList">Enumerable of dependency JProperty entries.</param>
+        /// <param name="directDependenciesList">List of tokens representing direct dependencies.</param>
         private static void GetComponentsForBom(string filepath, CommonAppSettings appSettings,
             ref List<BundledComponents> bundledComponents, ref List<Component> lstComponentForBOM,
             ref int noOfDevDependent, IEnumerable<JProperty> depencyComponentList, List<JToken> directDependenciesList)
@@ -458,6 +524,13 @@ namespace LCT.PackageIdentifier
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Scans the input folder for NPM-related files and parses them into components and dependencies.
+        /// </summary>
+        /// <param name="appSettings">Application settings containing input folder and NPM config.</param>
+        /// <param name="componentsForBOM">Reference list to populate with discovered components.</param>
+        /// <param name="bom">Reference BOM that may be filled when parsing CycloneDX/SPDX files.</param>
+        /// <param name="dependencies">Reference dependency list to populate.</param>
         private void ParsingInputFileForBOM(CommonAppSettings appSettings, ref List<Component> componentsForBOM, ref Bom bom, ref List<Dependency> dependencies)
         {
             List<string> configFiles = FolderScanner.FileScanner(appSettings.Directory.InputFolder, appSettings.Npm);
@@ -479,6 +552,14 @@ namespace LCT.PackageIdentifier
             SbomTemplate.ProcessTemplateFile(templateFilePath, _cycloneDXBomParser, componentsForBOM, appSettings.ProjectType);
         }
 
+        /// <summary>
+        /// Dispatches processing based on the file type (CycloneDX, SPDX or package file).
+        /// </summary>
+        /// <param name="filepath">Path of the file to process.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="componentsForBOM">Reference component list.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="dependencies">Reference dependency list.</param>
         private void ProcessFileBasedOnType(string filepath, CommonAppSettings appSettings, ref List<Component> componentsForBOM, ref Bom bom, ref List<Dependency> dependencies)
         {
             if (filepath.EndsWith(FileConstant.CycloneDXFileExtension))
@@ -495,6 +576,14 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Parses a CycloneDX file and merges its components and dependencies into the accumulators.
+        /// </summary>
+        /// <param name="filepath">CycloneDX file path.</param>
+        /// <param name="appSettings">Application settings for filtering.</param>
+        /// <param name="componentsForBOM">Reference component list.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="dependencies">Reference dependency list.</param>
         private void ProcessCycloneDXFile(string filepath, CommonAppSettings appSettings, ref List<Component> componentsForBOM, ref Bom bom, ref List<Dependency> dependencies)
         {
             if (filepath.EndsWith(FileConstant.SBOMTemplateFileExtension))
@@ -520,6 +609,14 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Parses an SPDX file, validates and merges components and unsupported ones.
+        /// </summary>
+        /// <param name="filepath">SPDX file path.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="componentsForBOM">Reference component list.</param>
+        /// <param name="bom">Reference BOM to update.</param>
+        /// <param name="dependencies">Reference dependency list.</param>
         private void ProcessSPDXFile(string filepath, CommonAppSettings appSettings, ref List<Component> componentsForBOM, ref Bom bom, ref List<Dependency> dependencies)
         {
             BomHelper.NamingConventionOfSPDXFile(filepath, appSettings);
@@ -537,6 +634,13 @@ namespace LCT.PackageIdentifier
             ListUnsupportedComponentsForBom.Dependencies.AddRange(listUnsupportedComponents.Dependencies);
         }
 
+        /// <summary>
+        /// Processes a package file (package-lock.json) and extracts components and dependencies.
+        /// </summary>
+        /// <param name="filepath">Path to the package file.</param>
+        /// <param name="appSettings">Application settings.</param>
+        /// <param name="componentsForBOM">Reference component list.</param>
+        /// <param name="dependencies">Reference dependency list.</param>
         private static void ProcessPackageFile(string filepath, CommonAppSettings appSettings, ref List<Component> componentsForBOM, ref List<Dependency> dependencies)
         {
             Logger.Debug($"ParsingInputFileForBOM():Found as Package File");
@@ -546,6 +650,11 @@ namespace LCT.PackageIdentifier
             GetDependencyDetails(components, dependencies);
         }
 
+        /// <summary>
+        /// Builds CycloneDX dependency relationships from internal manufacturer references.
+        /// </summary>
+        /// <param name="componentsForBOM">List of components for which to build dependencies.</param>
+        /// <param name="dependencies">Dependency list to populate.</param>
         public static void GetDependencyDetails(List<Component> componentsForBOM, List<Dependency> dependencies)
         {
             List<Dependency> dependencyList = new();
@@ -596,6 +705,11 @@ namespace LCT.PackageIdentifier
             dependencies.AddRange(dependencyList);
         }
 
+        /// <summary>
+        /// Normalizes component identifier strings replacing known characters.
+        /// </summary>
+        /// <param name="componentInfo">Raw component info string.</param>
+        /// <returns>Formatted string safe for PURL composition.</returns>
         private static string StringFormat(string componentInfo)
         {
             var replacements = new Dictionary<string, string> { { "@", "%40" }, { "\"", "" }, { "{", "" }, { "\r", "" }, { "}", "" }, { "\n", "" } };
@@ -604,6 +718,12 @@ namespace LCT.PackageIdentifier
             return formattedstring.Trim();
         }
 
+        /// <summary>
+        /// Determines whether a JToken represents a dev dependency and increments counter when true.
+        /// </summary>
+        /// <param name="devValue">JToken value to test.</param>
+        /// <param name="noOfDevDependent">Reference counter incremented for dev dependencies.</param>
+        /// <returns>True if devValue indicates a dev dependency; otherwise false.</returns>
         private static bool IsDevDependency(JToken devValue, ref int noOfDevDependent)
         {
             if (devValue != null)
@@ -614,6 +734,11 @@ namespace LCT.PackageIdentifier
             return devValue != null;
         }
 
+        /// <summary>
+        /// Collects bundled:true components from a dependency map into the bundledComponents list.
+        /// </summary>
+        /// <param name="subdependencies">JToken representing sub-dependencies.</param>
+        /// <param name="bundledComponents">Accumulator list for bundled components.</param>
         private static void GetBundledComponents(JToken subdependencies, ref List<BundledComponents> bundledComponents)
         {
             //changes for components with property "bundled:true" shouldn't be on BOMs 
@@ -637,6 +762,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Removes components that are identified as bundled from the list of components.
+        /// </summary>
+        /// <param name="bundledComponents">List of bundled component identifiers.</param>
+        /// <param name="lstComponentForBOM">Component list to filter.</param>
+        /// <returns>Filtered list with bundled components removed.</returns>
         private static List<Component> RemoveBundledComponentFromList(List<BundledComponents> bundledComponents, List<Component> lstComponentForBOM)
         {
             List<Component> components = [.. lstComponentForBOM];
@@ -649,6 +780,13 @@ namespace LCT.PackageIdentifier
             return components;
         }
 
+        /// <summary>
+        /// Determines whether a component is internal by checking npm.name and npm.version properties in AQL results.
+        /// </summary>
+        /// <param name="aqlResultList">AQL result entries to search.</param>
+        /// <param name="component">Component to check.</param>
+        /// <param name="bomHelper">BOM helper for full-name resolution.</param>
+        /// <returns>True if the component exists in the provided AQL results; otherwise false.</returns>
         private static bool IsInternalNpmComponent(
             List<AqlResult> aqlResultList, Component component, IBomHelper bomHelper)
         {
@@ -661,6 +799,14 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Locates a JFrog AQL result for an NPM component and returns repo details and path.
+        /// </summary>
+        /// <param name="aqlResultList">AQL results to search.</param>
+        /// <param name="component">Component to locate.</param>
+        /// <param name="bomHelper">BOM helper for full-name calculation.</param>
+        /// <param name="jfrogRepoPath">Outputs the repo path when found.</param>
+        /// <returns>Located AqlResult or a default empty result when none found.</returns>
         public static AqlResult GetJfrogArtifactoryRepoDetials(List<AqlResult> aqlResultList,
                                                                 Component component,
                                                                 IBomHelper bomHelper,
@@ -688,6 +834,11 @@ namespace LCT.PackageIdentifier
             return aqlResult;
         }
 
+        /// <summary>
+        /// Formats a JFrog repo path from an AQL result entry.
+        /// </summary>
+        /// <param name="aqlResult">AQL result entry.</param>
+        /// <returns>Formatted repo path.</returns>
         public static string GetJfrogRepoPath(AqlResult aqlResult)
         {
             if (string.IsNullOrEmpty(aqlResult.Path) || aqlResult.Path.Equals("."))
@@ -699,6 +850,12 @@ namespace LCT.PackageIdentifier
         }
 
 
+        /// <summary>
+        /// Adds identification properties to components depending on the source (package, SPDX, CycloneDX).
+        /// </summary>
+        /// <param name="components">List of components to annotate.</param>
+        /// <param name="identifiedBy">Source identifier string (e.g., "PackageFile", "SpdxFile").</param>
+        /// <param name="filePath">Source file path used for SPDX filename property when applicable.</param>
         private static void AddingIdentifierType(List<Component> components, string identifiedBy, string filePath)
         {
             foreach (var component in components)
@@ -734,6 +891,9 @@ namespace LCT.PackageIdentifier
                 }
             }
         }
+        #endregion
 
+        #region Events
+        #endregion
     }
-}
+ }

--- a/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
+++ b/src/LCT.PackageIdentifier/NugetDevDependencyParser.cs
@@ -28,12 +28,20 @@ namespace LCT.PackageIdentifier
 {
     public class NugetDevDependencyParser
     {
+        #region Fields
         private static NugetDevDependencyParser instance = null;
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
         private static readonly List<string> s_nugetDirectDependencies = new List<string>();
-        public static IReadOnlyList<string> NugetDirectDependencies => s_nugetDirectDependencies;
+        #endregion
 
+        #region Properties
+        /// <summary>
+        /// Read-only view of collected NuGet direct dependencies.
+        /// </summary>
+        public static IReadOnlyList<string> NugetDirectDependencies => s_nugetDirectDependencies;
+        #endregion
+
+        #region Constructors
         /// <summary>
         /// Private constructor for singleton pattern implementation.
         /// Registers MSBuild defaults if not already registered.
@@ -47,7 +55,9 @@ namespace LCT.PackageIdentifier
                 MSBuildLocator.RegisterDefaults();
             }
         }
+        #endregion
 
+        #region Methods
         public static NugetDevDependencyParser Instance
         {
             get
@@ -58,6 +68,11 @@ namespace LCT.PackageIdentifier
         }
 
 #pragma warning disable CA1822 // Mark members as static
+        /// <summary>
+        /// Parses the provided project.assets.json file and returns container information with discovered components.
+        /// </summary>
+        /// <param name="configFile">Path to the project.assets.json file to parse.</param>
+        /// <returns>List of containers containing parsed build info components.</returns>
         public List<Container> Parse(string configFile)
 #pragma warning restore CA1822 // Mark members as static
         {
@@ -76,6 +91,11 @@ namespace LCT.PackageIdentifier
             return containerList;
         }
 
+        /// <summary>
+        /// Determines whether the supplied lockfile library represents a development-only dependency.
+        /// </summary>
+        /// <param name="library">The lockfile target library to evaluate.</param>
+        /// <returns>True when the library contains no runtime assets and is considered a dev dependency.</returns>
         private static bool IsDevDependecy(LockFileTargetLibrary library)
         {
             return library.CompileTimeAssemblies.Count == 0
@@ -87,6 +107,11 @@ namespace LCT.PackageIdentifier
                 && library.ToolsAssemblies.Count == 0;
         }
 
+        /// <summary>
+        /// Determines whether the given project file declares it is a test container project.
+        /// </summary>
+        /// <param name="projectPath">Path to the .csproj file to evaluate.</param>
+        /// <returns>True when the project contains a TestContainer capability; otherwise false.</returns>
         private static bool IsTestProject(string projectPath)
         {
             Project csProj;
@@ -140,6 +165,11 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Parses a project.assets.json (lock) file and populates the provided container with discovered components.
+        /// </summary>
+        /// <param name="filePath">Path to the lock file.</param>
+        /// <param name="container">Container to populate with components.</param>
         private static void ParseJsonFile(string filePath, Container container)
         {
             bool isTestProject;
@@ -190,6 +220,10 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Reads direct dependencies (top-level) from a project.assets.json file and registers them.
+        /// </summary>
+        /// <param name="filePath">Path to the lock file.</param>
         private static void GetDirectDependencies(string filePath)
         {
             var readValue = File.ReadAllText(filePath);
@@ -223,6 +257,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Attempts to discover the referenced .csproj when running inside a container by inspecting the assets file path.
+        /// </summary>
+        /// <param name="filePath">Path to the project.assets.json file.</param>
+        /// <param name="container">Container whose name may be updated from discovered project.</param>
+        /// <returns>True when a project file was found and identified as a test project; otherwise false.</returns>
         private static bool ParseJsonInContainer(string filePath, ref Container container)
         {
             bool isTestProject;
@@ -251,6 +291,13 @@ namespace LCT.PackageIdentifier
             return isTestProject;
         }
 
+        /// <summary>
+        /// Parses a lockfile library entry and adds or updates a corresponding component entry in the components map.
+        /// </summary>
+        /// <param name="library">The LockFileTargetLibrary entry to parse.</param>
+        /// <param name="isTestProject">Indicates whether the containing project is a test project.</param>
+        /// <param name="components">Dictionary of components to populate.</param>
+        /// <param name="assetFile">The parsed LockFile for additional context.</param>
         private static void ParseLibrary(LockFileTargetLibrary library, bool isTestProject, IDictionary<string, BuildInfoComponent> components, LockFile assetFile)
         {
             if (library.Type.Equals("project", StringComparison.InvariantCultureIgnoreCase))
@@ -284,6 +331,12 @@ namespace LCT.PackageIdentifier
             GetDependencies(library, component, components);
         }
 
+        /// <summary>
+        /// Adds dependency relationships for a component based on lockfile package dependencies.
+        /// </summary>
+        /// <param name="library">LockFile library with dependency declarations.</param>
+        /// <param name="component">NuGetComponent to populate dependencies for.</param>
+        /// <param name="components">Component dictionary where dependencies are resolved/added.</param>
         private static void GetDependencies(LockFileTargetLibrary library, NuGetComponent component, IDictionary<string, BuildInfoComponent> components)
         {
             foreach (PackageDependency dependency in library.Dependencies)
@@ -314,6 +367,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Attempts to locate local nupkg files for the given package and populate its file hashes.
+        /// </summary>
+        /// <param name="nuGetComponent">Component to populate hashes for.</param>
+        /// <param name="assetFile">LockFile containing package folder information.</param>
+        /// <param name="lockFileTargetLibrary">LockFile library entry corresponding to the component.</param>
         private static void GetLocalPackageHashes(NuGetComponent nuGetComponent, LockFile assetFile, LockFileTargetLibrary lockFileTargetLibrary)
         {
             if (!string.IsNullOrEmpty(nuGetComponent.Md5) && !string.IsNullOrEmpty(nuGetComponent.Sha1) && !string.IsNullOrEmpty(nuGetComponent.Sha256))
@@ -335,6 +394,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Locates the nupkg file in a package folder and calculates its SHA256 hash to assign to the component.
+        /// </summary>
+        /// <param name="nuGetComponent">Component to assign the hash to.</param>
+        /// <param name="packageFolder">Package folder entry from the lock file.</param>
+        /// <param name="lockFileLibrary">LockFileLibrary containing the package path metadata.</param>
         private static void CalculateHashOfPackage(NuGetComponent nuGetComponent, LockFileItem packageFolder, LockFileLibrary lockFileLibrary)
         {
             string packagePath = Path.GetFullPath(Path.Combine(packageFolder.Path, lockFileLibrary.Path));
@@ -361,6 +426,12 @@ namespace LCT.PackageIdentifier
             nuGetComponent.Sha256 = GetFileHash(filePath, SHA256.Create());
         }
 
+        /// <summary>
+        /// Computes a file hash using the supplied hash algorithm and returns it as a lowercase hex string.
+        /// </summary>
+        /// <param name="path">Path to the file to hash.</param>
+        /// <param name="hashAlgorithm">HashAlgorithm instance to use for computation.</param>
+        /// <returns>Hex-encoded hash string or null when the file does not exist.</returns>
         private static string GetFileHash(string path, HashAlgorithm hashAlgorithm)
         {
             if (!File.Exists(path)) return null;
@@ -372,9 +443,9 @@ namespace LCT.PackageIdentifier
         }
 
         /// <summary>
-        /// Adds a direct dependency to the collection if it doesn't already exist
+        /// Adds a direct dependency to the collection if it doesn't already exist.
         /// </summary>
-        /// <param name="dependency">The dependency string to add</param>
+        /// <param name="dependency">The dependency string to add.</param>
         public static void AddDirectDependency(string dependency)
         {
             if (!s_nugetDirectDependencies.Contains(dependency))
@@ -384,16 +455,16 @@ namespace LCT.PackageIdentifier
         }
 
         /// <summary>
-        /// Adds multiple direct dependencies to the collection
+        /// Adds multiple direct dependencies to the collection.
         /// </summary>
-        /// <param name="dependencies">The dependencies to add</param>
+        /// <param name="dependencies">The dependencies to add.</param>
         public static void AddRangeDirectDependencies(IEnumerable<string> dependencies)
         {
             s_nugetDirectDependencies.AddRange(dependencies);
         }
 
         /// <summary>
-        /// Clears all direct dependencies from the collection
+        /// Clears all direct dependencies from the collection.
         /// </summary>
         public static void ClearDirectDependencies()
         {
@@ -401,13 +472,17 @@ namespace LCT.PackageIdentifier
         }
 
         /// <summary>
-        /// Sets the direct dependencies collection (primarily for testing)
+        /// Sets the direct dependencies collection (primarily for testing).
         /// </summary>
-        /// <param name="dependencies">The dependencies to set</param>
+        /// <param name="dependencies">The dependencies to set.</param>
         public static void SetDirectDependencies(IEnumerable<string> dependencies)
         {
             s_nugetDirectDependencies.Clear();
             s_nugetDirectDependencies.AddRange(dependencies);
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Program.cs
+++ b/src/LCT.PackageIdentifier/Program.cs
@@ -38,23 +38,47 @@ namespace LCT.PackageIdentifier
     [ExcludeFromCodeCoverage]
     public class Program
     {
+        #region Fields
         private bool m_Verbose = false;
 
-        public static Stopwatch BomStopWatch { get; set; }
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private static readonly EnvironmentHelper environmentHelper = new EnvironmentHelper();
 
         private readonly ISettingsManager _settingsManager;
         private readonly IBomCreator _bomCreator;
+        #endregion
 
+        #region Properties
+        public static Stopwatch BomStopWatch { get; set; }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Program"/> class with provided dependencies.
+        /// </summary>
+        /// <param name="frameworkPackages">Framework packages provider.</param>
+        /// <param name="settingsManager">Settings manager instance.</param>
+        /// <param name="cycloneDXBomParser">CycloneDX BOM parser.</param>
+        /// <param name="bomCreator">BOM creator instance.</param>
         public Program(IFrameworkPackages frameworkPackages, ISettingsManager settingsManager, ICycloneDXBomParser cycloneDXBomParser, IBomCreator bomCreator)
         {
             _settingsManager = settingsManager;
             _bomCreator = bomCreator;
         }
-        protected Program() { }
 
+        /// <summary>
+        /// Protected parameterless constructor for testing or DI.
+        /// </summary>
+        protected Program() { }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Asynchronously entry point of the application.
+        /// </summary>
+        /// <param name="args">Command line arguments.</param>
+        /// <returns>Asynchronously completes when the application finishes.</returns>
         static async Task Main(string[] args)
         {
             var serviceCollection = new ServiceCollection();
@@ -66,6 +90,10 @@ namespace LCT.PackageIdentifier
             await program.Run(args);
         }
 
+        /// <summary>
+        /// Configures dependency injection services for the application.
+        /// </summary>
+        /// <param name="services">Service collection to populate.</param>
         private static void ConfigureServices(IServiceCollection services)
         {
             services.AddTransient<IFrameworkPackages, FrameworkPackages>();
@@ -78,6 +106,11 @@ namespace LCT.PackageIdentifier
             services.AddScoped<IRuntimeIdentifier, DotnetRuntimeIdentifer>();
         }
 
+        /// <summary>
+        /// Asynchronously runs the main program logic using the provided arguments.
+        /// </summary>
+        /// <param name="args">Command line arguments.</param>
+        /// <returns>Asynchronously completes when run finishes.</returns>
         public async Task Run(string[] args)
         {
             BomStopWatch = new Stopwatch();
@@ -138,6 +171,10 @@ namespace LCT.PackageIdentifier
             PipelineArtifactUploader.UploadArtifacts();
         }
 
+        /// <summary>
+        /// Retrieves the CA tool version and running location from the executing assembly.
+        /// </summary>
+        /// <returns>Information about the CA tool version and running location.</returns>
         private static CatoolInfo GetCatoolVersionFromProjectfile()
         {
             CatoolInfo catoolInfo = new CatoolInfo();
@@ -147,6 +184,11 @@ namespace LCT.PackageIdentifier
             return catoolInfo;
         }
 
+        /// <summary>
+        /// Creates an IJFrogService instance configured from the given application settings.
+        /// </summary>
+        /// <param name="appSettings">Application settings that contain JFrog configuration.</param>
+        /// <returns>Configured IJFrogService or null when settings are not provided.</returns>
         private static IJFrogService GetJfrogService(CommonAppSettings appSettings)
         {
             if (appSettings == null)
@@ -165,6 +207,12 @@ namespace LCT.PackageIdentifier
             return jFrogService;
         }
 
+        /// <summary>
+        /// Asynchronously validates SW360 settings from application settings and exits the environment on failure.
+        /// </summary>
+        /// <param name="appSettings">Application settings to validate.</param>
+        /// <param name="projectReleases">Project releases holder used during validation.</param>
+        /// <returns>Asynchronously completes after validation (may exit process on failure).</returns>
         private static async Task ValidateAppsettingsFile(CommonAppSettings appSettings, ProjectReleases projectReleases)
         {
             SW360ConnectionSettings sw360ConnectionSettings = new SW360ConnectionSettings()
@@ -182,5 +230,9 @@ namespace LCT.PackageIdentifier
                 environmentHelper.CallEnvironmentExit(-1);
             }
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/PythonProcessor.cs
+++ b/src/LCT.PackageIdentifier/PythonProcessor.cs
@@ -36,6 +36,12 @@ namespace LCT.PackageIdentifier
         private readonly ISpdxBomParser _spdxBomParser = spdxBomParser;
         private static Bom ListUnsupportedComponentsForBom = new Bom { Components = new List<Component>(), Dependencies = new List<Dependency>() };
 
+        /// <summary>
+        ///Parses PackageFile
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="unSupportedBomList"></param>
+        /// <returns>updated BOM data</returns>
         public Bom ParsePackageFile(CommonAppSettings appSettings, ref Bom unSupportedBomList)
         {
             List<string> configFiles = FolderScanner.FileScanner(appSettings.Directory.InputFolder, appSettings.Poetry);
@@ -90,6 +96,10 @@ namespace LCT.PackageIdentifier
             return bom;
         }
 
+        /// <summary>
+        /// Adds Siemens DirectProperty
+        /// </summary>
+        /// <param name="bom"></param>
         public static void AddSiemensDirectProperty(ref Bom bom)
         {
             List<string> pythonDirectDependencies = new List<string>();
@@ -115,6 +125,12 @@ namespace LCT.PackageIdentifier
 
         #region Private Methods
 
+        /// <summary>
+        /// Extract Details For Poetry Lock file
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="dependencies"></param>
+        /// <returns> list of package</returns>
         public static List<PythonPackage> ExtractDetailsForPoetryLockfile(string filePath, List<Dependency> dependencies)
         {
             List<PythonPackage> PythonPackages;
@@ -122,6 +138,12 @@ namespace LCT.PackageIdentifier
             return PythonPackages;
         }
 
+        /// <summary>
+        /// Gets Packages From TOML File
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="dependencies"></param>
+        /// <returns>list of package</returns>
         private static List<PythonPackage> GetPackagesFromTOMLFile(string filePath, List<Dependency> dependencies)
         {
             List<PythonPackage> PythonPackages = new();
@@ -155,6 +177,12 @@ namespace LCT.PackageIdentifier
             return PythonPackages;
         }
 
+        /// <summary>
+        /// Gets Ref Details From DependencyText
+        /// </summary>
+        /// <param name="keyValues"></param>
+        /// <param name="dependencies"></param>
+        /// <param name="PythonPackages"></param>
         private static void GetRefDetailsFromDependencyText(List<KeyValuePair<string, TomlNode>> keyValues, List<Dependency> dependencies, List<PythonPackage> PythonPackages)
         {
             foreach (var node in keyValues)
@@ -180,6 +208,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Form Ref From Node Details
+        /// </summary>
+        /// <param name="valuePair"></param>
+        /// <param name="PythonPackages"></param>
+        /// <returns>node details</returns>
         private static string FormRefFromNodeDetails(KeyValuePair<string, TomlNode> valuePair, List<PythonPackage> PythonPackages)
         {
             var value = PythonPackages.Find(val => val.Name == valuePair.Key)?.Version;
@@ -194,6 +228,13 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Extract Details From Json
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="dependencies"></param>
+        /// <returns>list of package</returns>
         private List<PythonPackage> ExtractDetailsFromJson(string filePath, CommonAppSettings appSettings, ref List<Dependency> dependencies)
         {
             Bom bom;
@@ -248,6 +289,10 @@ namespace LCT.PackageIdentifier
             return PythonPackages;
         }
 
+        /// <summary>
+        /// Gets Distinct ComponentList
+        /// </summary>
+        /// <param name="listofComponents"></param>
         private static void GetDistinctComponentList(ref List<PythonPackage> listofComponents)
         {
             int initialCount = listofComponents.Count;
@@ -257,6 +302,12 @@ namespace LCT.PackageIdentifier
                 BomCreator.bomKpiData.DuplicateComponents = initialCount - listofComponents.Count;
         }
 
+        /// <summary>
+        /// Gets Release ExternalId
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>release id</returns>
         private static string GetReleaseExternalId(string name, string version)
         {
             version = WebUtility.UrlEncode(version);
@@ -265,6 +316,11 @@ namespace LCT.PackageIdentifier
             return $"{Dataconstant.PurlCheck()["POETRY"]}{Dataconstant.ForwardSlash}{name}@{version}";
         }
 
+        /// <summary>
+        /// Form Component Release ExternalID
+        /// </summary>
+        /// <param name="listOfComponents"></param>
+        /// <returns>list of components</returns>
         private static List<Component> FormComponentReleaseExternalID(List<PythonPackage> listOfComponents)
         {
             List<Component> listComponentForBOM = new List<Component>();
@@ -283,6 +339,12 @@ namespace LCT.PackageIdentifier
             return listComponentForBOM;
         }
 
+        /// <summary>
+        /// Remove Excluded Components
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="cycloneDXBOM"></param>
+        /// <returns>updated BOM file</returns>
         private static Bom RemoveExcludedComponents(CommonAppSettings appSettings,
             Bom cycloneDXBOM)
         {
@@ -290,6 +352,14 @@ namespace LCT.PackageIdentifier
                 noOfExcludedComponents => BomCreator.bomKpiData.ComponentsExcludedSW360 += noOfExcludedComponents);
         }
 
+        /// <summary>
+        /// Identification Of InternalComponents
+        /// </summary>
+        /// <param name="componentData"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="jFrogService"></param>
+        /// <param name="bomhelper"></param>
+        /// <returns>component identification</returns>
         public async Task<ComponentIdentification> IdentificationOfInternalComponents(ComponentIdentification componentData, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
             // get the  component list from Jfrog for given repo
@@ -310,6 +380,13 @@ namespace LCT.PackageIdentifier
             return componentData;
         }
 
+        /// <summary>
+        /// Is Internal PythonComponent
+        /// </summary>
+        /// <param name="aqlResultList"></param>
+        /// <param name="component"></param>
+        /// <param name="bomHelper"></param>
+        /// <returns>boolean value</returns>
         private static bool IsInternalPythonComponent(List<AqlResult> aqlResultList, Component component, IBomHelper bomHelper)
         {
             string jfrogcomponentName = bomHelper.GetFullNameOfComponent(component);
@@ -321,7 +398,13 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
-
+        /// <summary>
+        /// Gets Jfrog Name Of PypiComponent
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="aqlResultList"></param>
+        /// <returns>component name</returns>
         private static string GetJfrogNameOfPypiComponent(string name, string version, List<AqlResult> aqlResultList)
         {
 
@@ -333,7 +416,14 @@ namespace LCT.PackageIdentifier
             return nameVerison;
         }
 
-
+        /// <summary>
+        ///Gets Jfrog Repo Details OfAComponent
+        /// </summary>
+        /// <param name="componentsForBOM"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="jFrogService"></param>
+        /// <param name="bomhelper"></param>
+        /// <returns>list of component</returns>
         public async Task<List<Component>> GetJfrogRepoDetailsOfAComponent(List<Component> componentsForBOM, CommonAppSettings appSettings, IJFrogService jFrogService, IBomHelper bomhelper)
         {
             // get the  component list from Jfrog for given repo + internal repo
@@ -350,6 +440,15 @@ namespace LCT.PackageIdentifier
             return modifiedBOM;
         }
 
+        /// <summary>
+        /// Process Python Component
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="aqlResultList"></param>
+        /// <param name="bomhelper"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="projectType"></param>
+        /// <returns>component name</returns>
         private static Component ProcessPythonComponent(Component component, List<AqlResult> aqlResultList, IBomHelper bomhelper, CommonAppSettings appSettings, Property projectType)
         {
             string repoName = GetArtifactoryRepoName(aqlResultList, component, bomhelper, out string jfrogPackageNameWhlExten, out string jfrogRepoPath);
@@ -369,6 +468,11 @@ namespace LCT.PackageIdentifier
             return componentVal;
         }
 
+        /// <summary>
+        /// Updates Python Kpi Data Based On Repo
+        /// </summary>
+        /// <param name="repoValue"></param>
+        /// <param name="appSettings"></param>
         private static void UpdatePythonKpiDataBasedOnRepo(string repoValue, CommonAppSettings appSettings)
         {
             if (repoValue == appSettings.Poetry.DevDepRepo)
@@ -399,6 +503,15 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Gets Artifactory Repo Name
+        /// </summary>
+        /// <param name="aqlResultList"></param>
+        /// <param name="component"></param>
+        /// <param name="bomHelper"></param>
+        /// <param name="jfrogPackageName"></param>
+        /// <param name="jfrogRepoPath"></param>
+        /// <returns>repo name</returns>
         private static string GetArtifactoryRepoName(List<AqlResult> aqlResultList,
                                                      Component component,
                                                      IBomHelper bomHelper,
@@ -444,6 +557,11 @@ namespace LCT.PackageIdentifier
             return repoName;
         }
 
+        /// <summary>
+        /// Gets Jfrog Repo Path
+        /// </summary>
+        /// <param name="aqlResult"></param>
+        /// <returns>repo path</returns>
         private static string GetJfrogRepoPath(AqlResult aqlResult)
         {
             if (string.IsNullOrEmpty(aqlResult.Path) || aqlResult.Path.Equals("."))
@@ -453,6 +571,12 @@ namespace LCT.PackageIdentifier
 
             return $"{aqlResult.Repo}/{aqlResult.Path}/{aqlResult.Name}";
         }
+
+        /// <summary>
+        /// Adds Component Properties
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="component"></param>
         private static void AddComponentProperties(PythonPackage prop, Component component)
         {
             var devDependency = new Property
@@ -473,6 +597,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Adds Spdx Properties
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="component"></param>
         private static void AddSpdxProperties(PythonPackage prop, Component component)
         {
             string fileName = Path.GetFileName(prop.SpdxComponentDetails.SpdxFilePath);
@@ -480,6 +609,12 @@ namespace LCT.PackageIdentifier
             SpdxSbomHelper.AddDevelopmentPropertyForSpdx(prop.SpdxComponentDetails.DevComponent, component);
         }
 
+        /// <summary>
+        /// Adds Identifier Type Property
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="component"></param>
+        /// <param name="devDependency"></param>
         private static void AddIdentifierTypeProperty(PythonPackage prop, Component component, Property devDependency)
         {
             component.Properties ??= new List<Property>();
@@ -494,6 +629,13 @@ namespace LCT.PackageIdentifier
                 identifierTypeValue);
             component.Properties = properties;
         }
+
+        /// <summary>
+        /// Sets Spdx ComponentDetails
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="package"></param>
+        /// <param name="componentInfo"></param>
         private static void SetSpdxComponentDetails(string filePath, PythonPackage package, Component componentInfo)
         {
             if (filePath.EndsWith(FileConstant.SPDXFileExtension))

--- a/src/LCT.PackageIdentifier/SbomTemplate.cs
+++ b/src/LCT.PackageIdentifier/SbomTemplate.cs
@@ -19,8 +19,24 @@ namespace LCT.PackageIdentifier
 {
     public static class SbomTemplate
     {
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        #endregion
 
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Processes a SBOM template file and applies template component details to the provided BOM components list.
+        /// </summary>
+        /// <param name="templateFilePath">Path to the CycloneDX template file.</param>
+        /// <param name="cycloneDXBomParser">Parser used to read CycloneDX BOM files.</param>
+        /// <param name="componentsForBOM">Component list to which template details will be applied or appended.</param>
+        /// <param name="projectType">Project type used to validate components from the template.</param>
         public static void ProcessTemplateFile(string templateFilePath, ICycloneDXBomParser cycloneDXBomParser, List<Component> componentsForBOM, string projectType)
         {
             if (File.Exists(templateFilePath) && templateFilePath.EndsWith(FileConstant.SBOMTemplateFileExtension))
@@ -30,6 +46,12 @@ namespace LCT.PackageIdentifier
                 AddComponentDetails(componentsForBOM, templateDetails);
             }
         }
+
+        /// <summary>
+        /// Selects the first template file path from a list and logs when multiple templates are provided.
+        /// </summary>
+        /// <param name="filePaths">List of candidate template file paths.</param>
+        /// <returns>The selected template file path, or an empty string when none provided.</returns>
         public static string GetFilePathForTemplate(List<string> filePaths)
         {
             string firstFilePath = string.Empty;
@@ -43,6 +65,12 @@ namespace LCT.PackageIdentifier
             }
             return firstFilePath;
         }
+
+        /// <summary>
+        /// Adds components from the SBOM template into the target BOM list when missing.
+        /// </summary>
+        /// <param name="bom">Target BOM component list to merge into.</param>
+        /// <param name="sbomdDetails">Template BOM details containing components to apply.</param>
         public static void AddComponentDetails(List<Component> bom, Bom sbomdDetails)
         {
             if (sbomdDetails.Components == null)
@@ -56,6 +84,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Adds a template component to the BOM or updates an existing BOM component with template properties/licenses.
+        /// </summary>
+        /// <param name="bom">Target BOM component list.</param>
+        /// <param name="sbomcomp">Template component to add or apply.</param>
         private static void PropertyAdditionForTemplate(List<Component> bom, Component sbomcomp)
         {
             try
@@ -86,6 +119,11 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Updates an existing BOM component using values from a template component and increments KPI counters when updated.
+        /// </summary>
+        /// <param name="sbomcomp">Template component.</param>
+        /// <param name="bomComp">Existing BOM component to update.</param>
         private static void TemplateComponentUpdation(Component sbomcomp, Component bomComp)
         {
             bool isLicenseUpdated = UpdateLicenseDetails(bomComp, sbomcomp);
@@ -102,6 +140,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Merges license information from the template component into the BOM component when present.
+        /// </summary>
+        /// <param name="bomComp">Existing BOM component to update.</param>
+        /// <param name="sbomcomp">Template component containing license data.</param>
+        /// <returns>True if licenses were added; otherwise false.</returns>
         private static bool UpdateLicenseDetails(Component bomComp, Component sbomcomp)
         {
             //Adding Licenses if mainatined
@@ -121,6 +165,12 @@ namespace LCT.PackageIdentifier
             return false;
         }
 
+        /// <summary>
+        /// Merges properties from the template component into the BOM component and sets identifier type to 'TemplateUpdated'.
+        /// </summary>
+        /// <param name="bomComp">Existing BOM component to update.</param>
+        /// <param name="sbomcomp">Template component containing properties.</param>
+        /// <returns>True if properties were added; otherwise false.</returns>
         private static bool UpdatePropertiesDetails(Component bomComp, Component sbomcomp)
         {
             //Adding properties if mainatined
@@ -145,5 +195,9 @@ namespace LCT.PackageIdentifier
             }
             return false;
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.PackageIdentifier/Scanner.cs
+++ b/src/LCT.PackageIdentifier/Scanner.cs
@@ -24,8 +24,25 @@ namespace LCT.PackageIdentifier
     public static class FolderScanner
     {
 
+        #region Fields
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private static readonly EnvironmentHelper environmentHelper = new EnvironmentHelper();
+        #endregion
+
+        #region Properties
+        #endregion
+
+        #region Constructors
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Scans the specified rootPath for files matching include patterns from the config and returns the matching file paths,
+        /// excluding those that match any exclusion patterns.
+        /// </summary>
+        /// <param name="rootPath">Root directory to scan for package files.</param>
+        /// <param name="config">Configuration containing Include and Exclude patterns.</param>
+        /// <returns>List of discovered file paths that match include patterns and are not excluded.</returns>
         public static List<string> FileScanner(string rootPath, Config config)
         {
 
@@ -76,6 +93,13 @@ namespace LCT.PackageIdentifier
 
         }
 
+        /// <summary>
+        /// Validates a discovered file against the exclusion patterns and, when not excluded, logs and validates the file path.
+        /// </summary>
+        /// <param name="config">Config instance containing Exclude patterns.</param>
+        /// <param name="fileOperations">File operations helper used to validate the file path.</param>
+        /// <param name="allFoundConfigFiles">Accumulator list of discovered files to add to.</param>
+        /// <param name="configFile">Path of the discovered file to check.</param>
         private static void CheckingForExcludedFiles(Config config, IFileOperations fileOperations, List<string> allFoundConfigFiles, string configFile)
         {
             if (!IsExcluded(configFile, config.Exclude))
@@ -90,6 +114,12 @@ namespace LCT.PackageIdentifier
             }
         }
 
+        /// <summary>
+        /// Determines whether the provided file path matches any of the exclusion regular expressions.
+        /// </summary>
+        /// <param name="filePath">File path to evaluate.</param>
+        /// <param name="exclusionPatterns">Array of regex patterns to test against. When null or empty, no exclusion is applied.</param>
+        /// <returns>True if the file path matches any exclusion pattern; otherwise false.</returns>
         internal static bool IsExcluded(string filePath, string[] exclusionPatterns)
         {
             if (exclusionPatterns == null || exclusionPatterns.Length == 0)
@@ -106,5 +136,9 @@ namespace LCT.PackageIdentifier
 
             return false;
         }
+        #endregion
+
+        #region Events
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/AlpinePackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/AlpinePackageDownloader.cs
@@ -31,7 +31,13 @@ namespace LCT.SW360PackageCreator
 
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-
+        /// <summary>
+        /// Downloads the source package for the specified component and returns the local file path to the downloaded
+        /// archive.
+        /// </summary>
+        /// <param name="component">The component metadata containing information about the package to download. Cannot be null.</param>
+        /// <param name="localPathforDownload">The local directory path where the package should be downloaded. Must be a valid, writable path.</param>
+        /// <returns>A string containing the full local file path to the downloaded package archive.</returns>
         public async Task<string> DownloadPackage(ComparisonBomData component, string localPathforDownload)
         {
             string localPathforSourceRepo = UrlHelper.GetDownloadPathForAlpineRepo();
@@ -43,6 +49,13 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// copies the build files from source repo to download folder
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <param name="sourceData"></param>
+        /// <param name="localPathforSourceRepo"></param>
         private static void CopyBuildFilesFromSourceRepo(string localPathforDownload, ComparisonBomData component, string sourceData, string localPathforSourceRepo)
         {
             if (sourceData != null)
@@ -64,12 +77,26 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// gets the current download folder path
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <returns>folder path</returns>
         private static string GetCurrentDownloadFolderPath(string localPathforDownload, ComparisonBomData component)
         {
             return $"{localPathforDownload}{component.Name}--{DateTime.Now.ToString("yyyyMMddHHmmss")}{Dataconstant.ForwardSlash}";
         }
 
-
+        /// <summary>
+        /// downloads the tar file and get the path
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="SourceUrl"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="sourceData"></param>
+        /// <param name="localPathforSourceRepo"></param>
+        /// <returns>file and path</returns>
         private static async Task<string> DownloadTarFileAndGetPath(ComparisonBomData component, string SourceUrl, string localPathforDownload, string sourceData, string localPathforSourceRepo)
         {
             string downloadPath = string.Empty;
@@ -100,6 +127,15 @@ namespace LCT.SW360PackageCreator
 
             return downloadPath;
         }
+
+        /// <summary>
+        /// applies the patch files to source code
+        /// </summary>
+        /// <param name="downloadPath"></param>
+        /// <param name="sourceData"></param>
+        /// <param name="localPathforSourceRepo"></param>
+        /// <param name="component"></param>
+        /// <param name="localPathforDownload"></param>
         private static void ApplyPatchFilesToSourceCode(string downloadPath, string sourceData, string localPathforSourceRepo, ComparisonBomData component, string localPathforDownload)
         {
             string[] buildFilesList = sourceData.Split("\n");
@@ -158,7 +194,13 @@ namespace LCT.SW360PackageCreator
 
         }
 
-
+        /// <summary>
+        /// package folder ungzip
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <param name="sourceCodezippedFolder"></param>
+        /// <param name="downloadPath"></param>
         public static void PackageFolderUnGzip(string localPathforDownload, ComparisonBomData component, string sourceCodezippedFolder, string downloadPath)
         {
             DirectoryInfo directorySelected = new DirectoryInfo(localPathforDownload);
@@ -211,6 +253,13 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// packages the folder gzip
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <param name="sourceCodezippedFolder"></param>
+        /// <returns>package zip folder</returns>
         public static string PackageFolderGzip(string localPathforDownload, ComparisonBomData component, string sourceCodezippedFolder)
         {
             string tarArchivePath;
@@ -240,6 +289,11 @@ namespace LCT.SW360PackageCreator
 
             return tarArchivePath;
         }
+        /// <summary>
+        /// gets the correct file extension
+        /// </summary>
+        /// <param name="sourceURL"></param>
+        /// <returns>file extension</returns>
         private static string GetCorrectFileExtension(string sourceURL)
         {
             int idx = sourceURL.LastIndexOf(Dataconstant.ForwardSlash);
@@ -253,6 +307,11 @@ namespace LCT.SW360PackageCreator
             return fullname;
         }
 
+        /// <summary>
+        /// applies the patchs to source code
+        /// </summary>
+        /// <param name="patchFileFolder"></param>
+        /// <param name="sourceCodezippedFolder"></param>
         public static void ApplyPatchsToSourceCode(string patchFileFolder, string sourceCodezippedFolder)
         {
             Process p = new Process();

--- a/src/LCT.SW360PackageCreator/CreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/CreatorHelper.cs
@@ -45,6 +45,11 @@ namespace LCT.SW360PackageCreator
         private const string SOURCE = "SOURCE";
         private readonly IDictionary<string, IPackageDownloader> _packageDownloderList = packageDownloderList;
 
+        /// <summary>
+        /// Get Download Url Not Found List
+        /// </summary>
+        /// <param name="comparisionBomDataList"></param>
+        /// <returns>BOM data</returns>
         public List<ComparisonBomData> GetDownloadUrlNotFoundList(List<ComparisonBomData> comparisionBomDataList)
         {
             List<ComparisonBomData> downloadUrlNotFoundList = new List<ComparisonBomData>();
@@ -67,6 +72,11 @@ namespace LCT.SW360PackageCreator
             return downloadUrlNotFoundList;
         }
 
+        /// <summary>
+        /// Download Release Attachment Source
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns>url list</returns>
         public async Task<Dictionary<string, string>> DownloadReleaseAttachmentSource(ComparisonBomData component)
         {
             Dictionary<string, string> AttachmentUrlList = new Dictionary<string, string>();
@@ -96,6 +106,13 @@ namespace LCT.SW360PackageCreator
             return AttachmentUrlList;
         }
 
+        /// <summary>
+        /// get attachment url list
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="AttachmentUrlList"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>path</returns>
         private async Task<string> GetAttachmentUrlList(ComparisonBomData component, Dictionary<string, string> AttachmentUrlList, string localPathforDownload)
         {
             string downloadPath = string.Empty;
@@ -139,6 +156,12 @@ namespace LCT.SW360PackageCreator
             return downloadPath;
         }
 
+        /// <summary>
+        /// Download Cargo Source
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>data</returns>
         private static async Task<string> DownloadCargoSource(ComparisonBomData component, string localPathforDownload)
         {
             if (!string.IsNullOrEmpty(component.DownloadUrl))
@@ -163,6 +186,11 @@ namespace LCT.SW360PackageCreator
             }
             return "";
         }
+        /// <summary>
+        /// Convert Zip To TarGz If Needed
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns>file path</returns>
         private static string ConvertZipToTarGzIfNeeded(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
@@ -175,6 +203,12 @@ namespace LCT.SW360PackageCreator
             }
             return filePath;
         }
+
+        /// <summary>
+        /// Download  Dependency List
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns>task that returns asynchronous operation</returns>
         private static async Task DownloadDependencyList(ComparisonBomData component)
         {
             string localPathforDownload = $"{Path.GetTempPath()}ClearingTool\\DownloadedFiles/";
@@ -203,6 +237,12 @@ namespace LCT.SW360PackageCreator
             await processResult;
         }
 
+        /// <summary>
+        /// Gets Attachment Url List For Mvn
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <param name="attachmentUrlList"></param>
         public static void GetAttachmentUrlListForMvn(string localPathforDownload, ComparisonBomData component,
                                                       ref Dictionary<string, string> attachmentUrlList)
         {
@@ -215,6 +255,12 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// Gets Attachment Url List
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>task that returns asynchronous operation</returns>
         private static async Task<string> GetAttachmentUrlList(ComparisonBomData component, string localPathforDownload)
         {
             string downloadPath = string.Empty;
@@ -242,7 +288,12 @@ namespace LCT.SW360PackageCreator
             return downloadPath;
         }
 
-
+        /// <summary>
+        /// Sets Contents For Comparison BOM
+        /// </summary>
+        /// <param name="lstComponentForBOM"></param>
+        /// <param name="sw360Service"></param>
+        /// <returns>BOM data</returns>
         public async Task<List<ComparisonBomData>> SetContentsForComparisonBOM(List<Components> lstComponentForBOM, ISW360Service sw360Service)
         {
             Logger.Debug($"SetContentsForComparisonBOM():Start");           
@@ -257,6 +308,12 @@ namespace LCT.SW360PackageCreator
             return comparisonBomData;
         }       
 
+        /// <summary>
+        /// Gets Comparision Bom Items
+        /// </summary>
+        /// <param name="lstComponentForBOM"></param>
+        /// <param name="sw360Service"></param>
+        /// <returns>BOM data</returns>
         private async Task<List<ComparisonBomData>> GetComparisionBomItems(List<Components> lstComponentForBOM, ISW360Service sw360Service)
         {
             List<ComparisonBomData> comparisonBomData = new();
@@ -302,6 +359,12 @@ namespace LCT.SW360PackageCreator
             return comparisonBomData;
         }
 
+        /// <summary>
+        /// Sets Debia nUrls
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="releasesInfo"></param>
+        /// <param name="mapper"></param>
         private static void SetDebianUrls(Components item, ReleasesInfo releasesInfo, ComparisonBomData mapper)
         {
             if ((string.IsNullOrEmpty(item.SourceUrl) || item.SourceUrl == Dataconstant.SourceUrlNotFound) && !string.IsNullOrEmpty(releasesInfo.SourceCodeDownloadUrl))
@@ -313,6 +376,11 @@ namespace LCT.SW360PackageCreator
             mapper.PatchURls = item.PatchURLs;
         }
 
+        /// <summary>
+        /// package type
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>boolean value</returns>
         private static bool IsOtherPackageType(Components item)
         {
             return item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["POETRY"]) ||
@@ -321,6 +389,11 @@ namespace LCT.SW360PackageCreator
                    item.ReleaseExternalId.Contains(Dataconstant.PurlCheck()["CARGO"]);
         }
 
+        /// <summary>
+        /// Sets Mapper Status
+        /// </summary>
+        /// <param name="mapper"></param>
+        /// <param name="releasesInfo"></param>
         private void SetMapperStatus(ComparisonBomData mapper, ReleasesInfo releasesInfo)
         {
             mapper.ApprovedStatus = GetApprovedStatus(mapper.ComponentStatus, mapper.ReleaseStatus, releasesInfo);
@@ -332,6 +405,14 @@ namespace LCT.SW360PackageCreator
             mapper.FossologyLink = releasesInfo?.AdditionalData?.TryGetValue("fossology url", out string fossologyUrl) == true ? fossologyUrl : string.Empty;
             mapper.ReleaseCreatedBy = releasesInfo?.CreatedBy ?? string.Empty;
         }
+
+        /// <summary>
+        /// Gets Maven Download Url
+        /// </summary>
+        /// <param name="mapper"></param>
+        /// <param name="item"></param>
+        /// <param name="releasesInfo"></param>
+        /// <returns></returns>
         public static string GetMavenDownloadUrl(ComparisonBomData mapper, Components item, ReleasesInfo releasesInfo)
         {
             string sourceURL = string.Empty;
@@ -350,6 +431,14 @@ namespace LCT.SW360PackageCreator
             return sourceURL;
         }
 
+        /// <summary>
+        /// Gets Updated Components Details
+        /// </summary>
+        /// <param name="ListofBomComponents"></param>
+        /// <param name="updatedCompareBomData"></param>
+        /// <param name="sw360Service"></param>
+        /// <param name="bom"></param>
+        /// <returns>bom data</returns>
         public async Task<Bom> GetUpdatedComponentsDetails(List<Components> ListofBomComponents, List<ComparisonBomData> updatedCompareBomData,
             ISW360Service sw360Service, Bom bom)
         {
@@ -378,6 +467,13 @@ namespace LCT.SW360PackageCreator
             }
             return bom;
         }
+
+        /// <summary>
+        /// Finds Matching Component
+        /// </summary>
+        /// <param name="bom"></param>
+        /// <param name="comBom"></param>
+        /// <returns>component data</returns>
         private static Component FindMatchingComponent(Bom bom, ComparisonBomData comBom)
         {
             if (!bom.Components.Exists(x => x.BomRef.Contains(Dataconstant.PurlCheck()["MAVEN"])))
@@ -392,6 +488,11 @@ namespace LCT.SW360PackageCreator
                 return bom.Components.Find(com => com.Name == comBom.Name && com.Version.Contains(comBom.Version));
             }
         }
+
+        /// <summary>
+        /// Updates Release Link
+        /// </summary>
+        /// <param name="comBom"></param>
         private void UpdateReleaseLink(ComparisonBomData comBom)
         {
             if (string.IsNullOrEmpty(comBom.ReleaseLink))
@@ -399,6 +500,12 @@ namespace LCT.SW360PackageCreator
                 comBom.ReleaseLink = GetReleaseLink(componentsAvailableInSw360, comBom.Name, comBom.Version);
             }
         }
+
+        /// <summary>
+        /// Add Or Update Properties
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="listOfProperties"></param>
         private static void AddOrUpdateProperties(Component component, Dictionary<string, string> listOfProperties)
         {
             if (component == null) return;
@@ -410,6 +517,12 @@ namespace LCT.SW360PackageCreator
             }
 
         }
+
+        /// <summary>
+        /// Gets Download Path For Componet Type
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns>local path</returns>
         private static string GetDownloadPathForComponetType(ComparisonBomData component)
         {
             string localPathforDownload = string.Empty;
@@ -440,6 +553,11 @@ namespace LCT.SW360PackageCreator
             return localPathforDownload;
         }
 
+        /// <summary>
+        /// Gets Creator Kpi Data
+        /// </summary>
+        /// <param name="updatedCompareBomData"></param>
+        /// <returns>kpi data</returns>
         public CreatorKpiData GetCreatorKpiData(List<ComparisonBomData> updatedCompareBomData)
         {
             CreatorKpiData creatorKpiData = new CreatorKpiData
@@ -476,6 +594,11 @@ namespace LCT.SW360PackageCreator
             return creatorKpiData;
         }
 
+        /// <summary>
+        /// Components With And With Out Source Download Url
+        /// </summary>
+        /// <param name="creatorKpiData"></param>
+        /// <param name="item"></param>
         public static void ComponentsWithAndWithOutSourceDownloadUrl(ref CreatorKpiData creatorKpiData, ComparisonBomData item)
         {
             if (item.DownloadUrl == Dataconstant.DownloadUrlNotFound || string.IsNullOrEmpty(item.DownloadUrl))
@@ -507,22 +630,42 @@ namespace LCT.SW360PackageCreator
             }
         }
 
+        /// <summary>
+        /// Is Component Not Created
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>boolean value</returns>
         private static bool IsComponentNotCreated(ComparisonBomData item)
         {
             return item.IsComponentCreated == Dataconstant.NotCreated || item.IsReleaseCreated == Dataconstant.NotCreated;
         }
 
+        /// <summary>
+        /// Is component created
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>boolean value</returns>
         private static bool IsComponentCreated(ComparisonBomData item)
         {
             return item.IsComponentCreated == Dataconstant.Created && item.IsReleaseCreated == Dataconstant.Created;
         }
 
+        /// <summary>
+        /// Is Component Newly Created
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>boolean value</returns>
         private static bool IsComponentNewlyCreated(ComparisonBomData item)
         {
             return (item.IsComponentCreated == Dataconstant.NewlyCreated && item.IsReleaseCreated == Dataconstant.NewlyCreated)
                                 || (item.IsComponentCreated == Dataconstant.Created && item.IsReleaseCreated == Dataconstant.NewlyCreated);
         }
 
+        /// <summary>
+        /// Initialize Sw360 Creator Service
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <returns>sw360 creator service</returns>
         public static ISw360CreatorService InitializeSw360CreatorService(CommonAppSettings appSettings)
         {
             SW360ConnectionSettings sw360ConnectionSettings = new SW360ConnectionSettings()
@@ -537,6 +680,11 @@ namespace LCT.SW360PackageCreator
             return new Sw360CreatorService(sw360ApicommunicationFacade);
         }
 
+        /// <summary>
+        /// initialize project service
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <returns>project service</returns>
         public static ISw360ProjectService InitializeSw360ProjectService(CommonAppSettings appSettings)
         {
             SW360ConnectionSettings sw360ConnectionSettings = new SW360ConnectionSettings()
@@ -552,6 +700,10 @@ namespace LCT.SW360PackageCreator
             return new Sw360ProjectService(sW360ApicommunicationFacade);
         }
 
+        /// <summary>
+        /// write creator kpt data to console
+        /// </summary>
+        /// <param name="creatorKpiData"></param>
         public void WriteCreatorKpiDataToConsole(CreatorKpiData creatorKpiData)
         {
             Logger.Warn("Todo: Default component type is OSS. User is expected to manually change the component type from OSS to COTS.");
@@ -588,6 +740,12 @@ namespace LCT.SW360PackageCreator
 
             LoggerHelper.WriteToConsoleTable(printList, printTimingList, "", Dataconstant.Creator, createrKpiNames);
         }
+
+        /// <summary>
+        /// identify kpi names
+        /// </summary>
+        /// <param name="creatorKpiData"></param>
+        /// <returns>kpi names</returns>
         private static KpiNames IdentifyKpiNames(CreatorKpiData creatorKpiData)
         {
             KpiNames createrKpiNames = new KpiNames();
@@ -607,6 +765,11 @@ namespace LCT.SW360PackageCreator
             return createrKpiNames;
         }
 
+        /// <summary>
+        /// Write Source Not Found List To Console
+        /// </summary>
+        /// <param name="comparisionBomDataList"></param>
+        /// <param name="appSetting"></param>
         public void WriteSourceNotFoundListToConsole(List<ComparisonBomData> comparisionBomDataList, CommonAppSettings appSetting)
         {          
 
@@ -630,12 +793,25 @@ namespace LCT.SW360PackageCreator
             LoggerHelper.WriteComponentsWithoutDownloadURLToKpi(sourceNotAvailable, lstReleaseNotCreated, appSetting.SW360.URL, DuplicateComponentsByPurlId);
         }
 
+        /// <summary>
+        /// Gets Component Availability Status
+        /// </summary>
+        /// <param name="componentsAvailable"></param>
+        /// <param name="component"></param>
+        /// <returns></returns>
         private static string GetComponentAvailabilityStatus(List<Components> componentsAvailable, Components component)
         {
             return componentsAvailable.Exists(x => x.Name.Equals(component.Name, StringComparison.InvariantCultureIgnoreCase)
             || x.ComponentExternalId.Equals(component.ComponentExternalId, StringComparison.InvariantCultureIgnoreCase)) ? Dataconstant.Available : Dataconstant.NotAvailable;
         }
 
+        /// <summary>
+        /// Is Release Available
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componentVersion"></param>
+        /// <param name="releaseExternalId"></param>
+        /// <returns>data</returns>
         private string IsReleaseAvailable(string componentName, string componentVersion, string releaseExternalId)
         {
             if (componentsAvailableInSw360.Exists(
@@ -647,6 +823,15 @@ namespace LCT.SW360PackageCreator
 
             return Dataconstant.NotAvailable;
         }
+
+        /// <summary>
+        /// Gets Component Download Url
+        /// </summary>
+        /// <param name="mapper"></param>
+        /// <param name="item"></param>
+        /// <param name="repo"></param>
+        /// <param name="releasesInfo"></param>
+        /// <returns>data</returns>
         public static string GetComponentDownloadUrl(ComparisonBomData mapper, Components item, IRepository repo, ReleasesInfo releasesInfo)
         {
 
@@ -657,6 +842,13 @@ namespace LCT.SW360PackageCreator
             return repo.FormGitCloneUrl(mapper.SourceUrl, item.Name, item.Version);
         }
 
+        /// <summary>
+        /// Gets Approved Status
+        /// </summary>
+        /// <param name="componentAvailabelStatus"></param>
+        /// <param name="releaseAvailbilityStatus"></param>
+        /// <param name="releasesInfo"></param>
+        /// <returns>data</returns>
         public static string GetApprovedStatus(string componentAvailabelStatus, string releaseAvailbilityStatus, ReleasesInfo releasesInfo)
         {
 
@@ -668,17 +860,34 @@ namespace LCT.SW360PackageCreator
             return Dataconstant.NotAvailable;
         }
 
+        /// <summary>
+        /// Gets Created Status
+        /// </summary>
+        /// <param name="availabilityStatus"></param>
+        /// <returns>status</returns>
         public static string GetCreatedStatus(string availabilityStatus)
         {
             return availabilityStatus == Dataconstant.Available ? Dataconstant.Created : Dataconstant.NotCreated;
         }
 
+        /// <summary>
+        /// Gets Fossology Upload Status
+        /// </summary>
+        /// <param name="ComponentApprovedStatus"></param>
+        /// <returns>status</returns>
         public static string GetFossologyUploadStatus(string ComponentApprovedStatus)
         {
             return (ComponentApprovedStatus == Dataconstant.NotAvailable ||
                      ComponentApprovedStatus == Dataconstant.NewClearing) ? Dataconstant.NotUploaded : Dataconstant.AlreadyUploaded;
         }
 
+        /// <summary>
+        /// Gets Release Link
+        /// </summary>
+        /// <param name="componentsAvailableInSw360"></param>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>release link</returns>
         public static string GetReleaseLink(List<Components> componentsAvailableInSw360, string name, string version)
         {
             string releaseLink = componentsAvailableInSw360.Where(x => x.Name.Trim().Equals(name.Trim(), StringComparison.CurrentCultureIgnoreCase)
@@ -703,6 +912,13 @@ namespace LCT.SW360PackageCreator
             return releaseLink ?? string.Empty;
         }
 
+        /// <summary>
+        /// Gets Release Info From Sw360
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="componentsAvailableInSw360"></param>
+        /// <param name="sw360Service"></param>
+        /// <returns>task that returns asynchronous operation</returns>
         private static async Task<ReleasesInfo> GetReleaseInfoFromSw360(Components item, List<Components> componentsAvailableInSw360, ISW360Service sw360Service)
         {
             ReleasesInfo releasesInfo = new ReleasesInfo();
@@ -718,6 +934,11 @@ namespace LCT.SW360PackageCreator
 
             return releasesInfo;
         }
+
+        /// <summary>
+        /// Log Source And Download Url Warnings
+        /// </summary>
+        /// <param name="component"></param>
         private static void LogSourceAndDownloadUrlWarnings(ComparisonBomData component)
         {
             bool isSourceUrlMissing = string.IsNullOrEmpty(component.SourceUrl) ||

--- a/src/LCT.SW360PackageCreator/CreatorValidator.cs
+++ b/src/LCT.SW360PackageCreator/CreatorValidator.cs
@@ -64,6 +64,11 @@ namespace LCT.SW360PackageCreator
             }
         }
 
+        /// <summary>
+        /// Finds Valid Release
+        /// </summary>
+        /// <param name="sW360ApicommunicationFacade"></param>
+        /// <returns></returns>
         private static async Task<ReleasesAllDetails.Sw360Release> FindValidRelease(ISW360ApicommunicationFacade sW360ApicommunicationFacade)
         {
             int page = 0;
@@ -101,6 +106,13 @@ namespace LCT.SW360PackageCreator
             return null;
         }
 
+        /// <summary>
+        /// Moves To Next Page
+        /// </summary>
+        /// <param name="releaseResponse"></param>
+        /// <param name="page"></param>
+        /// <param name="pageCount"></param>
+        /// <returns>boolean value</returns>
         private static bool MoveToNextPage(ReleasesAllDetails releaseResponse, ref int page, ref int pageCount)
         {
             int currentPage = page;
@@ -116,6 +128,13 @@ namespace LCT.SW360PackageCreator
             return false;
         }
 
+        /// <summary>
+        /// Triggers Fossology Process For Release
+        /// </summary>
+        /// <param name="validRelease"></param>
+        /// <param name="appSettings"></param>
+        /// <param name="sw360CreatorService"></param>
+        /// <returns>task that returns asynchronous operation</returns>
         private static async Task TriggerFossologyProcessForRelease(ReleasesAllDetails.Sw360Release validRelease, CommonAppSettings appSettings, ISw360CreatorService sw360CreatorService)
         {
             var releaseUrl = validRelease?.Links?.Self?.Href;
@@ -132,6 +151,13 @@ namespace LCT.SW360PackageCreator
             }
         }
 
+        /// <summary>
+        /// Gets All Releases Details
+        /// </summary>
+        /// <param name="sW360ApicommunicationFacade"></param>
+        /// <param name="page"></param>
+        /// <param name="pageEntries"></param>
+        /// <returns>release details</returns>
         private static async Task<ReleasesAllDetails> GetAllReleasesDetails(ISW360ApicommunicationFacade sW360ApicommunicationFacade, int page, int pageEntries)
         {
             ReleasesAllDetails releaseResponse = null;
@@ -160,6 +186,13 @@ namespace LCT.SW360PackageCreator
 
             return releaseResponse;
         }
+        /// <summary>
+        /// Fossology Url Validation
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="client"></param>
+        /// <param name="environmentHelper"></param>
+        /// <returns>task that represents asynchronous operation</returns>
         public static async Task<bool> FossologyUrlValidation(CommonAppSettings appSettings, HttpClient client, IEnvironmentHelper environmentHelper)
         {
             string url = appSettings.SW360.Fossology.URL;

--- a/src/LCT.SW360PackageCreator/DebianPackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/DebianPackageDownloader.cs
@@ -29,6 +29,12 @@ namespace LCT.SW360PackageCreator
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         readonly IDebianPatcher _debianPatcher = debianPatcher;
 
+        /// <summary>
+        /// Download Package
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>download path</returns>
         public async Task<string> DownloadPackage(ComparisonBomData component, string localPathforDownload)
         {
             string downloadPath = string.Empty;
@@ -76,6 +82,12 @@ namespace LCT.SW360PackageCreator
             return downloadPath;
         }
 
+        /// <summary>
+        /// Gets File Details
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="currentDownloadFolder"></param>
+        /// <returns></returns>
         private static async Task<Dictionary<string, string>> GetFileDetails(ComparisonBomData component, string currentDownloadFolder)
         {
             Dictionary<string, string> fileInfo = new Dictionary<string, string>();
@@ -115,6 +127,11 @@ namespace LCT.SW360PackageCreator
             return fileInfo;
         }
 
+        /// <summary>
+        /// Gets Correct File Extension
+        /// </summary>
+        /// <param name="sourceURL"></param>
+        /// <returns>name of the file</returns>
         private static string GetCorrectFileExtension(string sourceURL)
         {
             int idx = sourceURL.LastIndexOf(Dataconstant.ForwardSlash);
@@ -128,11 +145,24 @@ namespace LCT.SW360PackageCreator
             return fullname;
         }
 
+        /// <summary>
+        /// Gets Current Download Folder Path
+        /// </summary>
+        /// <param name="localPathforDownload"></param>
+        /// <param name="component"></param>
+        /// <returns></returns>
         private static string GetCurrentDownloadFolderPath(string localPathforDownload, ComparisonBomData component)
         {
             return $"{localPathforDownload}{component.Name}--{DateTime.Now.ToString("yyyyMMddHHmmss")}{Dataconstant.ForwardSlash}";
         }
 
+        /// <summary>
+        /// Download Tar File And Get Path
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="SourceUrl"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>path name</returns>
         private static async Task<string> DownloadTarFileAndGetPath(ComparisonBomData component, string SourceUrl, string localPathforDownload)
         {
             string downloadPath = string.Empty;
@@ -160,6 +190,13 @@ namespace LCT.SW360PackageCreator
             return downloadPath;
         }
 
+        /// <summary>
+        /// Apply Patch for Components
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localDownloadPath"></param>
+        /// <param name="fileName"></param>
+        /// <returns>patch file</returns>
         public string ApplyPatchforComponents(ComparisonBomData component, string localDownloadPath, string fileName)
         {
             Result result;
@@ -195,6 +232,13 @@ namespace LCT.SW360PackageCreator
             return patchedFile;
         }
 
+        /// <summary>
+        /// Gets Patched File Path By Retrying
+        /// </summary>
+        /// <param name="currentDownloadFolder"></param>
+        /// <param name="component"></param>
+        /// <param name="dscFileName"></param>
+        /// <returns>file path</returns>
         private string GetPatchedFilePathByRetrying(string currentDownloadFolder, ComparisonBomData component, string dscFileName)
         {
             string patchedFilePath = string.Empty;
@@ -222,6 +266,11 @@ namespace LCT.SW360PackageCreator
             return patchedFilePath;
         }
 
+        /// <summary>
+        /// Delete Patched Folder And File
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <param name="downloadPath"></param>
         private static void DeletePatchedFolderAndFile(string folderPath, string downloadPath)
         {
             try
@@ -250,6 +299,11 @@ namespace LCT.SW360PackageCreator
             }
         }
 
+        /// <summary>
+        /// Gets Patched File From Downloaded Folder
+        /// </summary>
+        /// <param name="currentDownloadFolder"></param>
+        /// <returns></returns>
         public static string GetPatchedFileFromDownloadedFolder(string currentDownloadFolder)
         {
             string patchedFilePath = string.Empty;

--- a/src/LCT.SW360PackageCreator/DebianPatcher.cs
+++ b/src/LCT.SW360PackageCreator/DebianPatcher.cs
@@ -18,6 +18,14 @@ namespace LCT.SW360PackageCreator
     [ExcludeFromCodeCoverage]
     public class DebianPatcher : IDebianPatcher
     {
+
+        /// <summary>
+        /// Apply Patch
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localDownloadPath"></param>
+        /// <param name="fileName"></param>
+        /// <returns>result</returns>
         public Result ApplyPatch(ComparisonBomData component, string localDownloadPath, string fileName)
         {
             Result result;

--- a/src/LCT.SW360PackageCreator/Interfaces/IComponentCreator.cs
+++ b/src/LCT.SW360PackageCreator/Interfaces/IComponentCreator.cs
@@ -18,8 +18,28 @@ namespace LCT.SW360PackageCreator.Interfaces
     /// </summary>
     interface IComponentCreator
     {
+        /// <summary>
+        /// Asynchronously parses a CycloneDX BOM file.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="sw360Service">The SW360 service instance.</param>
+        /// <param name="cycloneDXBomParser">The CycloneDX BOM parser instance.</param>
+        /// <param name="creatorHelper">The creator helper instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of comparison BOM data.</returns>
         Task<List<ComparisonBomData>> CycloneDxBomParser(CommonAppSettings appSettings,
             ISW360Service sw360Service, ICycloneDXBomParser cycloneDXBomParser, ICreatorHelper creatorHelper);
+        
+        /// <summary>
+        /// Asynchronously creates components in SW360 from the parsed BOM data.
+        /// </summary>
+        /// <param name="appSettings">The common application settings.</param>
+        /// <param name="sw360CreatorService">The SW360 creator service instance.</param>
+        /// <param name="sw360Service">The SW360 service instance.</param>
+        /// <param name="sw360ProjectService">The SW360 project service instance.</param>
+        /// <param name="fileOperations">The file operations instance.</param>
+        /// <param name="creatorHelper">The creator helper instance.</param>
+        /// <param name="parsedBomData">The parsed BOM data list.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         Task CreateComponentInSw360(CommonAppSettings appSettings,
             ISw360CreatorService sw360CreatorService, ISW360Service sw360Service, ISw360ProjectService sw360ProjectService,
             IFileOperations fileOperations, ICreatorHelper creatorHelper, List<ComparisonBomData> parsedBomData);

--- a/src/LCT.SW360PackageCreator/Interfaces/ICreatorHelper.cs
+++ b/src/LCT.SW360PackageCreator/Interfaces/ICreatorHelper.cs
@@ -19,12 +19,56 @@ namespace LCT.SW360PackageCreator.Interfaces
     /// </summary>
     public interface ICreatorHelper
     {
+        /// <summary>
+        /// Asynchronously sets contents for comparison BOM from the list of components.
+        /// </summary>
+        /// <param name="lstComponentForBOM">The list of components for BOM.</param>
+        /// <param name="sw360Service">The SW360 service instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of comparison BOM data.</returns>
         public Task<List<ComparisonBomData>> SetContentsForComparisonBOM(List<Components> lstComponentForBOM, ISW360Service sw360Service);
+        
+        /// <summary>
+        /// Asynchronously downloads release attachment source for a component.
+        /// </summary>
+        /// <param name="component">The comparison BOM data component.</param>
+        /// <returns>A task representing the asynchronous operation that returns a dictionary of attachment URLs.</returns>
         public Task<Dictionary<string, string>> DownloadReleaseAttachmentSource(ComparisonBomData component);
+        
+        /// <summary>
+        /// Gets creator KPI data from the updated comparison BOM data.
+        /// </summary>
+        /// <param name="updatedCompareBomData">The updated comparison BOM data list.</param>
+        /// <returns>The creator KPI data.</returns>
         public CreatorKpiData GetCreatorKpiData(List<ComparisonBomData> updatedCompareBomData);
+        
+        /// <summary>
+        /// Writes creator KPI data to the console.
+        /// </summary>
+        /// <param name="creatorKpiData">The creator KPI data to write.</param>
         public void WriteCreatorKpiDataToConsole(CreatorKpiData creatorKpiData);
+        
+        /// <summary>
+        /// Writes source not found list to the console.
+        /// </summary>
+        /// <param name="comparisionBomDataList">The comparison BOM data list.</param>
+        /// <param name="appSetting">The common application settings.</param>
         public void WriteSourceNotFoundListToConsole(List<ComparisonBomData> comparisionBomDataList, CommonAppSettings appSetting);
+        
+        /// <summary>
+        /// Gets the list of components with download URL not found.
+        /// </summary>
+        /// <param name="comparisionBomDataList">The comparison BOM data list.</param>
+        /// <returns>A list of comparison BOM data with missing download URLs.</returns>
         public List<ComparisonBomData> GetDownloadUrlNotFoundList(List<ComparisonBomData> comparisionBomDataList);
+        
+        /// <summary>
+        /// Asynchronously gets updated component details and merges with the BOM.
+        /// </summary>
+        /// <param name="ListofBomComponents">The list of BOM components.</param>
+        /// <param name="updatedCompareBomData">The updated comparison BOM data list.</param>
+        /// <param name="sw360Service">The SW360 service instance.</param>
+        /// <param name="bom">The BOM to update.</param>
+        /// <returns>A task representing the asynchronous operation that returns the updated BOM.</returns>
         public Task<Bom> GetUpdatedComponentsDetails(List<Components> ListofBomComponents, List<ComparisonBomData> updatedCompareBomData, ISW360Service sw360Service, Bom bom);
     }
 }

--- a/src/LCT.SW360PackageCreator/Interfaces/IDebianPatcher.cs
+++ b/src/LCT.SW360PackageCreator/Interfaces/IDebianPatcher.cs
@@ -9,8 +9,18 @@ using LCT.Common.Model;
 
 namespace LCT.SW360PackageCreator.Interfaces
 {
+    /// <summary>
+    /// Interface for Debian package patching operations.
+    /// </summary>
     public interface IDebianPatcher
     {
+        /// <summary>
+        /// Applies patches to a Debian component.
+        /// </summary>
+        /// <param name="component">The comparison BOM data component.</param>
+        /// <param name="localDownloadPath">The local download path for the component.</param>
+        /// <param name="fileName">The file name of the component.</param>
+        /// <returns>The result of the patch operation.</returns>
         public Result ApplyPatch(ComparisonBomData component, string localDownloadPath, string fileName);
     }
 }

--- a/src/LCT.SW360PackageCreator/Interfaces/IPackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/Interfaces/IPackageDownloader.cs
@@ -9,8 +9,17 @@ using System.Threading.Tasks;
 
 namespace LCT.SW360PackageCreator.Interfaces
 {
+    /// <summary>
+    /// Interface for package download operations.
+    /// </summary>
     public interface IPackageDownloader
     {
+        /// <summary>
+        /// Asynchronously downloads a package to the specified local path.
+        /// </summary>
+        /// <param name="component">The comparison BOM data component to download.</param>
+        /// <param name="localPathforDownload">The local path where the package should be downloaded.</param>
+        /// <returns>A task representing the asynchronous operation that returns the path to the downloaded package.</returns>
         public Task<string> DownloadPackage(ComparisonBomData component, string localPathforDownload);
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/AlpinePackage.cs
+++ b/src/LCT.SW360PackageCreator/Model/AlpinePackage.cs
@@ -14,18 +14,36 @@ namespace LCT.SW360PackageCreator.Model
     [ExcludeFromCodeCoverage]
     public class AlpinePackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the Alpine package.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the version of the Alpine package.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Package URL (PURL) identifier.
+        /// </summary>
         public string PurlID { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source URL of the Alpine package.
+        /// </summary>
         public string SourceUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the download URL of the Alpine package.
+        /// </summary>
         public string DownloadUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source data specific to Alpine packages.
+        /// </summary>
         public string SourceDataForAlpine { get; set; }
-
-
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/ConanSources.cs
+++ b/src/LCT.SW360PackageCreator/Model/ConanSources.cs
@@ -10,33 +10,79 @@ using YamlDotNet.Serialization;
 
 namespace LCT.SW360PackageCreator.Model
 {
+    /// <summary>
+    /// Represents Conan sources and patches data.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class Sources
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the dictionary of sources data.
+        /// </summary>
         [YamlMember(Alias = "sources")]
         public Dictionary<string, Source> SourcesData { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the dictionary of patches.
+        /// </summary>
         [YamlMember(Alias = "patches")]
         public Dictionary<string, List<Patch>> Patches { get; set; }
+        #endregion
     }
 
+    /// <summary>
+    /// Represents a Conan source with URL and SHA256 hash.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class Source
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the URL of the source.
+        /// </summary>
         [YamlMember(Alias = "url")]
         public object Url { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the SHA256 hash of the source.
+        /// </summary>
         [YamlMember(Alias = "sha256")]
         public string Sha256 { get; set; }
-
-
+        #endregion
     }
 
+    /// <summary>
+    /// Represents a patch with file, description, type, source, and SHA256 hash.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class Patch
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the patch file name.
+        /// </summary>
         public string PatchFile { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the patch description.
+        /// </summary>
         public string PatchDescription { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the patch type.
+        /// </summary>
         public string PatchType { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the patch source.
+        /// </summary>
         public string PatchSource { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the SHA256 hash of the patch.
+        /// </summary>
         public string Sha256 { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/CreatorKpiData.cs
+++ b/src/LCT.SW360PackageCreator/Model/CreatorKpiData.cs
@@ -15,40 +15,78 @@ namespace LCT.SW360PackageCreator.Model
     [ExcludeFromCodeCoverage]
     public class CreatorKpiData
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the number of components read from the comparison BOM.
+        /// </summary>
         [DisplayName(@"Components from BoM")]
         public int ComponentsReadFromComparisonBOM { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components or releases created newly in SW360.
+        /// </summary>
         [DisplayName(@"Releases created in SW360")]
         public int ComponentsOrReleasesCreatedNewlyInSw360 { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components or releases already existing in SW360.
+        /// </summary>
         [DisplayName(@"Releases exists in SW360")]
         public int ComponentsOrReleasesExistingInSw360 { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of releases without source download URL.
+        /// </summary>
         [DisplayName(@"Releases Without source download URL")]
         public int ComponentsWithoutSourceDownloadUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of releases with source download URL.
+        /// </summary>
         [DisplayName(@"Releases with source download URL")]
         public int ComponentsWithSourceDownloadUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components or releases not created in SW360.
+        /// </summary>
         [DisplayName(@"Releases not created in SW360")]
         public int ComponentsOrReleasesNotCreatedInSw360 { get; set; }
 
+        /// <summary>
+        /// Gets or sets the time taken by the component creator in seconds.
+        /// </summary>
         [DisplayName(@"Time taken by ComponentCreator")]
         public double TimeTakenByComponentCreator { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components without source and package URL.
+        /// </summary>
         [DisplayName(@"Components without source and package URL")]
         public int ComponentsWithoutSourceAndPackageUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components without package URL.
+        /// </summary>
         [DisplayName(@"Components without package URL")]
         public int ComponentsWithoutPackageUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components uploaded in FOSSology.
+        /// </summary>
         [DisplayName(@"Components uploaded in FOSSology")]
         public int ComponentsUploadedInFossology { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of components not uploaded in FOSSology.
+        /// </summary>
         [DisplayName(@"Components not uploaded in FOSSology")]
         public int ComponentsNotUploadedInFossology { get; set; }
 
+        /// <summary>
+        /// Gets or sets the total number of duplicate and invalid components.
+        /// </summary>
         [DisplayName(@"Total Duplicate and InValid Components")]
         public int TotalDuplicateAndInValidComponents { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/DebianFileInfo.cs
+++ b/src/LCT.SW360PackageCreator/Model/DebianFileInfo.cs
@@ -9,16 +9,32 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace LCT.SW360PackageCreator.Model
 {
+    /// <summary>
+    /// Represents Debian file information.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class DebianFileInfo
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the Debian file.
+        /// </summary>
         public string name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the archive name.
+        /// </summary>
         public string archive_name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the file path.
+        /// </summary>
         public string path { get; set; }
 
+        /// <summary>
+        /// Gets or sets the timestamp when the file was first seen.
+        /// </summary>
         public string first_seen { get; set; }
-
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/DebianPackage.cs
+++ b/src/LCT.SW360PackageCreator/Model/DebianPackage.cs
@@ -14,20 +14,46 @@ namespace LCT.SW360PackageCreator.Model
     [ExcludeFromCodeCoverage]
     public class DebianPackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the Debian package.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the version of the Debian package.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Package URL (PURL) identifier.
+        /// </summary>
         public string PurlID { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source URL of the Debian package.
+        /// </summary>
         public string SourceUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the array of patch URLs.
+        /// </summary>
         public string[] PatchURLs { get; set; }
 
+        /// <summary>
+        /// Gets or sets the download URL of the Debian package.
+        /// </summary>
         public string DownloadUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the JSON text representation.
+        /// </summary>
         public string JsonText { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether a retry is required.
+        /// </summary>
         public bool IsRetryRequired { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/DownloadedSourceInfo.cs
+++ b/src/LCT.SW360PackageCreator/Model/DownloadedSourceInfo.cs
@@ -14,14 +14,31 @@ namespace LCT.SW360PackageCreator.Model
     [ExcludeFromCodeCoverage]
     public class DownloadedSourceInfo
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the downloaded source.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the version of the downloaded source.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source repository URL.
+        /// </summary>
         public string SourceRepoUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the path where the source was downloaded.
+        /// </summary>
         public string DownloadedPath { get; set; }
 
+        /// <summary>
+        /// Gets or sets the tagged version of the source.
+        /// </summary>
         public string TaggedVersion { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/MavenPackage.cs
+++ b/src/LCT.SW360PackageCreator/Model/MavenPackage.cs
@@ -14,9 +14,21 @@ namespace LCT.SW360PackageCreator.Model
     [ExcludeFromCodeCoverage]
     public class MavenPackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the Maven package identifier.
+        /// </summary>
         public string ID { get; set; }
 
+        /// <summary>
+        /// Gets or sets the version of the Maven package.
+        /// </summary>
         public string Version { get; set; }
+        
+        /// <summary>
+        /// Gets the Maven group identifier.
+        /// </summary>
         public string GroupID { get; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/PythonPackage.cs
+++ b/src/LCT.SW360PackageCreator/Model/PythonPackage.cs
@@ -8,17 +8,37 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace LCT.SW360PackageCreator.Model
 {
+    /// <summary>
+    /// Represents a Python package with its metadata.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     internal class PythonPackage
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the Python package.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the version of the Python package.
+        /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Package URL (PURL) identifier.
+        /// </summary>
         public string PurlID { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source URL of the Python package.
+        /// </summary>
         public string SourceUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets the wheel distribution URL.
+        /// </summary>
         public string WheelUrl { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.SW360PackageCreator/Model/ReleasesAllDetails.cs
+++ b/src/LCT.SW360PackageCreator/Model/ReleasesAllDetails.cs
@@ -10,60 +10,144 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace LCT.SW360PackageCreator.Model
 {
+    /// <summary>
+    /// Represents all release details from SW360 including embedded data and pagination.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class ReleasesAllDetails
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the embedded release data.
+        /// </summary>
         [JsonProperty("_embedded")]
         public AllReleasesEmbedded Embedded { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the pagination information.
+        /// </summary>
         [JsonProperty("page")]
         public Pagination Page { get; set; }
+        #endregion
+        
+        /// <summary>
+        /// Represents embedded data containing releases and attachments.
+        /// </summary>
         public class AllReleasesEmbedded
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the list of SW360 releases.
+            /// </summary>
             [JsonProperty("sw360:releases")]
             public List<Sw360Release> Sw360releases { get; set; }
 
+            /// <summary>
+            /// Gets or sets the list of SW360 attachments for each release.
+            /// </summary>
             [JsonProperty("sw360:attachments")]
             public List<List<Attachment>> Sw360attachments { get; set; }
-
+            #endregion
         }
+        
+        /// <summary>
+        /// Represents an attachment with filename and type.
+        /// </summary>
         public class Attachment
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the filename of the attachment.
+            /// </summary>
             [JsonProperty("filename")]
             public string Filename { get; set; }
+            
+            /// <summary>
+            /// Gets or sets the type of the attachment.
+            /// </summary>
             [JsonProperty("attachmentType")]
             public string AttachmentType { get; set; }
-
+            #endregion
         }
+        
+        /// <summary>
+        /// Represents links associated with a resource.
+        /// </summary>
         public class Links
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the self link.
+            /// </summary>
             [JsonProperty("self")]
             public Self Self { get; set; }
-
+            #endregion
         }
+        
+        /// <summary>
+        /// Represents a self-referencing link.
+        /// </summary>
         public class Self
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the href URL.
+            /// </summary>
             [JsonProperty("href")]
             public string Href { get; set; }
+            #endregion
         }
+        
+        /// <summary>
+        /// Represents a SW360 release with name, version, clearing state, and embedded data.
+        /// </summary>
         public class Sw360Release
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the name of the release.
+            /// </summary>
             [JsonProperty("name")]
             public string Name { get; set; }
+            
+            /// <summary>
+            /// Gets or sets the version of the release.
+            /// </summary>
             [JsonProperty("version")]
             public string Version { get; set; }
+            
+            /// <summary>
+            /// Gets or sets the clearing state of the release.
+            /// </summary>
             [JsonProperty("clearingState")]
             public string ClearingState { get; set; }
+            
+            /// <summary>
+            /// Gets or sets the links associated with the release.
+            /// </summary>
             [JsonProperty("_links")]
             public Links Links { get; set; }
+            
+            /// <summary>
+            /// Gets or sets the embedded release data.
+            /// </summary>
             [JsonProperty("_embedded")]
             public AllReleasesEmbedded AllReleasesEmbedded { get; set; }
-
+            #endregion
         }
+        
+        /// <summary>
+        /// Represents pagination information.
+        /// </summary>
         public class Pagination
         {
+            #region Properties
+            /// <summary>
+            /// Gets or sets the total number of pages.
+            /// </summary>
             [JsonProperty("totalPages")]
             public int TotalPages { get; set; }
-
+            #endregion
         }
     }
 }

--- a/src/LCT.SW360PackageCreator/PackageDownloader.cs
+++ b/src/LCT.SW360PackageCreator/PackageDownloader.cs
@@ -31,6 +31,12 @@ namespace LCT.SW360PackageCreator
         private static readonly string[] WindowsLineSeparators = ["\r\n"];
         private static readonly string[] UnixLineSeparators = ["\n"];
 
+        /// <summary>
+        /// Download Package
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="localPathforDownload"></param>
+        /// <returns>task that represents asynchronous operation</returns>
         public async Task<string> DownloadPackage(ComparisonBomData component, string localPathforDownload)
         {
             string path = Download(component, localPathforDownload);
@@ -38,6 +44,12 @@ namespace LCT.SW360PackageCreator
             return path;
         }
 
+        /// <summary>
+        /// donwload
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="downloadPath"></param>
+        /// <returns>compressed file path</returns>
         private string Download(ComparisonBomData component, string downloadPath)
         {
             string downloadedPackageName = string.Empty;
@@ -75,6 +87,13 @@ namespace LCT.SW360PackageCreator
             component.DownloadUrl = GetSourceRepositoryUrl(component, taggedVersion);
             return compressedFilePath;
         }
+
+        /// <summary>
+        /// Gets Source Repository Url
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="tag"></param>
+        /// <returns>url path</returns>
         private static string GetSourceRepositoryUrl(ComparisonBomData component, string tag)
         {
             if (!string.IsNullOrEmpty(component.SourceUrl) && component.SourceUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(tag))
@@ -86,6 +105,12 @@ namespace LCT.SW360PackageCreator
             }
             return component.DownloadUrl;
         }
+
+        /// <summary>
+        /// Sanitize File Name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>file name</returns>
         private static string SanitizeFileName(string name)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
@@ -95,6 +120,12 @@ namespace LCT.SW360PackageCreator
             name = name.Replace('/', '_').Replace('\\', '_');
             return name;
         }
+
+        /// <summary>
+        /// Gets Correct Version
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns>version name</returns>
         private static string GetCorrectVersion(ComparisonBomData component)
         {
             string correctVersion = string.Empty;
@@ -141,6 +172,12 @@ namespace LCT.SW360PackageCreator
             Logger.Debug($"componentName - given version:{component.Version}, correctVersion:{correctVersion}");
             return correctVersion;
         }
+
+        /// <summary>
+        /// Gets Tag List From Result
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns>result</returns>
         private static string[] GetTagListFromResult(Result result)
         {
             if (result == null || string.IsNullOrEmpty(result.StdOut))
@@ -157,6 +194,12 @@ namespace LCT.SW360PackageCreator
                 return result.StdOut.Split(UnixLineSeparators, StringSplitOptions.None);
             }
         }
+
+        /// <summary>
+        /// Gets Base Version
+        /// </summary>
+        /// <param name="version"></param>
+        /// <returns>version name</returns>
         private static string GetBaseVersion(string version)
         {
             if (string.IsNullOrWhiteSpace(version))
@@ -173,6 +216,14 @@ namespace LCT.SW360PackageCreator
             }
             return version;
         }
+
+        /// <summary>
+        /// Checks If Already Downloaded
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="tagVersion"></param>
+        /// <param name="downloadedPath"></param>
+        /// <returns>boolean value</returns>
         private bool CheckIfAlreadyDownloaded(ComparisonBomData component, string tagVersion, out string downloadedPath)
         {
             downloadedPath = string.Empty;
@@ -188,6 +239,11 @@ namespace LCT.SW360PackageCreator
             return false;
         }
 
+        /// <summary>
+        /// List Tags Of Component
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns>result</returns>
         private static Result ListTagsOfComponent(ComparisonBomData component)
         {
             string gitCommand = $"ls-remote --tags {component.DownloadUrl}";
@@ -209,6 +265,14 @@ namespace LCT.SW360PackageCreator
             return result;
         }
 
+        /// <summary>
+        /// Clone Source
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="downloadPath"></param>
+        /// <param name="taggedVersion"></param>
+        /// <param name="compressedFilePath"></param>
+        /// <returns>result</returns>
         private static Result CloneSource(ComparisonBomData component, string downloadPath, string taggedVersion, string compressedFilePath)
         {
             const int timeoutInMs = 200 * 60 * 1000;
@@ -237,6 +301,13 @@ namespace LCT.SW360PackageCreator
             return result;
         }
 
+        /// <summary>
+        /// Gets Git Clone Commands
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="taggedVersion"></param>
+        /// <param name="compressedFilePath"></param>
+        /// <returns>list of commands</returns>
         private static List<string> GetGitCloneCommands(ComparisonBomData component, string taggedVersion, string compressedFilePath)
         {
             return new List<string>()

--- a/src/LCT.SW360PackageCreator/Program.cs
+++ b/src/LCT.SW360PackageCreator/Program.cs
@@ -43,6 +43,14 @@ namespace LCT.SW360PackageCreator
 
         protected Program() { }
 
+        /// <summary>
+        /// Initializes and executes the package creator application workflow. This includes reading configuration
+        /// settings, validating input parameters, performing compliance checks, and uploading artifacts as part of the
+        /// application's main entry point.
+        /// </summary>        
+        /// <param name="args">An array of command-line arguments supplied to the application. These arguments are used to configure
+        /// application settings and control execution behavior.</param>
+        /// <returns>A task that represents the asynchronous operation of the application's main workflow.</returns>
         static async Task Main(string[] args)
         {
             CreatorStopWatch = new Stopwatch();
@@ -102,7 +110,10 @@ namespace LCT.SW360PackageCreator
             PipelineArtifactUploader.UploadArtifacts();
         }
 
-
+        /// <summary>
+        /// gets the catool version from project file
+        /// </summary>
+        /// <returns>ca tool information</returns>
         private static CatoolInfo GetCatoolVersionFromProjectfile()
         {
             CatoolInfo catoolInfo = new CatoolInfo();
@@ -112,6 +123,12 @@ namespace LCT.SW360PackageCreator
             return catoolInfo;
         }
 
+        /// <summary>
+        /// gets the sw360 project service object
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="sW360ApicommunicationFacade"></param>
+        /// <returns>project service data</returns>
         private static ISw360ProjectService Getsw360ProjectServiceObject(CommonAppSettings appSettings, out ISW360ApicommunicationFacade sW360ApicommunicationFacade)
         {
             ISw360ProjectService sw360ProjectService;
@@ -130,6 +147,13 @@ namespace LCT.SW360PackageCreator
             return sw360ProjectService;
         }
 
+        /// <summary>
+        /// initiates the package creator process
+        /// </summary>
+        /// <param name="appSettings"></param>
+        /// <param name="sw360ProjectService"></param>
+        /// <param name="sW360ApicommunicationFacade"></param>
+        /// <returns>a task represents async operation</returns>
         private static async Task InitiatePackageCreatorProcess(CommonAppSettings appSettings, ISw360ProjectService sw360ProjectService, ISW360ApicommunicationFacade sW360ApicommunicationFacade)
         {
             ISW360CommonService sw360CommonService = new SW360CommonService(sW360ApicommunicationFacade);
@@ -157,6 +181,10 @@ namespace LCT.SW360PackageCreator
                  sw360ProjectService, new FileOperations(), creatorHelper, parsedBomData);
         }
 
+        /// <summary>
+        /// compliance check for all found components
+        /// </summary>
+        /// <returns>task that represents asynchronous operation</returns>
         private static async Task ComplianceCheckForAllFoundComponents()
         {
             if (parsedBomData != null && parsedBomData.Count > 0)

--- a/src/LCT.SW360PackageCreator/Repository.cs
+++ b/src/LCT.SW360PackageCreator/Repository.cs
@@ -63,6 +63,13 @@ namespace LCT.SW360PackageCreator
             return downloadUrl;
         }
 
+        /// <summary>
+        /// form git clone url
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="componentName"></param>
+        /// <param name="version"></param>
+        /// <returns>url</returns>
         public string FormGitCloneUrl(string url, string componentName, string version)
         {
             Logger.Debug($"FormGitCloneUrl():Start");
@@ -80,6 +87,11 @@ namespace LCT.SW360PackageCreator
             return downloadUrl;
         }
 
+        /// <summary>
+        /// get repo name from url
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns>repo name</returns>
         private string GetRepoName(string url)
         {
             string repoUrl = string.Empty;

--- a/src/LCT.SW360PackageCreator/URLHelper.cs
+++ b/src/LCT.SW360PackageCreator/URLHelper.cs
@@ -87,6 +87,12 @@ namespace LCT.SW360PackageCreator
             }
             return componentsData;
         }
+
+        /// <summary>
+        /// Gets Alpine Distro
+        /// </summary>
+        /// <param name="bomRef"></param>
+        /// <returns>distro</returns>
         public static string GetAlpineDistro(string bomRef)
         {
 
@@ -97,6 +103,13 @@ namespace LCT.SW360PackageCreator
             return distro;
         }
 
+        /// <summary>
+        /// Gets Alpine Source Url
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="localPathforSourceRepo"></param>
+        /// <returns>AlpinePackage</returns>
         private static Task<AlpinePackage> GetAlpineSourceUrl(string name, string version, string localPathforSourceRepo)
         {
             AlpinePackage sourceURLDetails = new AlpinePackage { Name = name, Version = version };
@@ -124,6 +137,13 @@ namespace LCT.SW360PackageCreator
             }
             return Task.FromResult(sourceURLDetails);
         }
+
+        /// <summary>
+        /// Gets Source From APK BUILD
+        /// </summary>
+        /// <param name="localPathforSourceRepo"></param>
+        /// <param name="name"></param>
+        /// <returns>source data</returns>
         public static string GetSourceFromAPKBUILD(string localPathforSourceRepo, string name)
         {
             string sourceData = string.Empty;
@@ -156,6 +176,13 @@ namespace LCT.SW360PackageCreator
 
             return sourceData;
         }
+
+        /// <summary>
+        /// Gets Source Url For Alpine
+        /// </summary>
+        /// <param name="pkgFilePath"></param>
+        /// <param name="sourceData"></param>
+        /// <returns>source url</returns>
         public static string GetSourceUrlForAlpine(string pkgFilePath, string sourceData)
         {
             string sourceUrl = string.Empty;
@@ -217,6 +244,10 @@ namespace LCT.SW360PackageCreator
             return sourceUrl;
         }
 
+        /// <summary>
+        /// Gets Download Path For Alpine Repo
+        /// </summary>
+        /// <returns>local path for repo</returns>
         public static string GetDownloadPathForAlpineRepo()
         {
             string localPathforSourceRepo = string.Empty;
@@ -239,17 +270,38 @@ namespace LCT.SW360PackageCreator
 
             return localPathforSourceRepo;
         }
+
+        /// <summary>
+        /// Get Release External Id For Alpine
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>external id</returns>
         public static string GetReleaseExternalIdForAlpine(string name, string version)
         {
 
             return $"{Dataconstant.PurlCheck()["ALPINE"]}{Dataconstant.ForwardSlash}{name}@{version}?arch=source";
         }
 
+        /// <summary>
+        /// Generates the external identifier URL for an Alpine Linux package component using the specified package
+        /// name.
+        /// </summary>       
+        /// <param name="name">The name of the Alpine Linux package for which to generate the external identifier. Cannot be null or empty.</param>
+        /// <returns>A string containing the external identifier URL for the specified Alpine Linux package.</returns>
         private static string GetComponentExternalIdForAlpine(string name)
         {
             return $"{Dataconstant.PurlCheck()["ALPINE"]}{Dataconstant.ForwardSlash}{name}?arch=source";
         }
 
+        /// <summary>
+        /// Clones a source Git repository to a specified local directory and checks out the specified Alpine
+        /// distribution if the target path exists.
+        /// </summary>       
+        /// <param name="localPathforSourceRepo">The local file system path where the source repository will be cloned. Must be a valid, existing directory.</param>
+        /// <param name="alpineDistro">The name or identifier of the Alpine distribution branch or tag to check out after cloning.</param>
+        /// <param name="fullPath">The full file system path to the directory where the repository should be checked out. If this directory
+        /// exists, the specified Alpine distribution is checked out.</param>
         private static void CloneSource(string localPathforSourceRepo, string alpineDistro, string fullPath)
         {
             List<string> gitCommands = GetGitCloneCommands();
@@ -294,6 +346,11 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// Check out Distro
+        /// </summary>
+        /// <param name="alpineDistro"></param>
+        /// <param name="fullPath"></param>
         private static void CheckoutDistro(string alpineDistro, string fullPath)
         {
 
@@ -312,6 +369,10 @@ namespace LCT.SW360PackageCreator
 
         }
 
+        /// <summary>
+        /// Get Git Clone Commands
+        /// </summary>
+        /// <returns></returns>
         private static List<string> GetGitCloneCommands()
         {
             return new List<string>()
@@ -528,6 +589,12 @@ namespace LCT.SW360PackageCreator
             return componentSrcURL;
         }
 
+        /// <summary>
+        /// Gets Source URL From Nuspec File
+        /// </summary>
+        /// <param name="nuspecURL"></param>
+        /// <param name="componentName"></param>
+        /// <returns>task that represents asynchronous operation</returns>
         private async Task<string> GetSourceURLFromNuspecFile(string nuspecURL, string componentName)
         {
             string response;
@@ -565,6 +632,11 @@ namespace LCT.SW360PackageCreator
             return GithubUrl;
         }
 
+        /// <summary>
+        /// Search For Project URL Tag In Nuspec File
+        /// </summary>
+        /// <param name="xmlDoc"></param>
+        /// <returns>url</returns>
         private static string SearchForProjectURLTagInNuspecFile(XmlDocument xmlDoc)
         {
             string url = string.Empty;
@@ -593,6 +665,12 @@ namespace LCT.SW360PackageCreator
             return url;
         }
 
+        /// <summary>
+        /// Gets Release External Id
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>external id</returns>
         public static string GetReleaseExternalId(string name, string version)
         {
             version = WebUtility.UrlEncode(version);
@@ -601,11 +679,22 @@ namespace LCT.SW360PackageCreator
             return $"{Dataconstant.PurlCheck()["DEBIAN"]}{Dataconstant.ForwardSlash}{name}@{version}?arch=source";
         }
 
+        /// <summary>
+        /// Gets Component External Id
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>external id</returns>
         private static string GetComponentExternalId(string name)
         {
             return $"{Dataconstant.PurlCheck()["DEBIAN"]}{Dataconstant.ForwardSlash}{name}?arch=source";
         }
 
+        /// <summary>
+        /// Gets Source Url
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>task</returns>
         private async Task<DebianPackage> GetSourceUrl(string name, string version)
         {
             DebianPackage sourceURLDetails = new DebianPackage { Name = name, Version = version };
@@ -626,6 +715,12 @@ namespace LCT.SW360PackageCreator
             return sourceURLDetails;
         }
 
+        /// <summary>
+        /// Gets Archive Response
+        /// </summary>
+        /// <param name="packageDetails"></param>
+        /// <param name="packageType"></param>
+        /// <returns>package</returns>
         private async Task<DebianPackage> GetArchiveResponse(DebianPackage packageDetails, string packageType)
         {
             string URL;
@@ -660,6 +755,12 @@ namespace LCT.SW360PackageCreator
             return packageDetails;
         }
 
+        /// <summary>
+        /// Gets Source Detials From Type
+        /// </summary>
+        /// <param name="packageType"></param>
+        /// <param name="sourceURLDetails"></param>
+        /// <returns>debian package</returns>
         private async Task<DebianPackage> GetSourceDetialsFromType(string packageType, DebianPackage sourceURLDetails)
         {
             if (packageType == "source")
@@ -673,6 +774,11 @@ namespace LCT.SW360PackageCreator
             return sourceURLDetails;
         }
 
+        /// <summary>
+        /// Gets Source URL From Json Text For SourceType
+        /// </summary>
+        /// <param name="sourceURLDetails"></param>
+        /// <returns>devbian package</returns>
         private static DebianPackage GetSourceURLFromJsonTextForSourceType(DebianPackage sourceURLDetails)
         {
             List<string> SourceURL = new List<string>();
@@ -715,6 +821,11 @@ namespace LCT.SW360PackageCreator
             return sourceURLDetails;
         }
 
+        /// <summary>
+        /// Gets Source URL From Json Text For Binary Type
+        /// </summary>
+        /// <param name="sourceURLDetails"></param>
+        /// <returns>debian package</returns>
         private async Task<DebianPackage> GetSourceURLFromJsonTextForBinaryType(DebianPackage sourceURLDetails)
         {
             try
@@ -752,6 +863,12 @@ namespace LCT.SW360PackageCreator
             return sourceURLDetails;
         }
 
+        /// <summary>
+        /// Gets Proper Source URL
+        /// </summary>
+        /// <param name="sourceURLDetails"></param>
+        /// <param name="URLs"></param>
+        /// <returns>debian package</returns>
         private static DebianPackage GetProperSourceURL(DebianPackage sourceURLDetails, List<string> URLs)
         {
             if (URLs.Count > 2)
@@ -807,6 +924,12 @@ namespace LCT.SW360PackageCreator
             return sourceURLDetails;
         }
 
+        /// <summary>
+        /// Retry To Get Source  URl Details Async
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns>debian package</returns>
         private async Task<DebianPackage> RetryToGetSourceURlDetailsAsync(string name, string version)
         {
             Logger.Debug($"Retry for.. {name}-{version}");
@@ -842,6 +965,12 @@ namespace LCT.SW360PackageCreator
             return sourceURL;
         }
 
+        /// <summary>
+        /// Gets Response From PyPiOrg
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componenVersion"></param>
+        /// <returns>result</returns>
         private async Task<string> GetResponseFromPyPiOrg(string componentName, string componenVersion)
         {
             string URL;
@@ -865,6 +994,11 @@ namespace LCT.SW360PackageCreator
             return result;
         }
 
+        /// <summary>
+        /// Gets Source URL From PyPi Response
+        /// </summary>
+        /// <param name="response"></param>
+        /// <returns>source url</returns>
         private static string GetSourceURLFromPyPiResponse(string response)
         {
             string SourceURL = "";
@@ -895,6 +1029,12 @@ namespace LCT.SW360PackageCreator
             return SourceURL;
         }
 
+        /// <summary>
+        /// Download File Async
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="downloadFilePath"></param>
+        /// <returns>download path</returns>
         public static async Task<string> DownloadFileAsync(Uri uri, string downloadFilePath)
         {
             string downloadedPath = string.Empty;
@@ -915,6 +1055,11 @@ namespace LCT.SW360PackageCreator
             return downloadedPath;
         }
 
+        /// <summary>
+        /// Gets Correct File Extension
+        /// </summary>
+        /// <param name="sourceURL"></param>
+        /// <returns></returns>
         public static string GetCorrectFileExtension(string sourceURL)
         {
             int idx = sourceURL.LastIndexOf(Dataconstant.ForwardSlash);

--- a/src/LCT.Services/Interface/ISW360CreatorService.cs
+++ b/src/LCT.Services/Interface/ISW360CreatorService.cs
@@ -18,34 +18,146 @@ namespace LCT.Services.Interface
     /// </summary>
     public interface ISw360CreatorService
     {
+        /// <summary>
+        /// Asynchronously creates a component in SW360 based on comparison BOM data.
+        /// </summary>
+        /// <param name="componentInfo">The component information from comparison BOM.</param>
+        /// <param name="attachmentUrlList">The dictionary of attachment URLs.</param>
+        /// <returns>A task representing the asynchronous operation that returns the component creation status.</returns>
         Task<ComponentCreateStatus> CreateComponentBasesOFswComaprisonBOM(
             ComparisonBomData componentInfo, Dictionary<string, string> attachmentUrlList);
 
+        /// <summary>
+        /// Asynchronously creates a release for a component in SW360.
+        /// </summary>
+        /// <param name="componentInfo">The component information from comparison BOM.</param>
+        /// <param name="componentId">The SW360 component identifier.</param>
+        /// <param name="attachmentUrlList">The dictionary of attachment URLs.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release creation status.</returns>
         Task<ReleaseCreateStatus> CreateReleaseForComponent(
             ComparisonBomData componentInfo, string componentId, Dictionary<string, string> attachmentUrlList);
 
+        /// <summary>
+        /// Asynchronously links releases to a SW360 project.
+        /// </summary>
+        /// <param name="releasesTobeLinked">The list of releases to be linked.</param>
+        /// <param name="manuallyLinkedReleases">The list of manually linked releases.</param>
+        /// <param name="sw360ProjectId">The SW360 project identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if successful; otherwise, false.</returns>
         Task<bool> LinkReleasesToProject(List<ReleaseLinked> releasesTobeLinked, List<ReleaseLinked> manuallyLinkedReleases, string sw360ProjectId);
 
+        /// <summary>
+        /// Asynchronously gets the release identifier of a component.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <param name="componentVersion">The component version.</param>
+        /// <param name="componentid">The component identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release identifier.</returns>
         Task<string> GetReleaseIDofComponent(string componentName, string componentVersion, string componentid);
 
+        /// <summary>
+        /// Asynchronously triggers the FOSSology process for a release.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="sw360link">The SW360 link.</param>
+        /// <returns>A task representing the asynchronous operation that returns the FOSSology trigger status.</returns>
         Task<FossTriggerStatus> TriggerFossologyProcess(string releaseId, string sw360link);
 
+        /// <summary>
+        /// Asynchronously checks the FOSSology process status.
+        /// </summary>
+        /// <param name="link">The link to check status.</param>
+        /// <returns>A task representing the asynchronous operation that returns the FOSSology process status.</returns>
         Task<CheckFossologyProcess> CheckFossologyProcessStatus(string link);
 
+        /// <summary>
+        /// Asynchronously gets the component identifier by name.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <returns>A task representing the asynchronous operation that returns the component identifier.</returns>
         Task<string> GetComponentId(string componentName);
+        
+        /// <summary>
+        /// Asynchronously gets the component identifier using external ID.
+        /// </summary>
+        /// <param name="name">The component name.</param>
+        /// <param name="componentExternalId">The component external identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns the component identifier.</returns>
         Task<string> GetComponentIdUsingExternalId(string name, string componentExternalId);
+        
+        /// <summary>
+        /// Asynchronously gets the release by external ID.
+        /// </summary>
+        /// <param name="name">The component name.</param>
+        /// <param name="releaseVersion">The release version.</param>
+        /// <param name="releaseExternalId">The release external identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release identifier.</returns>
         Task<string> GetReleaseByExternalId(string name, string releaseVersion, string releaseExternalId);
+        
+        /// <summary>
+        /// Asynchronously gets the release information.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release information.</returns>
         Task<ReleasesInfo> GetReleaseInfo(string releaseId);
 
+        /// <summary>
+        /// Asynchronously gets the release identifier by component name and version.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <param name="componentVersion">The component version.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release identifier.</returns>
         Task<string> GetReleaseIdByName(string componentName, string componentVersion);
 
+        /// <summary>
+        /// Asynchronously updates the PURL identifier for an existing component.
+        /// </summary>
+        /// <param name="cbomData">The comparison BOM data.</param>
+        /// <param name="componentId">The component identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if successful; otherwise, false.</returns>
         Task<bool> UpdatePurlIdForExistingComponent(ComparisonBomData cbomData, string componentId);
 
+        /// <summary>
+        /// Asynchronously updates the PURL identifier for an existing release.
+        /// </summary>
+        /// <param name="cbomData">The comparison BOM data.</param>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="releasesInfo">The optional release information.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if successful; otherwise, false.</returns>
         Task<bool> UpdatePurlIdForExistingRelease(ComparisonBomData cbomData, string releaseId, ReleasesInfo releasesInfo = null);
 
+        /// <summary>
+        /// Asynchronously updates the SW360 release content.
+        /// </summary>
+        /// <param name="component">The component to update.</param>
+        /// <param name="fossUrl">The FOSSology URL.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if successful; otherwise, false.</returns>
         Task<bool> UpdateSW360ReleaseContent(Components component, string fossUrl);
+        
+        /// <summary>
+        /// Asynchronously triggers the FOSSology process for validation.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="sw360link">The SW360 link.</param>
+        /// <returns>A task representing the asynchronous operation that returns the FOSSology trigger status.</returns>
         Task<FossTriggerStatus> TriggerFossologyProcessForValidation(string releaseId, string sw360link);
+        
+        /// <summary>
+        /// Attaches sources to releases created in SW360.
+        /// </summary>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <param name="attachmentUrlList">The dictionary of attachment URLs.</param>
+        /// <param name="comparisonBomData">The comparison BOM data.</param>
+        /// <returns>The result of the attachment operation.</returns>
         public string AttachSourcesToReleasesCreated(string releaseId, Dictionary<string, string> attachmentUrlList, ComparisonBomData comparisonBomData);
+        
+        /// <summary>
+        /// Asynchronously updates the source code download URL for an existing release.
+        /// </summary>
+        /// <param name="cbomData">The comparison BOM data.</param>
+        /// <param name="attachmentUrlList">The dictionary of attachment URLs.</param>
+        /// <param name="releaseId">The release identifier.</param>
+        /// <returns>A task representing the asynchronous operation that returns true if successful; otherwise, false.</returns>
         Task<bool> UpdateSourceCodeDownloadURLForExistingRelease(ComparisonBomData cbomData, Dictionary<string, string> attachmentUrlList, string releaseId);
     }
 }

--- a/src/LCT.Services/Interface/ISW360Service.cs
+++ b/src/LCT.Services/Interface/ISW360Service.cs
@@ -18,17 +18,55 @@ namespace LCT.Services.Interface
     /// </summary>
     public interface ISW360Service
     {
+        /// <summary>
+        /// Asynchronously gets the component release identifier by component name and version.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <param name="version">The component version.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release identifier.</returns>
         Task<string> GetComponentReleaseID(string componentName, string version);
 
+        /// <summary>
+        /// Asynchronously gets the release information by release identifier.
+        /// </summary>
+        /// <param name="releaseLink">The release link.</param>
+        /// <returns>A task representing the asynchronous operation that returns an HTTP response message.</returns>
         Task<HttpResponseMessage> GetReleaseInfoByReleaseId(string releaseLink);
 
+        /// <summary>
+        /// Asynchronously gets the release data of a component.
+        /// </summary>
+        /// <param name="releaseLink">The release link.</param>
+        /// <returns>A task representing the asynchronous operation that returns the release information.</returns>
         Task<ReleasesInfo> GetReleaseDataOfComponent(string releaseLink);
 
+        /// <summary>
+        /// Asynchronously gets the available releases in SW360 for the specified components.
+        /// </summary>
+        /// <param name="listOfComponentsToBom">The list of components to query.</param>
+        /// <returns>A task representing the asynchronous operation that returns a list of available components.</returns>
         Task<List<Components>> GetAvailableReleasesInSw360(List<Components> listOfComponentsToBom);
 
+        /// <summary>
+        /// Asynchronously gets the attachment download link.
+        /// </summary>
+        /// <param name="releaseAttachmentUrl">The release attachment URL.</param>
+        /// <returns>A task representing the asynchronous operation that returns the attachment hash information.</returns>
         Task<Sw360AttachmentHash> GetAttachmentDownloadLink(string releaseAttachmentUrl);
 
+        /// <summary>
+        /// Asynchronously gets the upload description from SW360.
+        /// </summary>
+        /// <param name="componentName">The component name.</param>
+        /// <param name="componetVersion">The component version.</param>
+        /// <param name="sw360url">The SW360 URL.</param>
+        /// <returns>A task representing the asynchronous operation that returns the upload description.</returns>
         Task<string> GetUploadDescriptionfromSW360(string componentName, string componetVersion, string sw360url);
+        
+        /// <summary>
+        /// Gets the duplicate components by PURL identifier.
+        /// </summary>
+        /// <returns>A list of duplicate components.</returns>
         List<Components> GetDuplicateComponentsByPurlId();
     }
 }

--- a/src/LCT.Services/Interface/ISw360ProjectService.cs
+++ b/src/LCT.Services/Interface/ISw360ProjectService.cs
@@ -23,6 +23,12 @@ namespace LCT.Services.Interface
         /// <returns>string</returns>
         Task<string> GetProjectNameByProjectIDFromSW360(string projectId, string projectName, ProjectReleases projectReleases);
 
+
+        /// <summary>
+        /// gets already linked project id
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <returns></returns>
         Task<List<ReleaseLinked>> GetAlreadyLinkedReleasesByProjectId(string projectId);
     }
 }

--- a/src/LCT.Services/JFrogService.cs
+++ b/src/LCT.Services/JFrogService.cs
@@ -32,6 +32,13 @@ namespace LCT.Services
         {
             m_JFrogApiCommunicationFacade = jFrogApiCommunicationFacade;
         }
+
+        /// <summary>
+        /// gets component data by repo
+        /// </summary>
+        /// <param name="apiCall"></param>
+        /// <param name="repoName"></param>
+        /// <returns>list of result</returns>
         private static async Task<IList<AqlResult>> GetComponentDataByRepo(Func<string, Task<HttpResponseMessage>> apiCall, string repoName)
         {
             HttpResponseMessage httpResponseMessage = null;
@@ -65,26 +72,54 @@ namespace LCT.Services
             return aqlResult;
         }
 
+        /// <summary>
+        /// gets internal component data by repo
+        /// </summary>
+        /// <param name="repoName"></param>
+        /// <returns>list of result</returns>
         public async Task<IList<AqlResult>> GetInternalComponentDataByRepo(string repoName)
         {
             return await GetComponentDataByRepo(m_JFrogApiCommunicationFacade.GetInternalComponentDataByRepo, repoName);
         }
 
+        /// <summary>
+        /// gets npm component data by repo
+        /// </summary>
+        /// <param name="repoName"></param>
+        /// <returns>list of aql result</returns>
         public async Task<IList<AqlResult>> GetNpmComponentDataByRepo(string repoName)
         {
             return await GetComponentDataByRepo(m_JFrogApiCommunicationFacade.GetNpmComponentDataByRepo, repoName);
         }
 
+        /// <summary>
+        /// gets pypi component data by repo
+        /// </summary>
+        /// <param name="repoName"></param>
+        /// <returns>list of aql result</returns>
         public async Task<IList<AqlResult>> GetPypiComponentDataByRepo(string repoName)
         {
             return await GetComponentDataByRepo(m_JFrogApiCommunicationFacade.GetPypiComponentDataByRepo, repoName);
         }
 
+        /// <summary>
+        /// Retrieves a collection of Cargo component data for the specified repository.
+        /// </summary>
+        /// <param name="repoName">The name of the repository from which to retrieve Cargo component data. Cannot be null or empty.</param>
+        /// <returns>A list of <see cref="AqlResult"/> objects containing Cargo component data for the specified repository. The
+        /// list will be empty if no components are found.</returns>
         public async Task<IList<AqlResult>> GetCargoComponentDataByRepo(string repoName)
         {
             return await GetComponentDataByRepo(m_JFrogApiCommunicationFacade.GetCargoComponentDataByRepo, repoName);
         }
 
+        /// <summary>
+        /// Retrieves package information from Artifactory for the specified component.
+        /// </summary>       
+        /// <param name="component">The component for which to retrieve package information. Must specify valid identifiers for the target
+        /// Artifactory package.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="AqlResult"/>
+        /// instance with package details if found; otherwise, <see langword="null"/>.</returns>
 #nullable enable
         public async Task<AqlResult?> GetPackageInfo(ComponentsToArtifactory component)
         {
@@ -115,6 +150,10 @@ namespace LCT.Services
             return aqlResult;
         }
 
+        /// <summary>
+        /// checks jfrog connectivity
+        /// </summary>
+        /// <returns>task that represents operation</returns>
         public async Task<HttpResponseMessage> CheckJFrogConnectivity()
         {
             HttpResponseMessage? httpResponseMessage = null;

--- a/src/LCT.Services/Model/ComponentCreateStatus.cs
+++ b/src/LCT.Services/Model/ComponentCreateStatus.cs
@@ -14,7 +14,16 @@ namespace LCT.Services.Model
     [ExcludeFromCodeCoverage]
     public class ComponentCreateStatus
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets a value indicating whether the component was created successfully.
+        /// </summary>
         public bool IsCreated { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the release creation status.
+        /// </summary>
         public ReleaseCreateStatus ReleaseStatus { get; set; }
+        #endregion
     }
 }

--- a/src/LCT.Services/Model/ReleaseCreateStatus.cs
+++ b/src/LCT.Services/Model/ReleaseCreateStatus.cs
@@ -14,11 +14,26 @@ namespace LCT.Services.Model
     [ExcludeFromCodeCoverage]
     public class ReleaseCreateStatus
     {
+        #region Properties
+        /// <summary>
+        /// Gets or sets a value indicating whether the release was created successfully.
+        /// </summary>
         public bool IsCreated { get; set; }
 
+        /// <summary>
+        /// Gets or sets the release identifier to link.
+        /// </summary>
         public string ReleaseIdToLink { get; set; }
 
+        /// <summary>
+        /// Gets or sets the attachment API URL.
+        /// </summary>
         public string AttachmentApiUrl { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether the release already exists.
+        /// </summary>
         public bool ReleaseAlreadyExist { get; set; } = false;
+        #endregion
     }
 }

--- a/src/LCT.Services/Sw360CommonService.cs
+++ b/src/LCT.Services/Sw360CommonService.cs
@@ -97,6 +97,13 @@ namespace LCT.Services
             return sw360components;
         }
 
+        /// <summary>
+        /// Retrieves a list of SW360 components that match the specified external ID combination.
+        /// </summary>       
+        /// <param name="externalIdUriString">The URI string representing the external ID value used to query components. Cannot be null or empty.</param>
+        /// <param name="externalIdKey">The key identifying the type of external ID to match against components. Cannot be null or empty.</param>
+        /// <returns>A list of SW360 components that correspond to the given external ID combination. Returns an empty list if no
+        /// matching components are found.</returns>
         private async Task<IList<Sw360Components>> GetCompListFromExternalIDCombinations(string externalIdUriString, string externalIdKey)
         {
             HttpResponseMessage httpResponseComponent = await m_SW360ApiCommunicationFacade.GetComponentByExternalId(externalIdUriString, externalIdKey);
@@ -207,6 +214,16 @@ namespace LCT.Services
 
         #region PrivateMethods
 
+        /// <summary>
+        /// Determines the existence status of a release by matching the specified release name and external ID key
+        /// against a collection of SW360 release data.
+        /// </summary>
+        /// <param name="name">The name of the release to search for within the provided release data. Cannot be null.</param>
+        /// <param name="externlaIdKey">The external ID key used to identify and match releases. Cannot be null.</param>
+        /// <param name="sw360releasesdata">A collection of SW360 release data to be searched. Cannot be null and must contain at least one element.</param>
+        /// <returns>A Releasestatus object containing information about the matched release and its existence status. The
+        /// returned object will indicate whether a release with the specified name and external ID exists in the
+        /// provided data.</returns>
         private static Releasestatus GetReleaseExistStatus(
             string name, string externlaIdKey, IList<Sw360Releases> sw360releasesdata)
         {
@@ -244,7 +261,13 @@ namespace LCT.Services
             return releasestatus;
         }
 
-
+        /// <summary>
+        /// gets component exist status
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="externlaIdKey"></param>
+        /// <param name="sw360components"></param>
+        /// <returns>comonent status</returns>
         private static ComponentStatus GetComponentExistStatus(string name, string externlaIdKey, IList<Sw360Components> sw360components)
         {
             Dictionary<int, Sw360Components> componentCollection = new Dictionary<int, Sw360Components>();
@@ -282,7 +305,13 @@ namespace LCT.Services
 
         }
 
-
+        /// <summary>
+        /// gets package url
+        /// </summary>
+        /// <param name="externlaIdKey"></param>
+        /// <param name="release"></param>
+        /// <param name="packageUrl"></param>
+        /// <returns>value</returns>
         private static string GetPackageUrlValue(string externlaIdKey, Sw360Releases release, string packageUrl)
         {
             if (externlaIdKey.Contains("purl"))
@@ -302,6 +331,13 @@ namespace LCT.Services
             return packageUrl;
         }
 
+        /// <summary>
+        /// gets package url value
+        /// </summary>
+        /// <param name="externlaIdKey"></param>
+        /// <param name="components"></param>
+        /// <param name="packageUrl"></param>
+        /// <returns>value</returns>
         private static string GetPackageUrlValue(string externlaIdKey, Sw360Components components, string packageUrl)
         {
             if (externlaIdKey.Contains("purl"))
@@ -321,6 +357,12 @@ namespace LCT.Services
             return packageUrl;
         }
 
+        /// <summary>
+        /// update collections
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="componentCollection"></param>
+        /// <param name="components"></param>
         private static void UpdateCollection(string name, ref Dictionary<int, Sw360Components> componentCollection, Sw360Components components)
         {
             if (componentCollection.TryGetValue(1, out Sw360Components value) && value.Name.ToLower().Equals(name.ToLower()))
@@ -333,6 +375,12 @@ namespace LCT.Services
             }
         }
 
+        /// <summary>
+        /// update collections
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="releaseCollection"></param>
+        /// <param name="release"></param>
         private static void UpdateCollection(string name, ref Dictionary<int, Sw360Releases> releaseCollection, Sw360Releases release)
         {
             if (releaseCollection.TryGetValue(1, out Sw360Releases value) && value.Name.ToLower().Equals(name.ToLower()))

--- a/src/LCT.Services/Sw360CreatorService.cs
+++ b/src/LCT.Services/Sw360CreatorService.cs
@@ -49,6 +49,12 @@ namespace LCT.Services
             m_SW360CommonService = sW360CommonService;
         }
 
+        /// <summary>
+        /// creates componnet base of comparison BOM
+        /// </summary>
+        /// <param name="componentInfo"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <returns>Component create status</returns>
         public async Task<ComponentCreateStatus> CreateComponentBasesOFswComaprisonBOM(
             ComparisonBomData componentInfo, Dictionary<string, string> attachmentUrlList)
         {
@@ -103,7 +109,12 @@ namespace LCT.Services
             return componentCreateStatus;
         }
 
-
+        /// <summary>
+        /// trigger fossology process
+        /// </summary>
+        /// <param name="releaseId"></param>
+        /// <param name="sw360link"></param>
+        /// <returns>task that represents foss trigger status</returns>
         public async Task<FossTriggerStatus> TriggerFossologyProcess(string releaseId, string sw360link)
         {
             FossTriggerStatus fossTriggerStatus = null;
@@ -122,6 +133,11 @@ namespace LCT.Services
 
         }
 
+        /// <summary>
+        /// checks fossology process status
+        /// </summary>
+        /// <param name="link"></param>
+        /// <returns>task that represents fosology process</returns>
         public async Task<CheckFossologyProcess> CheckFossologyProcessStatus(string link)
         {
             CheckFossologyProcess fossTriggerStatus = null;
@@ -143,6 +159,14 @@ namespace LCT.Services
             return fossTriggerStatus;
 
         }
+
+        /// <summary>
+        /// create release component
+        /// </summary>
+        /// <param name="componentInfo"></param>
+        /// <param name="componentId"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <returns>create status</returns>
         public async Task<ReleaseCreateStatus> CreateReleaseForComponent(ComparisonBomData componentInfo, string componentId,
                                                              Dictionary<string, string> attachmentUrlList)
         {
@@ -198,6 +222,15 @@ namespace LCT.Services
             }
             return createStatus;
         }
+
+        /// <summary>
+        /// gets release id to link to project
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="releaseExternalId"></param>
+        /// <param name="componentId"></param>
+        /// <returns>task that represents asynchronous operation</returns>
         private async Task<string> GetReleaseIdToLinkToProject(string name, string version, string releaseExternalId, string componentId)
         {
             string releaseId = await GetReleaseIdByName(name, version);
@@ -226,6 +259,14 @@ namespace LCT.Services
             return releaseId ?? string.Empty;
         }
 
+        /// <summary>
+        /// attach source and binary
+        /// </summary>
+        /// <param name="attachmentUrlList"></param>
+        /// <param name="createStatus"></param>
+        /// <param name="response"></param>
+        /// <param name="comparisonBomData"></param>
+        /// <returns>value</returns>
         private string AttachSourceAndBinary(Dictionary<string, string> attachmentUrlList, ReleaseCreateStatus createStatus, HttpResponseMessage response, ComparisonBomData comparisonBomData)
         {
             string releaseId = string.Empty;
@@ -242,6 +283,12 @@ namespace LCT.Services
             return releaseId;
         }
 
+        /// <summary>
+        /// gets source download url
+        /// </summary>
+        /// <param name="componentInfo"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <returns>value</returns>
         private static string GetSourceDownloadUrl(ComparisonBomData componentInfo, Dictionary<string, string> attachmentUrlList)
         {
             if (componentInfo.DownloadUrl == Dataconstant.DownloadUrlNotFound || !(attachmentUrlList.ContainsKey("SOURCE")))
@@ -251,6 +298,12 @@ namespace LCT.Services
             return componentInfo.DownloadUrl ?? string.Empty;
         }
 
+        /// <summary>
+        /// gets package download url
+        /// </summary>
+        /// <param name="componentInfo"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <returns>value</returns>
         private static string GetPackageDownloadUrl(ComparisonBomData componentInfo, Dictionary<string, string> attachmentUrlList)
         {
             if (!(attachmentUrlList.ContainsKey("BINARY")))
@@ -260,6 +313,14 @@ namespace LCT.Services
             return componentInfo.PackageUrl ?? string.Empty;
         }
 
+
+        /// <summary>
+        /// link releases to project 
+        /// </summary>
+        /// <param name="releasesTobeLinked"></param>
+        /// <param name="manuallyLinkedReleases"></param>
+        /// <param name="sw360ProjectId"></param>
+        /// <returns>boolean value</returns>
         public async Task<bool> LinkReleasesToProject(List<ReleaseLinked> releasesTobeLinked, List<ReleaseLinked> manuallyLinkedReleases, string sw360ProjectId)
         {
             if (manuallyLinkedReleases.Count <= 0 && releasesTobeLinked.Count <= 0)
@@ -326,6 +387,13 @@ namespace LCT.Services
             }
         }
 
+        /// <summary>
+        /// gets release id of a component
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componentVersion"></param>
+        /// <param name="componentid"></param>
+        /// <returns>value</returns>
         public async Task<string> GetReleaseIDofComponent(string componentName, string componentVersion, string componentid)
         {
             string releaseIdOfComponent = null;
@@ -348,6 +416,12 @@ namespace LCT.Services
             return releaseIdOfComponent ?? string.Empty;
         }
 
+        /// <summary>
+        /// gets release id by name
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componentVersion"></param>
+        /// <returns>name</returns>
         public async Task<string> GetReleaseIdByName(string componentName, string componentVersion)
         {
             string releaseid = string.Empty;
@@ -365,6 +439,14 @@ namespace LCT.Services
             return releaseid ?? string.Empty;
         }
 
+        /// <summary>
+        /// gets release id from response
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componentVersion"></param>
+        /// <param name="releaseid"></param>
+        /// <param name="responseBody"></param>
+        /// <returns>release id</returns>
         private static string GetReleaseIdFromResponse(string componentName, string componentVersion, string releaseid, string responseBody)
         {
             var responseData = JsonConvert.DeserializeObject<ReleaseIdOfComponent>(responseBody);
@@ -382,6 +464,11 @@ namespace LCT.Services
             return releaseid;
         }
 
+        /// <summary>
+        /// gets component id
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <returns>component id</returns>
         public async Task<string> GetComponentId(string componentName)
         {
             string ComponentId = "";
@@ -412,7 +499,13 @@ namespace LCT.Services
             return ComponentId;
         }
 
-
+        /// <summary>
+        /// attach sources to releases
+        /// </summary>
+        /// <param name="releaseId"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <param name="comparisonBomData"></param>
+        /// <returns>value</returns>
         public string AttachSourcesToReleasesCreated(string releaseId, Dictionary<string, string> attachmentUrlList, ComparisonBomData comparisonBomData)
         {
             Logger.Debug($"AttachSourcesToReleasesCreated(): start");
@@ -435,6 +528,12 @@ namespace LCT.Services
             return attachmentApiUrl;
         }
 
+        /// <summary>
+        /// update id for existing component
+        /// </summary>
+        /// <param name="cbomData"></param>
+        /// <param name="componentId"></param>
+        /// <returns>boolean value</returns>
         public async Task<bool> UpdatePurlIdForExistingComponent(ComparisonBomData cbomData, string componentId)
         {
             try
@@ -474,6 +573,14 @@ namespace LCT.Services
             }
         }
 
+        /// <summary>
+        /// external id addition for component
+        /// </summary>
+        /// <param name="cbomData"></param>
+        /// <param name="componentPurlId"></param>
+        /// <param name="externalIds"></param>
+        /// <param name="existingExternalIds"></param>
+        /// <returns>boolean value</returns>
         private static bool ExternalIdAdditionForComponent(ComparisonBomData cbomData, ComponentPurlId componentPurlId, ref Dictionary<string, string> externalIds, Dictionary<string, string> existingExternalIds)
         {
 
@@ -496,6 +603,14 @@ namespace LCT.Services
             return false;
         }
 
+        /// <summary>
+        /// adding to existing component url id list
+        /// </summary>
+        /// <param name="existingExternalIds"></param>
+        /// <param name="cbomData"></param>
+        /// <param name="componentPurlId"></param>
+        /// <param name="externalIds"></param>
+        /// <returns>boolean value</returns>
         private static bool AddingToExistingComponentPurlIdList(Dictionary<string, string> existingExternalIds, ComparisonBomData cbomData, ComponentPurlId componentPurlId, ref Dictionary<string, string> externalIds)
         {
             bool isUpdated = false;
@@ -541,6 +656,13 @@ namespace LCT.Services
             return isUpdated;
         }
 
+        /// <summary>
+        /// updates url for existing release
+        /// </summary>
+        /// <param name="cbomData"></param>
+        /// <param name="releaseId"></param>
+        /// <param name="releasesInfo"></param>
+        /// <returns>boolean value</returns>
         public async Task<bool> UpdatePurlIdForExistingRelease(ComparisonBomData cbomData, string releaseId, ReleasesInfo releasesInfo = null)
         {
             try
@@ -584,6 +706,14 @@ namespace LCT.Services
                 return false;
             }
         }
+
+        /// <summary>
+        /// Updates Source Code Download URL For Existing Release
+        /// </summary>
+        /// <param name="cbomData"></param>
+        /// <param name="attachmentUrlList"></param>
+        /// <param name="releaseId"></param>
+        /// <returns>boolean value</returns>
         public async Task<bool> UpdateSourceCodeDownloadURLForExistingRelease(ComparisonBomData cbomData, Dictionary<string, string> attachmentUrlList, string releaseId)
         {
             try
@@ -618,6 +748,12 @@ namespace LCT.Services
                 return false;
             }
         }
+
+        /// <summary>
+        /// gets decided external id
+        /// </summary>
+        /// <param name="ReleaseExternalID"></param>
+        /// <returns>external id</returns>
         private static string GetDecodedExternalId(string ReleaseExternalID)
         {
             string releaseID;
@@ -633,6 +769,14 @@ namespace LCT.Services
             return releaseID;
         }
 
+        /// <summary>
+        /// External Id Addition For Release
+        /// </summary>
+        /// <param name="cbomData"></param>
+        /// <param name="releasesInfo"></param>
+        /// <param name="externalIds"></param>
+        /// <param name="existingExternalIds"></param>
+        /// <returns>boolean value</returns>
         private static bool ExternalIdAdditionForRelease(ComparisonBomData cbomData, ReleasesInfo releasesInfo, ref Dictionary<string, string> externalIds, Dictionary<string, string> existingExternalIds)
         {
             if (releasesInfo == null || releasesInfo.ExternalIds == null || releasesInfo.ExternalIds?.Count == 0)
@@ -655,6 +799,14 @@ namespace LCT.Services
             return false;
         }
 
+        /// <summary>
+        /// Adding To Existing Release Purl Id List
+        /// </summary>
+        /// <param name="existingExternalIds"></param>
+        /// <param name="cbomData"></param>
+        /// <param name="releasesInfo"></param>
+        /// <param name="externalIds"></param>
+        /// <returns>boolean value</returns>
         private static bool AddingToExistingReleasePurlIdList(Dictionary<string, string> existingExternalIds, ComparisonBomData cbomData, ReleasesInfo releasesInfo, ref Dictionary<string, string> externalIds)
         {
             bool isUpdated = false;
@@ -700,6 +852,11 @@ namespace LCT.Services
             return isUpdated;
         }
 
+        /// <summary>
+        /// gets release info
+        /// </summary>
+        /// <param name="releaseId"></param>
+        /// <returns>release info</returns>
         public async Task<ReleasesInfo> GetReleaseInfo(string releaseId)
         {
             ReleasesInfo responsBody = null;
@@ -721,7 +878,12 @@ namespace LCT.Services
             return responsBody;
         }
 
-
+        /// <summary>
+        /// updates sw360 release content
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="fossUrl"></param>
+        /// <returns>boolean value</returns>
         public async Task<bool> UpdateSW360ReleaseContent(Components component, string fossUrl)
         {
             bool isUpdated = false;
@@ -761,6 +923,13 @@ namespace LCT.Services
             return isUpdated;
         }
 
+        /// <summary>
+        /// gets release by external id
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="releaseVersion"></param>
+        /// <param name="releaseExternalId"></param>
+        /// <returns>external id</returns>
         public async Task<string> GetReleaseByExternalId(string name, string releaseVersion, string releaseExternalId)
         {
             Releasestatus releasestatus = await m_SW360CommonService.GetReleaseDataByExternalId(name, releaseVersion, releaseExternalId);
@@ -769,6 +938,12 @@ namespace LCT.Services
             return releaseId;
         }
 
+        /// <summary>
+        /// Gets Component Id Using External Id
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="componentExternalId"></param>
+        /// <returns>component id</returns>
         public async Task<string> GetComponentIdUsingExternalId(string name, string componentExternalId)
         {
             ComponentStatus componentstatus = await m_SW360CommonService.GetComponentDataByExternalId(name, componentExternalId);
@@ -777,6 +952,13 @@ namespace LCT.Services
             return ComponentId;
         }
 
+        /// <summary>
+        /// Gets Update Release Content
+        /// </summary>
+        /// <param name="releaseId"></param>
+        /// <param name="fossUrl"></param>
+        /// <param name="uploadId"></param>
+        /// <returns></returns>
         private async Task<UpdateReleaseAdditinoalData> GetUpdateReleaseContent(string releaseId, string fossUrl, string uploadId)
         {
             ReleasesInfo releasesInfo = await GetReleaseInfo(releaseId);
@@ -819,6 +1001,13 @@ namespace LCT.Services
 
             return updateRelease;
         }
+
+        /// <summary>
+        /// Trigger Fossology Process For Validation
+        /// </summary>
+        /// <param name="releaseId"></param>
+        /// <param name="sw360link"></param>
+        /// <returns>trigger status</returns>
         public async Task<FossTriggerStatus> TriggerFossologyProcessForValidation(string releaseId, string sw360link)
         {
             FossTriggerStatus fossTriggerStatus = null;

--- a/src/LCT.Services/Sw360ProjectService.cs
+++ b/src/LCT.Services/Sw360ProjectService.cs
@@ -78,6 +78,11 @@ namespace LCT.Services
             return sw360ProjectName;
         }
 
+        /// <summary>
+        /// Gets Already Linked Releases By ProjectId
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <returns>release id</returns>
         public async Task<List<ReleaseLinked>> GetAlreadyLinkedReleasesByProjectId(string projectId)
         {
             List<ReleaseLinked> alreadyLinkedReleases = new List<ReleaseLinked>();

--- a/src/LCT.Services/Sw360Service.cs
+++ b/src/LCT.Services/Sw360Service.cs
@@ -55,11 +55,25 @@ namespace LCT.Services
             m_SW360CommonService = sw360CommonService;
             environmentHelper = _environmentHelper;
         }
+
+        /// <summary>
+        /// Retrieves a list of components that have duplicate Package URL (PURL) identifiers.
+        /// </summary>
+        /// <returns>A list of <see cref="Components"/> objects that share the same PURL identifier. The list is empty if no
+        /// duplicates are found.</returns>
         public List<Components> GetDuplicateComponentsByPurlId()
         {
             return InvalidComponentsIdentifiedByPurlId;
         }
 
+        /// <summary>
+        /// Retrieves the list of components from SW360 that are available as releases and match the specified
+        /// components.
+        /// </summary>       
+        /// <param name="listOfComponentsToBom">The list of components to check for available releases in SW360. Each component in the list is compared
+        /// against the releases retrieved from SW360.</param>
+        /// <returns>A list of components representing the available releases in SW360 that correspond to the specified
+        /// components. The list is empty if no matching releases are found.</returns>
         public async Task<List<Components>> GetAvailableReleasesInSw360(List<Components> listOfComponentsToBom)
         {
             List<Components> availableComponentsList = new List<Components>();
@@ -100,7 +114,13 @@ namespace LCT.Services
             return availableComponentsList;
         }
 
-
+        /// <summary>
+        /// Retrieves release information for a specified component using the provided release link.
+        /// </summary>
+        /// <param name="releaseLink">The URL or identifier used to locate and retrieve the release data for the component. Cannot be null or
+        /// empty.</param>
+        /// <returns>A <see cref="ReleasesInfo"/> object containing the release details for the specified component. Returns an
+        /// empty <see cref="ReleasesInfo"/> instance if no data is found or an error occurs.</returns>
         public async Task<ReleasesInfo> GetReleaseDataOfComponent(string releaseLink)
         {
             ReleasesInfo releasesInfo = new ReleasesInfo();
@@ -124,7 +144,14 @@ namespace LCT.Services
             return releasesInfo;
         }
 
-
+        /// <summary>
+        /// Retrieves release information from the SW360 API using the specified release link.
+        /// </summary>       
+        /// <param name="releaseLink">The URL or link identifying the release to retrieve. Must not be null or empty. The release ID is extracted
+        /// from the last segment of this link.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the HTTP response message with
+        /// the release information if the request is successful; otherwise, the response may be null if an error
+        /// occurs.</returns>
         public async Task<HttpResponseMessage> GetReleaseInfoByReleaseId(string releaseLink)
         {
             HttpResponseMessage responseBody = null;
@@ -142,6 +169,12 @@ namespace LCT.Services
             return responseBody;
         }
 
+        /// <summary>
+        /// Retrieves the release identifier for a specified component and version.
+        /// </summary>       
+        /// <param name="componentName">The name of the component for which to retrieve the release identifier. Cannot be null or empty.</param>
+        /// <param name="version">The version of the component for which to retrieve the release identifier. Cannot be null or empty.</param>
+        /// <returns>A string containing the release identifier if found; otherwise, an empty string.</returns>
         public async Task<string> GetComponentReleaseID(string componentName, string version)
         {
             string releaseId = ""; string href = "";
@@ -169,6 +202,15 @@ namespace LCT.Services
             return releaseId;
         }
 
+        /// <summary>
+        /// Retrieves the download link and related metadata for an attachment associated with a release, given the
+        /// attachment URL.
+        /// </summary>       
+        /// <param name="releaseAttachmentUrl">The URL of the release attachment for which to obtain the download link. Cannot be null, empty, or
+        /// whitespace.</param>
+        /// <returns>A <see cref="Sw360AttachmentHash"/> object containing the download link and related information. If the
+        /// attachment is not available or the URL is invalid, the returned object will indicate that the source is not
+        /// available.</returns>
         public async Task<Sw360AttachmentHash> GetAttachmentDownloadLink(string releaseAttachmentUrl)
         {
             Sw360AttachmentHash attachmentHash = new Sw360AttachmentHash();
@@ -207,6 +249,13 @@ namespace LCT.Services
             return attachmentHash;
         }
 
+        /// <summary>
+        /// Retrieves the attachment link, hash code, and name for the first attachment of type "SOURCE" from the
+        /// specified collection.
+        /// </summary>
+        /// <param name="sw360attachments">A list of SW360 attachments to search for a source attachment. Cannot be null.</param>
+        /// <returns>A Sw360AttachmentHash containing the link, hash code, and name of the first source attachment found;
+        /// otherwise, an empty Sw360AttachmentHash if no source attachment exists.</returns>
         private static Sw360AttachmentHash GetReleaseSourceAttachmentLink(IList<Sw360Attachments> sw360attachments)
         {
             Sw360AttachmentHash attachmentHash = new Sw360AttachmentHash();
@@ -222,6 +271,15 @@ namespace LCT.Services
             return attachmentHash;
         }
 
+        /// <summary>
+        /// Downloads the source code attachment for a release from the specified SW360 attachment information.
+        /// </summary>        
+        /// <param name="fileName">The name of the component file to use as a base for the downloaded file path.</param>
+        /// <param name="version">The version of the component associated with the source code to download.</param>
+        /// <param name="attachmentHash">The SW360 attachment hash containing metadata and the download URL for the source code attachment. Cannot be
+        /// null.</param>
+        /// <returns>The full file path to the downloaded source code file if the download succeeds; otherwise, returns the
+        /// original component file name if the download fails or the source download URL is not available.</returns>
         [ExcludeFromCodeCoverage]
         public string DownloadReleaseSourceCode(string fileName, string version, Sw360AttachmentHash attachmentHash)
         {
@@ -270,6 +328,13 @@ namespace LCT.Services
             return fileName;
         }
 
+        /// <summary>
+        /// gets upload description frim sw360
+        /// </summary>
+        /// <param name="componentName"></param>
+        /// <param name="componetVersion"></param>
+        /// <param name="sw360url"></param>
+        /// <returns>description</returns>
         [ExcludeFromCodeCoverage]
         public async Task<string> GetUploadDescriptionfromSW360(string componentName, string componetVersion, string sw360url)
         {
@@ -302,6 +367,12 @@ namespace LCT.Services
             return "";
         }
 
+        /// <summary>
+        /// gets available components list
+        /// </summary>
+        /// <param name="sw360Releases"></param>
+        /// <param name="listOfComponentsToBom"></param>
+        /// <returns>list of components</returns>
         private async Task<List<Components>> GetAvailableComponenentsList(IList<Sw360Releases> sw360Releases, List<Components> listOfComponentsToBom)
         {
 
@@ -331,6 +402,11 @@ namespace LCT.Services
             RemoveInvalidComponentsByPurlId(listOfComponentsToBom);
             return availableComponentList;
         }
+
+        /// <summary>
+        /// remove invalid component by purl id
+        /// </summary>
+        /// <param name="components"></param>
         private static void RemoveInvalidComponentsByPurlId(List<Components> components)
         {
             if (InvalidComponentsIdentifiedByPurlId.Count == 0)
@@ -343,6 +419,14 @@ namespace LCT.Services
                     invalid.ReleaseExternalId?.Equals(component.ReleaseExternalId) == true
                 ));
         }
+
+        /// <summary>
+        /// check availability by name and version
+        /// </summary>
+        /// <param name="sw360Releases"></param>
+        /// <param name="component"></param>
+        /// <param name="sw360ComponentList"></param>
+        /// <returns>boolean value</returns>
         private static bool CheckAvailabilityByNameAndVersion(IList<Sw360Releases> sw360Releases, Components component, IList<Sw360Components> sw360ComponentList)
         {
             Logger.Debug($"CheckAvailabilityByNameAndVersion(): Starting check for component '{component?.Name}' version '{component?.Version}'");
@@ -362,6 +446,12 @@ namespace LCT.Services
             return ValidateAndProcessComponent(sw360Release, sw360Component, component);
         }
 
+        /// <summary>
+        /// fins matching release
+        /// </summary>
+        /// <param name="sw360Releases"></param>
+        /// <param name="component"></param>
+        /// <returns>releases data</returns>
         private static Sw360Releases FindMatchingRelease(IList<Sw360Releases> sw360Releases, Components component)
         {
             // Find regular version match
@@ -381,12 +471,25 @@ namespace LCT.Services
             return sw360Release;
         }
 
+        /// <summary>
+        /// finds matching component
+        /// </summary>
+        /// <param name="sw360ComponentList"></param>
+        /// <param name="component"></param>
+        /// <returns>component</returns>
         private static Sw360Components FindMatchingComponent(IList<Sw360Components> sw360ComponentList, Components component)
         {
             return sw360ComponentList.FirstOrDefault(x =>
                 x.Name?.Trim().ToLowerInvariant() == component?.Name?.Trim().ToLowerInvariant());
         }
 
+        /// <summary>
+        /// validate and process component
+        /// </summary>
+        /// <param name="sw360Release"></param>
+        /// <param name="sw360Component"></param>
+        /// <param name="component"></param>
+        /// <returns>boolean value</returns>
         private static bool ValidateAndProcessComponent(Sw360Releases sw360Release, Sw360Components sw360Component, Components component)
         {
             if (string.IsNullOrEmpty(sw360Component?.ExternalIds?.Package_Url)
@@ -408,6 +511,12 @@ namespace LCT.Services
             return true;
         }
 
+        /// <summary>
+        /// validates project type url
+        /// </summary>
+        /// <param name="sw360Component"></param>
+        /// <param name="component"></param>
+        /// <returns>boolean value</returns>
         private static bool ValidateProjectTypePurl(Sw360Components sw360Component, Components component)
         {
             if (string.IsNullOrEmpty(component?.ProjectType)
@@ -431,6 +540,11 @@ namespace LCT.Services
             return true;
         }
 
+        /// <summary>
+        /// handle mismatched url id
+        /// </summary>
+        /// <param name="sw360Component"></param>
+        /// <param name="component"></param>
         private static void HandleMismatchedPurlId(Sw360Components sw360Component, Components component)
         {
             Logger.Debug($"GetAvailableComponenentsList(): Component Name '{component.Name}' PURL ID mismatched with SW360 component PURL ID");
@@ -442,6 +556,11 @@ namespace LCT.Services
             InvalidComponentsIdentifiedByPurlId.Add(component);
         }
 
+        /// <summary>
+        /// adds to available list
+        /// </summary>
+        /// <param name="sw360Release"></param>
+        /// <param name="component"></param>
         private static void AddToAvailableList(Sw360Releases sw360Release, Components component)
         {
             availableComponentList.Add(new Components
@@ -454,6 +573,10 @@ namespace LCT.Services
             });
         }
 
+        /// <summary>
+        /// gets available component list from sw360
+        /// </summary>
+        /// <returns></returns>
         private async Task<IList<Sw360Components>> GetAvailableComponenentsListFromSw360()
         {
             IList<Sw360Components> componentsList = new List<Sw360Components>();
@@ -471,6 +594,12 @@ namespace LCT.Services
             return componentsList;
         }
 
+        /// <summary>
+        /// checks availability by name
+        /// </summary>
+        /// <param name="sw360Components"></param>
+        /// <param name="component"></param>
+        /// <returns>boolean value</returns>
         private static bool CheckAvailabilityByName(IList<Sw360Components> sw360Components, Components component)
         {
             //checking for component existance with name 
@@ -492,6 +621,11 @@ namespace LCT.Services
             return isComponentAvailable;
         }
 
+        /// <summary>
+        /// checks component existence by external id
+        /// </summary>
+        /// <param name="componentToBomData"></param>
+        /// <returns>boolean value</returns>
         private async Task<bool> CheckComponentExistenceByExternalId(Components componentToBomData)
         {
             Logger.Debug($"CheckComponentExistenceByExternalId(): Component - {componentToBomData.Name}");
@@ -527,6 +661,11 @@ namespace LCT.Services
             return componentstatus.isComponentExist;
         }
 
+        /// <summary>
+        /// checks release existence by external id
+        /// </summary>
+        /// <param name="componentToBomData"></param>
+        /// <returns>boolean value</returns>
         private async Task<bool> CheckReleaseExistenceByExternalId(Components componentToBomData)
         {
             Logger.Debug($"CheckReleaseExistenceByExternalId():  start : Release name - {componentToBomData.Name}, version - {componentToBomData.Version}");

--- a/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
+++ b/src/LCT.Telemetry/ApplicationInsightsTelemetryProvider.cs
@@ -9,10 +9,21 @@ using Microsoft.ApplicationInsights.Extensibility;
 
 namespace LCT.Telemetry
 {
+    /// <summary>
+    /// Provides telemetry tracking functionality using Application Insights.
+    /// </summary>
     public class ApplicationInsightsTelemetryProvider : ITelemetryProvider
     {
+        #region Fields
         private readonly TelemetryClient _telemetryClient;
+        #endregion
 
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsTelemetryProvider"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration dictionary containing connection string.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the Application Insights Instrumentation Key is missing or invalid.</exception>
         public ApplicationInsightsTelemetryProvider(Dictionary<string, string> configuration)
         {
             var ConnectionString = configuration.GetValueOrDefault("ConnectionString")
@@ -28,12 +39,24 @@ namespace LCT.Telemetry
 
             _telemetryClient = new TelemetryClient(aiConfig);
         }
+        #endregion
 
+        #region Methods
+        /// <summary>
+        /// Tracks a custom event with optional properties.
+        /// </summary>
+        /// <param name="eventName">The name of the event to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the event.</param>
         public void TrackEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryClient.TrackEvent(eventName, properties);
         }
 
+        /// <summary>
+        /// Tracks an exception with optional properties.
+        /// </summary>
+        /// <param name="ex">The exception to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the exception.</param>
         public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             var exceptionTelemetry = new ExceptionTelemetry(ex);
@@ -49,10 +72,14 @@ namespace LCT.Telemetry
             _telemetryClient.TrackException(exceptionTelemetry);
         }
 
+        /// <summary>
+        /// Flushes the telemetry client to ensure all telemetry data is sent.
+        /// </summary>
         public void Flush()
         {
             _telemetryClient.Flush();
             Thread.Sleep(1000); // Allow some time for telemetry to be sent
         }
+        #endregion
     }
 }

--- a/src/LCT.Telemetry/HashUtility.cs
+++ b/src/LCT.Telemetry/HashUtility.cs
@@ -8,8 +8,17 @@ using System.Text;
 
 namespace LCT.Telemetry
 {
+    /// <summary>
+    /// Provides utility methods for generating hash strings.
+    /// </summary>
     public static class HashUtility
     {
+        #region Methods
+        /// <summary>
+        /// Generates a SHA256 hash string from the input string.
+        /// </summary>
+        /// <param name="input">The input string to hash.</param>
+        /// <returns>A lowercase hexadecimal string representation of the SHA256 hash, or an empty string if the input is null or empty.</returns>
         public static string GetHashString(string input)
         {
             if (string.IsNullOrEmpty(input))
@@ -19,5 +28,6 @@ namespace LCT.Telemetry
             byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
             return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
         }
+        #endregion
     }
 }

--- a/src/LCT.Telemetry/ITelemetryProvider.cs
+++ b/src/LCT.Telemetry/ITelemetryProvider.cs
@@ -5,10 +5,28 @@
 // -------------------------------------------------------------------------------------------------------------------- 
 namespace LCT.Telemetry
 {
+    /// <summary>
+    /// Defines a contract for telemetry providers.
+    /// </summary>
     public interface ITelemetryProvider
     {
+        /// <summary>
+        /// Tracks a custom event with optional properties.
+        /// </summary>
+        /// <param name="eventName">The name of the event to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the event.</param>
         void TrackEvent(string eventName, Dictionary<string, string>? properties = null);
+        
+        /// <summary>
+        /// Tracks an exception with optional properties.
+        /// </summary>
+        /// <param name="ex">The exception to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the exception.</param>
         void TrackException(Exception ex, Dictionary<string, string>? properties = null);
+        
+        /// <summary>
+        /// Flushes the telemetry provider to ensure all telemetry data is sent.
+        /// </summary>
         void Flush();
     }
 }

--- a/src/LCT.Telemetry/Telemetry.cs
+++ b/src/LCT.Telemetry/Telemetry.cs
@@ -12,11 +12,24 @@ using System.Globalization;
 
 namespace LCT.Telemetry
 {
+    /// <summary>
+    /// Telemetry class to track custom events, exceptions and execution time.
+    /// </summary>
     public class Telemetry
     {
+        #region Fields
         private readonly ITelemetryProvider _telemetryProvider;
         private readonly Stopwatch _stopwatch;
+        #endregion
 
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Telemetry"/> class.
+        /// </summary>
+        /// <param name="telemetryType">The type of telemetry provider to use.</param>
+        /// <param name="configuration">The configuration dictionary for the telemetry provider.</param>
+        /// <exception cref="NotSupportedException">Thrown when the telemetry type is not supported.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the configuration is null.</exception>
         public Telemetry(string telemetryType, Dictionary<string, string> configuration)
         {
             _stopwatch = new Stopwatch();
@@ -31,8 +44,14 @@ namespace LCT.Telemetry
                 configuration ?? throw new ArgumentNullException(nameof(configuration), "Configuration cannot be null.")
             );
         }
+        #endregion
 
-
+        #region Methods
+        /// <summary>
+        /// Initializes the telemetry tracking with application information and starts the stopwatch.
+        /// </summary>
+        /// <param name="appName">The name of the application.</param>
+        /// <param name="version">The version of the application.</param>
         public void Initialize(string appName, string version)
         {
             _stopwatch.Start();
@@ -48,16 +67,29 @@ namespace LCT.Telemetry
             TrackUserDetails();
         }
 
+        /// <summary>
+        /// Tracks a custom event with optional properties.
+        /// </summary>
+        /// <param name="eventName">The name of the event to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the event.</param>
         public void TrackCustomEvent(string eventName, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackEvent(eventName, properties);
         }
 
+        /// <summary>
+        /// Tracks an exception with optional properties.
+        /// </summary>
+        /// <param name="ex">The exception to track.</param>
+        /// <param name="properties">Optional dictionary of properties to include with the exception.</param>
         public void TrackException(Exception ex, Dictionary<string, string>? properties = null)
         {
             _telemetryProvider.TrackException(ex, properties);
         }
 
+        /// <summary>
+        /// Tracks the execution time of the application and stops the stopwatch.
+        /// </summary>
         public void TrackExecutionTime()
         {
             _stopwatch.Stop();
@@ -70,11 +102,17 @@ namespace LCT.Telemetry
             });
         }
 
+        /// <summary>
+        /// Flushes the telemetry provider to ensure all telemetry data is sent.
+        /// </summary>
         public void Flush()
         {
             _telemetryProvider.Flush();
         }
 
+        /// <summary>
+        /// Tracks user details including hashed user ID, machine name, and login time.
+        /// </summary>
         private void TrackUserDetails()
         {
             string userName = HashUtility.GetHashString(Environment.UserName);
@@ -87,5 +125,6 @@ namespace LCT.Telemetry
                 { "Login Time", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture) }
             });
         }
+        #endregion
     }
 }

--- a/src/LCT.Telemetry/TelemetryProviderFactory.cs
+++ b/src/LCT.Telemetry/TelemetryProviderFactory.cs
@@ -20,19 +20,21 @@ namespace LCT.Telemetry
     /// </summary>
     public static class TelemetryProviderFactory
     {
-        /// <summary>
-        /// Creates the telemetry provider based on the specified telemetry type and configuration.
-        /// </summary>
-        /// <param name="telemetryType">The telemetry type as an enum.</param>
-        /// <param name="configuration">The configuration for the telemetry provider.</param>
-        /// <returns>An instance of ITelemetryProvider.</returns>
-        public static ITelemetryProvider CreateTelemetryProvider(TelemetryType telemetryType, Dictionary<string, string> configuration)
-        {
-            return telemetryType switch
-            {
-                TelemetryType.ApplicationInsights => new ApplicationInsightsTelemetryProvider(configuration),
-                _ => throw new NotSupportedException($"Telemetry type '{telemetryType}' is not supported.")
-            };
-        }
-    }
-}
+        #region Methods
+         /// <summary>
+         /// Creates the telemetry provider based on the specified telemetry type and configuration.
+         /// </summary>
+         /// <param name="telemetryType">The telemetry type as an enum.</param>
+         /// <param name="configuration">The configuration for the telemetry provider.</param>
+         /// <returns>An instance of ITelemetryProvider.</returns>
+         public static ITelemetryProvider CreateTelemetryProvider(TelemetryType telemetryType, Dictionary<string, string> configuration)
+         {
+             return telemetryType switch
+             {
+                 TelemetryType.ApplicationInsights => new ApplicationInsightsTelemetryProvider(configuration),
+                 _ => throw new NotSupportedException($"Telemetry type '{telemetryType}' is not supported.")
+             };
+         }
+         #endregion
+     }
+ }


### PR DESCRIPTION
Code cleanup done in Package Identifier and Package Creator project like Adding summary above each methods, Removing unused imports, segregating properties, fields, constructors and methods and updating proper naming conventions.