### PR TITLE
feat: Implement AptRepositoryService for resolving source packages from APT archives

### DIFF
--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -480,6 +480,44 @@ Description for the settings in appSettings.json file
 | 32   | Npm.ReleaseRepo                 | NPM release repository name           | Yes             | `"npm-release"`                             |
 | 33   | Npm.DevDepRepo                  | NPM dev dependency repo name          | Yes             | `"npm-devdep"`                              |
 
+#### Debian source packages from custom APT repositories
+
+By default the source package of a Debian component is looked up on `snapshot.debian.org`. Images that install
+packages from other APT archives - vendor archives, hardened image archives or internal mirrors - are not covered
+by that archive, which results in `Source URL not found` for those components.
+
+Configure the APT archives the image installs from in `Debian.AptRepositories`. Every archive is read through its
+own index files (`dists/<suite>/Release`, `.../source/Sources`, `.../binary-<arch>/Packages`), so the exact pool
+location of the `.dsc`, the upstream tarball and the packaging patch is taken from the archive metadata instead of
+being guessed. The archives are searched in the configured order, and a file that one archive does not serve is
+looked up in the remaining ones - this is what happens when a vendor archive ships only the packaging delta and
+leaves the upstream tarball to the distribution.
+
+| S.No | Argument Name                          | Description                                                                    | Is it Mandatory | Example                                             |
+| ---- | -------------------------------------- | ------------------------------------------------------------------------------ | --------------- | --------------------------------------------------- |
+| 34   | Debian.AptRepositories[].Name          | Name of the archive, used for logging                                          | No              | `"debian"`                                         |
+| 35   | Debian.AptRepositories[].Uri           | Archive root, i.e. the URL that contains the `dists` and `pool` folders         | Yes             | `"https://deb.debian.org/debian"`                  |
+| 36   | Debian.AptRepositories[].Suites        | Suites to search. Defaults to the distribution of the scanned component        | No              | `["trixie", "trixie-updates"]`                    |
+| 37   | Debian.AptRepositories[].Components    | Components to search. Defaults to the components announced by the `Release` file | No              | `["main"]`                                         |
+| 38   | Debian.AptRepositories[].Architectures | Architectures to search. Defaults to the architectures announced by the `Release` file | No        | `["amd64"]`                                        |
+
+```json
+"Debian": {
+  "AptRepositories": [
+    {
+      "Name": "vendor",
+      "Uri": "https://vendor.example.com/deb/debian/main",
+      "Suites": [ "trixie" ]
+    },
+    {
+      "Name": "debian",
+      "Uri": "https://deb.debian.org/debian",
+      "Suites": [ "trixie", "trixie-updates" ]
+    }
+  ]
+}
+```
+
 
 #### **Method 2 - Only Cmd paramaters**
 You can also pass the above mentioned arguments in the command line.

--- a/doc/UsageDoc/CA_UsageDocument.md
+++ b/doc/UsageDoc/CA_UsageDocument.md
@@ -554,6 +554,44 @@ Description for the settings in appSettings.json file
 | 32   | Npm.ReleaseRepo                 | NPM release repository name           | Yes             | `"npm-release"`                             |
 | 33   | Npm.DevDepRepo                  | NPM dev dependency repo name          | Yes             | `"npm-devdep"`                              |
 
+#### Debian source packages from custom APT repositories
+
+By default the source package of a Debian component is looked up on `snapshot.debian.org`. Images that install
+packages from other APT archives - vendor archives, hardened image archives or internal mirrors - are not covered
+by that archive, which results in `Source URL not found` for those components.
+
+Configure the APT archives the image installs from in `Debian.AptRepositories`. Every archive is read through its
+own index files (`dists/<suite>/Release`, `.../source/Sources`, `.../binary-<arch>/Packages`), so the exact pool
+location of the `.dsc`, the upstream tarball and the packaging patch is taken from the archive metadata instead of
+being guessed. The archives are searched in the configured order, and a file that one archive does not serve is
+looked up in the remaining ones - this is what happens when a vendor archive ships only the packaging delta and
+leaves the upstream tarball to the distribution.
+
+| S.No | Argument Name                          | Description                                                                    | Is it Mandatory | Example                                             |
+| ---- | -------------------------------------- | ------------------------------------------------------------------------------ | --------------- | --------------------------------------------------- |
+| 34   | Debian.AptRepositories[].Name          | Name of the archive, used for logging                                          | No              | `"debian"`                                         |
+| 35   | Debian.AptRepositories[].Uri           | Archive root, i.e. the URL that contains the `dists` and `pool` folders         | Yes             | `"https://deb.debian.org/debian"`                  |
+| 36   | Debian.AptRepositories[].Suites        | Suites to search. Defaults to the distribution of the scanned component        | No              | `["trixie", "trixie-updates"]`                    |
+| 37   | Debian.AptRepositories[].Components    | Components to search. Defaults to the components announced by the `Release` file | No              | `["main"]`                                         |
+| 38   | Debian.AptRepositories[].Architectures | Architectures to search. Defaults to the architectures announced by the `Release` file | No        | `["amd64"]`                                        |
+
+```json
+"Debian": {
+  "AptRepositories": [
+    {
+      "Name": "vendor",
+      "Uri": "https://vendor.example.com/deb/debian/main",
+      "Suites": [ "trixie" ]
+    },
+    {
+      "Name": "debian",
+      "Uri": "https://deb.debian.org/debian",
+      "Suites": [ "trixie", "trixie-updates" ]
+    }
+  ]
+}
+```
+
 
 #### **Method 2 - Only Cmd paramaters**
 You can also pass the above mentioned arguments in the command line.

--- a/src/SIT.Common/Constants/Dataconstant.cs
+++ b/src/SIT.Common/Constants/Dataconstant.cs
@@ -103,6 +103,10 @@ namespace SIT.Common.Constants
         /// </summary>
         public const string SourceUrlNotFound = "Source URL not found";
         /// <summary>
+        /// Client identification sent with outgoing downloads.
+        /// </summary>
+        public const string UserAgent = "ContinuousClearing";
+        /// <summary>
         /// Error: Package URL not found.
         /// </summary>
         public const string PackageUrlNotFound = "Package URL not found";

--- a/src/SIT.Common/Model/AptRepository.cs
+++ b/src/SIT.Common/Model/AptRepository.cs
@@ -1,0 +1,47 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace SIT.Common.Model
+{
+    /// <summary>
+    /// Describes a Debian style APT archive that is used to resolve the source packages
+    /// (.dsc, .orig.tar.*, .debian.tar.*) of the binary packages found in an image.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptRepository
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the display name of the repository, used for logging only.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the archive root of the repository, i.e. the URL that contains the "dists" and "pool" folders.
+        /// </summary>
+        public string Uri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the suites (codenames) to search. When empty, the distribution of the scanned component is used.
+        /// </summary>
+        public string[] Suites { get; set; }
+
+        /// <summary>
+        /// Gets or sets the archive components to search. When empty, the components announced by the Release file are used.
+        /// </summary>
+        public string[] Components { get; set; }
+
+        /// <summary>
+        /// Gets or sets the binary architectures to search. When empty, the architectures announced by the Release file are used.
+        /// </summary>
+        public string[] Architectures { get; set; }
+
+        #endregion
+    }
+}

--- a/src/SIT.Common/Model/Config.cs
+++ b/src/SIT.Common/Model/Config.cs
@@ -43,6 +43,11 @@ namespace SIT.Common.Model
         /// </summary>
         public string DevDepRepo { get; set; }
 
+        /// <summary>
+        /// Gets or sets the APT archives that are used to resolve Debian source packages.
+        /// </summary>
+        public List<AptRepository> AptRepositories { get; set; }
+
         #endregion
     }
 

--- a/src/SIT.Common/appSettings.json
+++ b/src/SIT.Common/appSettings.json
@@ -131,6 +131,7 @@
       "*.spdx.sbom.json"
     ],
     "Exclude": [],
+    "AptRepositories": [],
     "Artifactory": {
       "ThirdPartyRepos": [
         {

--- a/src/SIT.Common/appSettings.json
+++ b/src/SIT.Common/appSettings.json
@@ -135,6 +135,7 @@
       "*.spdx.sbom.json"
     ],
     "Exclude": [],
+    "AptRepositories": [],
     "Artifactory": {
       "ThirdPartyRepos": [
         {

--- a/src/SIT.Create.UTest/AptRepositoryServiceTest.cs
+++ b/src/SIT.Create.UTest/AptRepositoryServiceTest.cs
@@ -1,0 +1,237 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using NUnit.Framework;
+using SIT.Common.Model;
+using SIT.Create.Model;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SIT.Create.UTest
+{
+    /// <summary>
+    /// The test class for AptRepositoryService
+    /// </summary>
+    [TestFixture]
+    public class AptRepositoryServiceTest
+    {
+        private const string VendorArchive = "http://vendor.test/deb/debian/main";
+        private const string DistributionArchive = "http://mirror.test/debian";
+
+        private const string VendorSources = @"Package: busybox
+Version: 1:1.37.0-6+dhi1
+Directory: pool/trixie/main/b/bu/busybox_1.37.0-6+dhi1
+Files:
+ aaa 1560 busybox_1.37.0-6+dhi1.dsc
+ bbb 2565764 busybox_1.37.0.orig.tar.bz2
+ ccc 70672 busybox_1.37.0-6+dhi1.debian.tar.xz
+
+Package: gcc-14
+Version: 14.2.0-19+dhi3
+Directory: pool/trixie/main/g/gc/gcc-14_14.2.0-19+dhi3
+Files:
+ ddd 100 gcc-14_14.2.0-19+dhi3.dsc
+ eee 200 gcc-14_14.2.0.orig.tar.gz
+ fff 300 gcc-14_14.2.0-19+dhi3.debian.tar.xz
+";
+
+        private const string VendorPackages = @"Package: busybox
+Version: 1:1.37.0-6+dhi1
+Filename: pool/trixie/main/b/bu/busybox_1.37.0-6+dhi1/busybox_1.37.0-6+dhi1_amd64.deb
+
+Package: libgcc-s1
+Version: 14.2.0-19+dhi3
+Source: gcc-14
+Filename: pool/trixie/main/l/li/libgcc-s1_14.2.0-19+dhi3/libgcc-s1_14.2.0-19+dhi3_amd64.deb
+
+Package: tzdata
+Version: 2026b-0+deb13u1+dhi2
+Filename: pool/trixie/main/t/tz/tzdata_2026b-0+deb13u1+dhi2/tzdata_2026b-0+deb13u1+dhi2_all.deb
+";
+
+        private const string TzdataDsc = @"Format: 3.0 (quilt)
+Source: tzdata
+Version: 2026b-0+deb13u1+dhi2
+Files:
+ 111 473703 tzdata_2026b.orig.tar.gz
+ 222 127236 tzdata_2026b-0+deb13u1+dhi2.debian.tar.xz
+";
+
+        private const string DistributionSources = @"Package: tzdata
+Version: 2026b-0+deb13u1
+Directory: pool/main/t/tzdata
+Files:
+ 111 473703 tzdata_2026b.orig.tar.gz
+ 333 120000 tzdata_2026b-0+deb13u1.debian.tar.xz
+";
+
+        private static StubHttpMessageHandler CreateArchives()
+        {
+            StubHttpMessageHandler handler = new();
+            handler.Content[$"{VendorArchive}/dists/trixie/Release"] = "Components: main\nArchitectures: amd64 source\n";
+            handler.Content[$"{VendorArchive}/dists/trixie/main/source/Sources"] = VendorSources;
+            handler.Content[$"{VendorArchive}/dists/trixie/main/binary-amd64/Packages"] = VendorPackages;
+            handler.Content[$"{DistributionArchive}/dists/trixie/Release"] = "Components: main\nArchitectures: amd64 source\n";
+            handler.Content[$"{DistributionArchive}/dists/trixie/main/source/Sources"] = DistributionSources;
+            return handler;
+        }
+
+        private static List<AptRepository> Repositories(params string[] uris)
+        {
+            return uris.Select(uri => new AptRepository { Name = uri, Uri = uri }).ToList();
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_SourcePackageWithSameName_ReturnsAllSourceFiles()
+        {
+            using AptRepositoryService service = new(new HttpClient(CreateArchives()));
+
+            // the installed version is reported without the epoch of the index
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                Repositories(VendorArchive), "busybox", "1.37.0-6+dhi1", new[] { "trixie" });
+
+            Assert.That(resolution, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(resolution.Name, Is.EqualTo("busybox"));
+                Assert.That(resolution.Version, Is.EqualTo("1:1.37.0-6+dhi1"));
+                Assert.That(resolution.FileUrls, Is.EquivalentTo(new[]
+                {
+                    $"{VendorArchive}/pool/trixie/main/b/bu/busybox_1.37.0-6+dhi1/busybox_1.37.0-6+dhi1.dsc",
+                    $"{VendorArchive}/pool/trixie/main/b/bu/busybox_1.37.0-6+dhi1/busybox_1.37.0.orig.tar.bz2",
+                    $"{VendorArchive}/pool/trixie/main/b/bu/busybox_1.37.0-6+dhi1/busybox_1.37.0-6+dhi1.debian.tar.xz"
+                }));
+            });
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_BinaryPackageWithOtherSourceName_ResolvesThroughBinaryIndex()
+        {
+            using AptRepositoryService service = new(new HttpClient(CreateArchives()));
+
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                Repositories(VendorArchive), "libgcc-s1", "14.2.0-19+dhi3", new[] { "trixie" });
+
+            Assert.That(resolution, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(resolution.Name, Is.EqualTo("gcc-14"));
+                Assert.That(resolution.Version, Is.EqualTo("14.2.0-19+dhi3"));
+                Assert.That(resolution.FileUrls, Has.Count.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_PackageMissingInSourceIndex_FallsBackToDscInThePool()
+        {
+            StubHttpMessageHandler handler = CreateArchives();
+            handler.Content[$"{VendorArchive}/pool/trixie/main/t/tz/tzdata_2026b-0+deb13u1+dhi2/tzdata_2026b-0+deb13u1+dhi2.dsc"] = TzdataDsc;
+            handler.Content[$"{VendorArchive}/pool/trixie/main/t/tz/tzdata_2026b-0+deb13u1+dhi2/tzdata_2026b-0+deb13u1+dhi2.debian.tar.xz"] = "delta";
+            handler.Content[$"{DistributionArchive}/pool/main/t/tzdata/tzdata_2026b.orig.tar.gz"] = "upstream";
+            using AptRepositoryService service = new(new HttpClient(handler));
+
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                Repositories(VendorArchive, DistributionArchive), "tzdata", "2026b-0+deb13u1+dhi2", new[] { "trixie" });
+
+            Assert.That(resolution, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(resolution.Name, Is.EqualTo("tzdata"));
+                Assert.That(resolution.Version, Is.EqualTo("2026b-0+deb13u1+dhi2"));
+
+                // the upstream tarball is not served by the vendor archive, it is taken from the distribution
+                Assert.That(resolution.FileUrls, Is.EquivalentTo(new[]
+                {
+                    $"{VendorArchive}/pool/trixie/main/t/tz/tzdata_2026b-0+deb13u1+dhi2/tzdata_2026b-0+deb13u1+dhi2.dsc",
+                    $"{DistributionArchive}/pool/main/t/tzdata/tzdata_2026b.orig.tar.gz",
+                    $"{VendorArchive}/pool/trixie/main/t/tz/tzdata_2026b-0+deb13u1+dhi2/tzdata_2026b-0+deb13u1+dhi2.debian.tar.xz"
+                }));
+            });
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_UnknownPackage_ReturnsNull()
+        {
+            using AptRepositoryService service = new(new HttpClient(CreateArchives()));
+
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                Repositories(VendorArchive), "openssl", "3.5.0-1", new[] { "trixie" });
+
+            Assert.That(resolution, Is.Null);
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_WithoutRepositories_ReturnsNull()
+        {
+            using AptRepositoryService service = new(new HttpClient(CreateArchives()));
+
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                new List<AptRepository>(), "busybox", "1.37.0-6+dhi1", new[] { "trixie" });
+
+            Assert.That(resolution, Is.Null);
+        }
+
+        [Test]
+        public async Task ResolveSourcePackageAsync_UnknownSuite_ReturnsNull()
+        {
+            using AptRepositoryService service = new(new HttpClient(CreateArchives()));
+
+            AptSourceResolution resolution = await service.ResolveSourcePackageAsync(
+                Repositories(VendorArchive), "busybox", "1.37.0-6+dhi1", new[] { "bookworm" });
+
+            Assert.That(resolution, Is.Null);
+        }
+
+        [Test]
+        public void GetDistributionCandidates_PurlWithDistributionQualifiers_PrefersTheCodename()
+        {
+            List<string> candidates = UrlHelper.GetDistributionCandidates(
+                "pkg:deb/debian/busybox@1.37.0-6%2Bdhi1?os_distro=trixie&os_name=debian&os_version=13");
+
+            Assert.That(candidates, Is.EqualTo(new[] { "trixie" }));
+        }
+
+        [Test]
+        public void GetDistributionCandidates_SyftPurl_ReturnsDistributionAndVersion()
+        {
+            List<string> candidates = UrlHelper.GetDistributionCandidates(
+                "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10");
+
+            Assert.That(candidates, Is.EqualTo(new[] { "debian-10", "10" }));
+        }
+
+        [Test]
+        public void GetDistributionCandidates_PurlWithoutQualifiers_ReturnsEmptyList()
+        {
+            Assert.That(UrlHelper.GetDistributionCandidates("pkg:deb/debian/adduser@3.118"), Is.Empty);
+        }
+
+        /// <summary>
+        /// Serves the configured URLs and answers with "404 Not Found" for everything else.
+        /// </summary>
+        private sealed class StubHttpMessageHandler : HttpMessageHandler
+        {
+            public Dictionary<string, string> Content { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (!Content.TryGetValue(request.RequestUri.AbsoluteUri, out string content))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(request.Method == HttpMethod.Head ? string.Empty : content)
+                });
+            }
+        }
+    }
+}

--- a/src/SIT.Create.UTest/UrlHelperTest.cs
+++ b/src/SIT.Create.UTest/UrlHelperTest.cs
@@ -267,6 +267,23 @@ namespace SIT.Create.UTest
             // Assert
             Assert.That(sourceUrlDetails.SourceUrl.Contains("apk-tools"));
         }
+
+        [TestCase("pkg:apk/alpine/apk-tools@2.12.9-r3?arch=x86_64&distro=alpine-3.16.2", "3.16-stable")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-3.22", "3.22-stable")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?os_name=alpine&os_version=3.22", "3.22-stable")]
+        public void GetAlpineDistro_BomRefWithDistributionQualifiers_ReturnsTheAportsBranch(string bomRef, string expectedBranch)
+        {
+            Assert.That(UrlHelper.GetAlpineDistro(bomRef), Is.EqualTo(expectedBranch));
+        }
+
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?arch=x86_64")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-edge")]
+        public void GetAlpineDistro_BomRefWithoutAKnownRelease_ReturnsTheDefaultBranch(string bomRef)
+        {
+            Assert.That(UrlHelper.GetAlpineDistro(bomRef), Is.EqualTo("master"));
+        }
+
         [Test]
         public void GetSourceFromAPKBUILD_WithValidData_ReturnsCorrectSource()
         {

--- a/src/SIT.Create/AptRepositoryService.cs
+++ b/src/SIT.Create/AptRepositoryService.cs
@@ -1,0 +1,750 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using log4net;
+using SIT.Common;
+using SIT.Common.Constants;
+using SIT.Common.Model;
+using SIT.Create.Interfaces;
+using SIT.Create.Model;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SIT.Create
+{
+    /// <summary>
+    /// Resolves source packages through the index files ("Release", "Sources", "Packages") of APT archives.
+    /// Those index files are part of the Debian repository format, so the same code works for the official
+    /// Debian archives as well as for any vendor or mirror archive an image installs its packages from.
+    /// </summary>
+    public class AptRepositoryService : IAptRepositoryService, IDisposable
+    {
+        static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const string SourceArchitecture = "source";
+        private const string DefaultComponent = "main";
+        private const long MaxDownloadSizeInBytes = 512L * 1024 * 1024;
+
+        private readonly HttpClient _httpClient;
+        private readonly ConcurrentDictionary<string, Task<AptReleaseInfo>> _releaseCache = new();
+        private readonly ConcurrentDictionary<string, Task<AptSourceIndex>> _sourceIndexCache = new();
+        private readonly ConcurrentDictionary<string, Task<Dictionary<string, List<AptBinaryEntry>>>> _binaryIndexCache = new();
+        private bool _disposed;
+
+        public AptRepositoryService() : this(new HttpClient { Timeout = TimeSpan.FromMinutes(10) })
+        {
+        }
+
+        public AptRepositoryService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Dataconstant.UserAgent);
+        }
+
+        /// <inheritdoc/>
+        public async Task<AptSourceResolution> ResolveSourcePackageAsync(IReadOnlyList<AptRepository> repositories,
+                                                                        string binaryName,
+                                                                        string binaryVersion,
+                                                                        IReadOnlyList<string> suiteCandidates)
+        {
+            if (repositories == null || repositories.Count == 0 || string.IsNullOrEmpty(binaryName))
+            {
+                return null;
+            }
+
+            List<AptIndexContext> contexts = await GetIndexContextsAsync(repositories, suiteCandidates);
+
+            // The source index of an archive is authoritative, it names the pool folder and every file that
+            // belongs to the source package.
+            foreach (AptIndexContext context in contexts)
+            {
+                AptSourceLocation location = await LocateInSourceIndexAsync(context, binaryName, binaryVersion);
+                if (location != null)
+                {
+                    List<string> fileUrls = location.FileNames
+                        .Select(fileName => BuildFileUrl(context.ArchiveRoot, location.Directory, fileName))
+                        .Where(url => url != null)
+                        .ToList();
+
+                    AptSourceResolution resolution = BuildResolution(location, fileUrls);
+                    if (resolution != null)
+                    {
+                        return resolution;
+                    }
+                }
+            }
+
+            // Archives that publish their sources without a complete source index still follow the pool
+            // convention, so the .dsc next to the binary package tells which files the source package consists of.
+            foreach (AptIndexContext context in contexts)
+            {
+                AptSourceLocation location = await LocateInPoolAsync(context, binaryName, binaryVersion);
+                if (location != null)
+                {
+                    AptSourceResolution resolution = BuildResolution(location, await ResolveFileUrlsAsync(location, contexts));
+                    if (resolution != null)
+                    {
+                        return resolution;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        #region source package lookup
+
+        private async Task<AptSourceLocation> LocateInSourceIndexAsync(AptIndexContext context, string binaryName, string binaryVersion)
+        {
+            AptSourceIndex sourceIndex = await GetSourceIndexAsync(context);
+
+            // A binary package usually carries the name of its source package.
+            AptSourceEntry entry = FindSourceEntry(sourceIndex, binaryName, binaryVersion);
+            string sourceName = binaryName;
+
+            if (entry == null)
+            {
+                AptBinaryEntry binary = await FindBinaryEntryAsync(context, binaryName, binaryVersion);
+                if (binary == null)
+                {
+                    return null;
+                }
+
+                sourceName = binary.SourceName ?? binaryName;
+                entry = FindSourceEntry(sourceIndex, sourceName, binary.SourceVersion ?? binary.Version);
+            }
+
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Directory))
+            {
+                return null;
+            }
+
+            return new AptSourceLocation
+            {
+                Context = context,
+                Name = sourceName,
+                Version = entry.Version,
+                Directory = entry.Directory,
+                FileNames = entry.FileNames
+            };
+        }
+
+        private async Task<AptSourceLocation> LocateInPoolAsync(AptIndexContext context, string binaryName, string binaryVersion)
+        {
+            AptBinaryEntry binary = await FindBinaryEntryAsync(context, binaryName, binaryVersion);
+            int lastSeparator = binary?.FileName?.LastIndexOf('/') ?? -1;
+            if (lastSeparator <= 0)
+            {
+                return null;
+            }
+
+            string directory = binary.FileName.Substring(0, lastSeparator);
+            string sourceName = binary.SourceName ?? binaryName;
+            string sourceVersion = binary.SourceVersion ?? binary.Version;
+            string dscFileName = $"{sourceName}_{StripEpoch(sourceVersion)}.dsc";
+            string dscUrl = BuildFileUrl(context.ArchiveRoot, directory, dscFileName);
+
+            List<string> fileNames = dscUrl == null ? null : await ReadFileNamesFromDscAsync(dscUrl);
+            if (fileNames == null)
+            {
+                return null;
+            }
+
+            Logger.DebugFormat("LocateInPoolAsync(): {0} is not listed in the source index of {1}, using {2} instead.",
+                sourceName, context.ArchiveRoot, dscUrl);
+
+            fileNames.Insert(0, dscFileName);
+            return new AptSourceLocation
+            {
+                Context = context,
+                Name = sourceName,
+                Version = sourceVersion,
+                Directory = directory,
+                FileNames = fileNames
+            };
+        }
+
+        private async Task<List<string>> ReadFileNamesFromDscAsync(string dscUrl)
+        {
+            byte[] payload = await TryDownloadAsync(dscUrl);
+            if (payload == null)
+            {
+                return null;
+            }
+
+            using StreamReader reader = new(new MemoryStream(payload), Encoding.UTF8);
+            Dictionary<string, string> stanza = ParseStanzas(reader).FirstOrDefault(entry => entry.ContainsKey("Files"));
+            return stanza == null ? null : ParseFileNames(stanza);
+        }
+
+        /// <summary>
+        /// Determines the download URL of every file of a source package. Files that the archive of the source
+        /// package does not serve itself are looked up in the remaining archives, which is what happens when a
+        /// vendor archive ships only the packaging delta and leaves the upstream tarball to the distribution.
+        /// </summary>
+        private async Task<List<string>> ResolveFileUrlsAsync(AptSourceLocation location, List<AptIndexContext> contexts)
+        {
+            List<string> fileUrls = new();
+
+            foreach (string fileName in location.FileNames)
+            {
+                string url = BuildFileUrl(location.Context.ArchiveRoot, location.Directory, fileName);
+                if (url != null && await ExistsAsync(url))
+                {
+                    fileUrls.Add(url);
+                    continue;
+                }
+
+                url = await FindFileInArchivesAsync(fileName, contexts);
+                if (url != null)
+                {
+                    fileUrls.Add(url);
+                }
+                else
+                {
+                    Logger.WarnFormat("ResolveFileUrlsAsync(): {0} of source package {1}-{2} is not served by any configured APT repository.",
+                        fileName, location.Name, location.Version);
+                }
+            }
+
+            return fileUrls;
+        }
+
+        private async Task<string> FindFileInArchivesAsync(string fileName, List<AptIndexContext> contexts)
+        {
+            foreach (AptIndexContext context in contexts)
+            {
+                AptSourceIndex sourceIndex = await GetSourceIndexAsync(context);
+                if (!sourceIndex.FileLocations.TryGetValue(fileName, out string directory))
+                {
+                    continue;
+                }
+
+                string url = BuildFileUrl(context.ArchiveRoot, directory, fileName);
+                if (url != null && await ExistsAsync(url))
+                {
+                    return url;
+                }
+            }
+
+            return null;
+        }
+
+        private static AptSourceResolution BuildResolution(AptSourceLocation location, List<string> fileUrls)
+        {
+            if (fileUrls.Count == 0)
+            {
+                return null;
+            }
+
+            Logger.DebugFormat("BuildResolution(): Source package {0}-{1} resolved to {2} file(s) in {3} ({4}).",
+                location.Name, location.Version, fileUrls.Count, location.Context.ArchiveRoot, location.Context.Suite);
+
+            return new AptSourceResolution
+            {
+                Name = location.Name,
+                Version = location.Version,
+                FileUrls = fileUrls,
+                Origin = string.IsNullOrEmpty(location.Context.RepositoryName)
+                    ? $"{location.Context.ArchiveRoot} {location.Context.Suite}"
+                    : location.Context.RepositoryName
+            };
+        }
+
+        private static AptSourceEntry FindSourceEntry(AptSourceIndex sourceIndex, string name, string version)
+        {
+            return sourceIndex.Packages.TryGetValue(name, out List<AptSourceEntry> entries)
+                ? entries.Find(entry => VersionMatches(entry.Version, version))
+                : null;
+        }
+
+        private async Task<AptBinaryEntry> FindBinaryEntryAsync(AptIndexContext context, string binaryName, string binaryVersion)
+        {
+            foreach (string architecture in context.Architectures)
+            {
+                Dictionary<string, List<AptBinaryEntry>> binaryIndex = await GetBinaryIndexAsync(context, architecture);
+                if (binaryIndex.TryGetValue(binaryName, out List<AptBinaryEntry> candidates))
+                {
+                    AptBinaryEntry binary = candidates.Find(candidate => VersionMatches(candidate.Version, binaryVersion));
+                    if (binary != null)
+                    {
+                        return binary;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        #region index handling
+
+        private async Task<List<AptIndexContext>> GetIndexContextsAsync(IReadOnlyList<AptRepository> repositories,
+                                                                        IReadOnlyList<string> suiteCandidates)
+        {
+            List<AptIndexContext> contexts = new();
+
+            foreach (AptRepository repository in repositories)
+            {
+                string archiveRoot = NormalizeArchiveRoot(repository?.Uri);
+                if (archiveRoot == null)
+                {
+                    Logger.WarnFormat("GetIndexContextsAsync(): Skipping APT repository '{0}', '{1}' is not a valid http(s) archive root.",
+                        repository?.Name, repository?.Uri);
+                    continue;
+                }
+
+                foreach (string suite in GetSuites(repository, suiteCandidates))
+                {
+                    AptReleaseInfo release = await GetReleaseAsync(archiveRoot, suite);
+                    if (release == null)
+                    {
+                        continue;
+                    }
+
+                    string[] components = FirstNonEmpty(repository.Components, release.Components, new[] { DefaultComponent });
+                    string[] architectures = FirstNonEmpty(repository.Architectures,
+                        release.Architectures.Where(architecture => !architecture.Equals(SourceArchitecture, StringComparison.OrdinalIgnoreCase)).ToArray());
+
+                    contexts.AddRange(components.Select(component => new AptIndexContext
+                    {
+                        RepositoryName = repository.Name,
+                        ArchiveRoot = archiveRoot,
+                        Suite = suite,
+                        Component = component,
+                        Architectures = architectures
+                    }));
+                }
+            }
+
+            if (contexts.Count == 0)
+            {
+                Logger.WarnFormat("GetIndexContextsAsync(): None of the {0} configured APT repositories provides a readable suite. " +
+                    "Configure the suites of a repository when the components carry no distribution.", repositories.Count);
+            }
+
+            return contexts;
+        }
+
+        private async Task<AptReleaseInfo> GetReleaseAsync(string archiveRoot, string suite)
+        {
+            return await _releaseCache.GetOrAdd($"{archiveRoot}|{suite}", _ => FetchReleaseAsync(archiveRoot, suite));
+        }
+
+        private async Task<AptSourceIndex> GetSourceIndexAsync(AptIndexContext context)
+        {
+            return await _sourceIndexCache.GetOrAdd($"{context.ArchiveRoot}|{context.Suite}|{context.Component}",
+                _ => FetchSourceIndexAsync(context));
+        }
+
+        private async Task<Dictionary<string, List<AptBinaryEntry>>> GetBinaryIndexAsync(AptIndexContext context, string architecture)
+        {
+            return await _binaryIndexCache.GetOrAdd($"{context.ArchiveRoot}|{context.Suite}|{context.Component}|{architecture}",
+                _ => FetchBinaryIndexAsync(context, architecture));
+        }
+
+        private async Task<AptReleaseInfo> FetchReleaseAsync(string archiveRoot, string suite)
+        {
+            using StreamReader reader = await OpenIndexAsync($"{archiveRoot}/dists/{suite}/Release");
+            if (reader == null)
+            {
+                Logger.DebugFormat("FetchReleaseAsync(): Suite {0} is not available in {1}.", suite, archiveRoot);
+                return null;
+            }
+
+            Dictionary<string, string> stanza = ParseStanzas(reader).FirstOrDefault();
+            if (stanza == null)
+            {
+                return null;
+            }
+
+            return new AptReleaseInfo
+            {
+                Components = SplitFieldValue(stanza, "Components"),
+                Architectures = SplitFieldValue(stanza, "Architectures")
+            };
+        }
+
+        private async Task<AptSourceIndex> FetchSourceIndexAsync(AptIndexContext context)
+        {
+            AptSourceIndex index = new();
+            using StreamReader reader = await OpenIndexAsync($"{context.ArchiveRoot}/dists/{context.Suite}/{context.Component}/source/Sources");
+            if (reader == null)
+            {
+                return index;
+            }
+
+            foreach (Dictionary<string, string> stanza in ParseStanzas(reader))
+            {
+                if (!stanza.TryGetValue("Package", out string name) || !stanza.TryGetValue("Version", out string version))
+                {
+                    continue;
+                }
+
+                stanza.TryGetValue("Directory", out string directory);
+                AptSourceEntry entry = new()
+                {
+                    Version = version,
+                    Directory = directory,
+                    FileNames = ParseFileNames(stanza)
+                };
+
+                AddToIndex(index.Packages, name, entry);
+
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    foreach (string fileName in entry.FileNames)
+                    {
+                        index.FileLocations[fileName] = directory;
+                    }
+                }
+            }
+
+            Logger.DebugFormat("FetchSourceIndexAsync(): Read {0} source packages from {1} {2}/{3}.",
+                index.Packages.Count, context.ArchiveRoot, context.Suite, context.Component);
+            return index;
+        }
+
+        private async Task<Dictionary<string, List<AptBinaryEntry>>> FetchBinaryIndexAsync(AptIndexContext context, string architecture)
+        {
+            Dictionary<string, List<AptBinaryEntry>> index = new(StringComparer.Ordinal);
+            using StreamReader reader = await OpenIndexAsync($"{context.ArchiveRoot}/dists/{context.Suite}/{context.Component}/binary-{architecture}/Packages");
+            if (reader == null)
+            {
+                return index;
+            }
+
+            foreach (Dictionary<string, string> stanza in ParseStanzas(reader))
+            {
+                if (!stanza.TryGetValue("Package", out string name) || !stanza.TryGetValue("Version", out string version))
+                {
+                    continue;
+                }
+
+                stanza.TryGetValue("Source", out string source);
+                stanza.TryGetValue("Filename", out string fileName);
+                (string sourceName, string sourceVersion) = ParseSourceField(source);
+                AddToIndex(index, name, new AptBinaryEntry
+                {
+                    Version = version,
+                    SourceName = sourceName,
+                    SourceVersion = sourceVersion,
+                    FileName = fileName
+                });
+            }
+
+            Logger.DebugFormat("FetchBinaryIndexAsync(): Read {0} binary packages from {1} {2}/{3} ({4}).",
+                index.Count, context.ArchiveRoot, context.Suite, context.Component, architecture);
+            return index;
+        }
+
+        /// <summary>
+        /// Downloads an index file, preferring the gzip compressed variant that every APT archive provides.
+        /// </summary>
+        private async Task<StreamReader> OpenIndexAsync(string indexUrl)
+        {
+            byte[] payload = await TryDownloadAsync($"{indexUrl}.gz");
+            if (payload != null)
+            {
+                return new StreamReader(new GZipStream(new MemoryStream(payload), CompressionMode.Decompress), Encoding.UTF8);
+            }
+
+            payload = await TryDownloadAsync(indexUrl);
+            return payload == null ? null : new StreamReader(new MemoryStream(payload), Encoding.UTF8);
+        }
+
+        private async Task<byte[]> TryDownloadAsync(string url)
+        {
+            try
+            {
+                using HttpResponseMessage response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return null;
+                }
+
+                if (response.Content.Headers.ContentLength > MaxDownloadSizeInBytes)
+                {
+                    Logger.WarnFormat("TryDownloadAsync(): Ignoring {0}, the file exceeds {1} bytes.", url, MaxDownloadSizeInBytes);
+                    return null;
+                }
+
+                return await response.Content.ReadAsByteArrayAsync();
+            }
+            catch (HttpRequestException ex)
+            {
+                LogHandlingHelper.ExceptionErrorHandling("TryDownloadAsync", $"MethodName:TryDownloadAsync(), Url: {url}", ex,
+                    "A network error occurred while reading a file of an APT repository.");
+            }
+            catch (TaskCanceledException ex)
+            {
+                LogHandlingHelper.ExceptionErrorHandling("TryDownloadAsync", $"MethodName:TryDownloadAsync(), Url: {url}", ex,
+                    "Reading a file of an APT repository timed out.");
+            }
+
+            return null;
+        }
+
+        private async Task<bool> ExistsAsync(string url)
+        {
+            try
+            {
+                using HttpRequestMessage request = new(HttpMethod.Head, url);
+                using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                // Archives that do not implement HEAD cannot be probed, they are given the benefit of the doubt.
+                return response.IsSuccessStatusCode ||
+                       response.StatusCode == HttpStatusCode.MethodNotAllowed ||
+                       response.StatusCode == HttpStatusCode.NotImplemented;
+            }
+            catch (HttpRequestException ex)
+            {
+                LogHandlingHelper.ExceptionErrorHandling("ExistsAsync", $"MethodName:ExistsAsync(), Url: {url}", ex,
+                    "A network error occurred while checking a file of an APT repository.");
+            }
+            catch (TaskCanceledException ex)
+            {
+                LogHandlingHelper.ExceptionErrorHandling("ExistsAsync", $"MethodName:ExistsAsync(), Url: {url}", ex,
+                    "Checking a file of an APT repository timed out.");
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region parsing helpers
+
+        /// <summary>
+        /// Reads the RFC822 style stanzas an APT index file or a .dsc consists of.
+        /// </summary>
+        internal static IEnumerable<Dictionary<string, string>> ParseStanzas(TextReader reader)
+        {
+            Dictionary<string, string> stanza = new(StringComparer.OrdinalIgnoreCase);
+            StringBuilder value = new();
+            string field = null;
+
+            void CloseField()
+            {
+                if (field != null)
+                {
+                    stanza[field] = value.ToString();
+                }
+
+                field = null;
+                value.Clear();
+            }
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (line.Length == 0)
+                {
+                    CloseField();
+                    if (stanza.Count > 0)
+                    {
+                        yield return stanza;
+                        stanza = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    }
+
+                    continue;
+                }
+
+                if (line[0] == ' ' || line[0] == '\t')
+                {
+                    if (field != null)
+                    {
+                        value.Append('\n').Append(line.Trim());
+                    }
+
+                    continue;
+                }
+
+                CloseField();
+                int separator = line.IndexOf(':');
+                if (separator <= 0)
+                {
+                    continue;
+                }
+
+                field = line.Substring(0, separator);
+                value.Append(line.Substring(separator + 1).Trim());
+            }
+
+            CloseField();
+            if (stanza.Count > 0)
+            {
+                yield return stanza;
+            }
+        }
+
+        /// <summary>
+        /// The "Source" field is either "name" or "name (version)" and is omitted when it equals the binary package.
+        /// </summary>
+        internal static (string Name, string Version) ParseSourceField(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return (null, null);
+            }
+
+            int versionStart = source.IndexOf('(');
+            if (versionStart < 0)
+            {
+                return (source.Trim(), null);
+            }
+
+            string name = source.Substring(0, versionStart).Trim();
+            string version = source.Substring(versionStart + 1).TrimEnd(')', ' ').Trim();
+            return (name, string.IsNullOrEmpty(version) ? null : version);
+        }
+
+        internal static List<string> ParseFileNames(Dictionary<string, string> stanza)
+        {
+            List<string> fileNames = new();
+            if (!stanza.TryGetValue("Files", out string files))
+            {
+                return fileNames;
+            }
+
+            foreach (string line in files.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                // Every line of the "Files" field is "<checksum> <size> <file name>".
+                string[] parts = line.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 3 && !fileNames.Contains(parts[2]))
+                {
+                    fileNames.Add(parts[2]);
+                }
+            }
+
+            return fileNames;
+        }
+
+        /// <summary>
+        /// Builds the download URL of a file and makes sure it stays inside the archive root.
+        /// </summary>
+        internal static string BuildFileUrl(string archiveRoot, string directory, string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(fileName))
+            {
+                return null;
+            }
+
+            string relativePath = $"{directory.Trim('/')}/{fileName.Trim()}";
+            if (relativePath.Contains("..") || relativePath.Contains("//") || relativePath.Any(char.IsWhiteSpace))
+            {
+                return null;
+            }
+
+            string candidate = $"{archiveRoot}/{relativePath}";
+            if (!Uri.TryCreate(candidate, UriKind.Absolute, out Uri uri) ||
+                !uri.AbsoluteUri.StartsWith($"{archiveRoot}/", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return uri.AbsoluteUri;
+        }
+
+        internal static bool VersionMatches(string indexVersion, string requestedVersion)
+        {
+            if (string.IsNullOrEmpty(indexVersion) || string.IsNullOrEmpty(requestedVersion))
+            {
+                return false;
+            }
+
+            // The version of an installed package is often reported without its epoch.
+            return string.Equals(indexVersion, requestedVersion, StringComparison.Ordinal) ||
+                   string.Equals(StripEpoch(indexVersion), StripEpoch(requestedVersion), StringComparison.Ordinal);
+        }
+
+        internal static string StripEpoch(string version)
+        {
+            int separator = version.IndexOf(':');
+            if (separator <= 0)
+            {
+                return version;
+            }
+
+            return version.Substring(0, separator).All(char.IsDigit) ? version.Substring(separator + 1) : version;
+        }
+
+        internal static string NormalizeArchiveRoot(string uri)
+        {
+            if (string.IsNullOrWhiteSpace(uri) ||
+                !Uri.TryCreate(uri.Trim().TrimEnd('/'), UriKind.Absolute, out Uri archiveRoot) ||
+                (archiveRoot.Scheme != Uri.UriSchemeHttp && archiveRoot.Scheme != Uri.UriSchemeHttps))
+            {
+                return null;
+            }
+
+            return archiveRoot.AbsoluteUri.TrimEnd('/');
+        }
+
+        private static void AddToIndex<T>(Dictionary<string, List<T>> index, string name, T entry)
+        {
+            if (!index.TryGetValue(name, out List<T> entries))
+            {
+                entries = new List<T>();
+                index.Add(name, entries);
+            }
+
+            entries.Add(entry);
+        }
+
+        private static IEnumerable<string> GetSuites(AptRepository repository, IReadOnlyList<string> suiteCandidates)
+        {
+            return FirstNonEmpty(repository.Suites, suiteCandidates?.ToArray())
+                .Where(suite => !string.IsNullOrWhiteSpace(suite) && !suite.Contains('/'))
+                .Distinct(StringComparer.Ordinal);
+        }
+
+        private static string[] FirstNonEmpty(params string[][] candidates)
+        {
+            return Array.Find(candidates, candidate => candidate != null && candidate.Length > 0) ?? Array.Empty<string>();
+        }
+
+        private static string[] SplitFieldValue(Dictionary<string, string> stanza, string field)
+        {
+            return stanza.TryGetValue(field, out string value)
+                ? value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)
+                : Array.Empty<string>();
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _httpClient?.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/SIT.Create/ComponentCreator.cs
+++ b/src/SIT.Create/ComponentCreator.cs
@@ -115,7 +115,7 @@ namespace SIT.Create
                     componentsData.Version = item.Version;
                     componentsData.ComponentExternalId = item.Purl.Substring(0, item.Purl.IndexOf('@'));
                     componentsData.ReleaseExternalId = item.Purl;
-                    Components component = await GetSourceUrl(componentsData.Name, componentsData.Version, componentsData.ProjectType, item.BomRef);
+                    Components component = await GetSourceUrl(componentsData.Name, componentsData.Version, componentsData.ProjectType, item.BomRef, item.Purl, appSettings);
                     componentsData.SourceUrl = component.SourceUrl;
 
                     if (componentsData.ProjectType.Equals("ALPINE", StringComparison.InvariantCultureIgnoreCase))
@@ -283,10 +283,12 @@ namespace SIT.Create
         /// "DEBIAN"). The value is case-insensitive.</param>
         /// <param name="bomRef">The Bill of Materials (BOM) reference identifier for the component. This parameter is required for certain
         /// project types, such as "ALPINE".</param>
+        /// <param name="purl">The package url of the component. It is required for certain project types, such as "DEBIAN".</param>
+        /// <param name="appSettings">The application settings that hold the package source configuration, e.g. the APT archives of an image.</param>
         /// <returns>A <see cref="Components"/> object containing the source URL and related metadata for the specified
         /// component. If the project type is not recognized, the returned object may not contain source URL
         /// information.</returns>
-        private static async Task<Components> GetSourceUrl(string name, string version, string projectType, string bomRef)
+        private static async Task<Components> GetSourceUrl(string name, string version, string projectType, string bomRef, string purl, CommonAppSettings appSettings)
         {
             Components componentsData = new Components();
             switch (projectType.ToUpperInvariant())
@@ -298,7 +300,7 @@ namespace SIT.Create
                     componentsData.SourceUrl = await UrlHelper.Instance.GetSourceUrlForNugetPackage(name, version);
                     break;
                 case DebianProjectType:
-                    Components debComponentData = await UrlHelper.Instance.GetSourceUrlForDebianPackage(name, version);
+                    Components debComponentData = await UrlHelper.Instance.GetSourceUrlForDebianPackage(name, version, purl, appSettings?.Debian?.AptRepositories);
                     componentsData = debComponentData;
                     componentsData.ProjectType = projectType;
                     break;

--- a/src/SIT.Create/Interfaces/IAptRepositoryService.cs
+++ b/src/SIT.Create/Interfaces/IAptRepositoryService.cs
@@ -1,0 +1,32 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using SIT.Common.Model;
+using SIT.Create.Model;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SIT.Create.Interfaces
+{
+    /// <summary>
+    /// Resolves the source package of a binary package by reading the index files of APT archives.
+    /// </summary>
+    public interface IAptRepositoryService
+    {
+        /// <summary>
+        /// Searches the given APT archives for the source package a binary package was built from.
+        /// </summary>
+        /// <param name="repositories">the APT archives to search, in order of precedence</param>
+        /// <param name="binaryName">name of the installed binary package</param>
+        /// <param name="binaryVersion">version of the installed binary package</param>
+        /// <param name="suiteCandidates">suites to search when a repository does not configure any</param>
+        /// <returns>the source package details, or null when none of the archives provides the package</returns>
+        Task<AptSourceResolution> ResolveSourcePackageAsync(IReadOnlyList<AptRepository> repositories,
+                                                            string binaryName,
+                                                            string binaryVersion,
+                                                            IReadOnlyList<string> suiteCandidates);
+    }
+}

--- a/src/SIT.Create/Interfaces/IURLHelper.cs
+++ b/src/SIT.Create/Interfaces/IURLHelper.cs
@@ -6,6 +6,7 @@
 
 
 using SIT.Common.Model;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SIT.Create.Interfaces
@@ -20,9 +21,13 @@ namespace SIT.Create.Interfaces
         /// </summary>
         /// <param name="componentName"></param>
         /// <param name="componenVersion"></param>
-        /// <param name="componentsData"></param>
+        /// <param name="purl">package url of the component, used to determine its distribution</param>
+        /// <param name="aptRepositories">APT archives the image installs its packages from</param>
         /// <returns>string</returns>
-        Task<Components> GetSourceUrlForDebianPackage(string componentName, string componenVersion);
+        Task<Components> GetSourceUrlForDebianPackage(string componentName,
+                                                      string componenVersion,
+                                                      string purl = null,
+                                                      IReadOnlyList<AptRepository> aptRepositories = null);
 
         /// <summary>
         /// Gets the Source Url For Nuget Package

--- a/src/SIT.Create/Model/AptIndexEntry.cs
+++ b/src/SIT.Create/Model/AptIndexEntry.cs
@@ -1,0 +1,159 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SIT.Create.Model
+{
+    /// <summary>
+    /// A stanza of the "Sources" index of an APT archive.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptSourceEntry
+    {
+        /// <summary>
+        /// Gets or sets the version of the source package.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pool folder the source files are stored in, relative to the archive root.
+        /// </summary>
+        public string Directory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file names that belong to the source package.
+        /// </summary>
+        public List<string> FileNames { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// A stanza of the "Packages" index of an APT archive.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptBinaryEntry
+    {
+        /// <summary>
+        /// Gets or sets the version of the binary package.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the source package the binary package was built from.
+        /// </summary>
+        public string SourceName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the source package the binary package was built from.
+        /// </summary>
+        public string SourceVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path of the .deb inside the pool, relative to the archive root.
+        /// </summary>
+        public string FileName { get; set; }
+    }
+
+    /// <summary>
+    /// The parsed "Sources" index of one component of a suite.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptSourceIndex
+    {
+        /// <summary>
+        /// Gets the source packages of the component, by package name.
+        /// </summary>
+        public Dictionary<string, List<AptSourceEntry>> Packages { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the pool folder of every source file of the component, by file name.
+        /// </summary>
+        public Dictionary<string, string> FileLocations { get; } = new(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// One component of one suite of one APT archive, i.e. the scope of a pair of index files.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptIndexContext
+    {
+        /// <summary>
+        /// Gets or sets the configured name of the repository, used for logging only.
+        /// </summary>
+        public string RepositoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the archive root, i.e. the URL that contains the "dists" and "pool" folders.
+        /// </summary>
+        public string ArchiveRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets the suite (codename).
+        /// </summary>
+        public string Suite { get; set; }
+
+        /// <summary>
+        /// Gets or sets the archive component.
+        /// </summary>
+        public string Component { get; set; }
+
+        /// <summary>
+        /// Gets or sets the binary architectures of the suite.
+        /// </summary>
+        public string[] Architectures { get; set; } = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// The place a source package and its files were found at.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptSourceLocation
+    {
+        /// <summary>
+        /// Gets or sets the index the source package was found through.
+        /// </summary>
+        public AptIndexContext Context { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the source package.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the source package.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pool folder of the source package, relative to the archive root.
+        /// </summary>
+        public string Directory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file names that belong to the source package.
+        /// </summary>
+        public List<string> FileNames { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// The parts of the "Release" file of a suite that are needed to locate its index files.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptReleaseInfo
+    {
+        /// <summary>
+        /// Gets or sets the archive components announced by the suite.
+        /// </summary>
+        public string[] Components { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the architectures announced by the suite.
+        /// </summary>
+        public string[] Architectures { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/SIT.Create/Model/AptSourceResolution.cs
+++ b/src/SIT.Create/Model/AptSourceResolution.cs
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+//  SPDX-License-Identifier: MIT
+// -------------------------------------------------------------------------------------------------------------------- 
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SIT.Create.Model
+{
+    /// <summary>
+    /// The source package of a binary package, as announced by the index files of an APT archive.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class AptSourceResolution
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the name of the source package.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the source package.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the download URLs of all files that belong to the source package
+        /// (.dsc, .orig.tar.*, .debian.tar.* / .diff.*).
+        /// </summary>
+        public List<string> FileUrls { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the archive the source package was found in, used for logging only.
+        /// </summary>
+        public string Origin { get; set; }
+
+        #endregion
+    }
+}

--- a/src/SIT.Create/URLHelper.cs
+++ b/src/SIT.Create/URLHelper.cs
@@ -40,6 +40,7 @@ namespace SIT.Create
     {
         static readonly ILog Logger = LoggerFactory.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly HttpClient httpClient = new HttpClient();
+        private readonly IAptRepositoryService _aptRepositoryService;
         public static string GithubUrl { get; set; } = string.Empty;
         public static UrlHelper Instance { get; } = new UrlHelper();
         public CommonAppSettings CommonAppSettings { get; } = new CommonAppSettings();
@@ -49,6 +50,15 @@ namespace SIT.Create
         private const string SourcePackageType = "source";
 
         private bool _disposed;
+
+        public UrlHelper() : this(new AptRepositoryService())
+        {
+        }
+
+        public UrlHelper(IAptRepositoryService aptRepositoryService)
+        {
+            _aptRepositoryService = aptRepositoryService;
+        }
 
         /// <summary>
         /// Gets the SourceUrl For Alpine Package
@@ -410,16 +420,26 @@ namespace SIT.Create
         /// </summary>
         /// <param name="componentName"></param>
         /// <param name="componenVersion"></param>
+        /// <param name="purl">package url of the component, used to determine its distribution</param>
+        /// <param name="aptRepositories">APT archives the image installs its packages from</param>
         /// <returns>Components</returns>
-        public async Task<Components> GetSourceUrlForDebianPackage(string componentName, string componenVersion)
+        public async Task<Components> GetSourceUrlForDebianPackage(string componentName,
+                                                                   string componenVersion,
+                                                                   string purl = null,
+                                                                   IReadOnlyList<AptRepository> aptRepositories = null)
         {
             Components componentsData = new Components();
-            DebianPackage debianPackSourceDetails = await GetSourceUrl(componentName, componenVersion);
+            DebianPackage debianPackSourceDetails = await GetSourceUrlFromAptRepositories(componentName, componenVersion, purl, aptRepositories);
 
-            if (debianPackSourceDetails.IsRetryRequired)
+            if (debianPackSourceDetails == null)
             {
-                Logger.DebugFormat("Retry for.. {0}-{1}", componentName, componenVersion);
-                debianPackSourceDetails = await RetryToGetSourceURlDetailsAsync(componentName, componenVersion);
+                debianPackSourceDetails = await GetSourceUrl(componentName, componenVersion);
+
+                if (debianPackSourceDetails.IsRetryRequired)
+                {
+                    Logger.DebugFormat("Retry for.. {0}-{1}", componentName, componenVersion);
+                    debianPackSourceDetails = await RetryToGetSourceURlDetailsAsync(componentName, componenVersion);
+                }
             }
 
             componentsData.Name = debianPackSourceDetails.Name;
@@ -713,14 +733,90 @@ namespace SIT.Create
         }
 
         /// <summary>
+        /// Looks the source package up in the APT archives the image installs its packages from.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="purl"></param>
+        /// <param name="aptRepositories"></param>
+        /// <returns>the debian package, or null when it is not provided by any of the archives</returns>
+        private async Task<DebianPackage> GetSourceUrlFromAptRepositories(string name,
+                                                                          string version,
+                                                                          string purl,
+                                                                          IReadOnlyList<AptRepository> aptRepositories)
+        {
+            if (aptRepositories == null || aptRepositories.Count == 0 || _aptRepositoryService == null)
+            {
+                return null;
+            }
+
+            AptSourceResolution resolution = await _aptRepositoryService.ResolveSourcePackageAsync(
+                aptRepositories, name, version, GetDistributionCandidates(purl));
+
+            if (resolution == null)
+            {
+                Logger.DebugFormat("GetSourceUrlFromAptRepositories(): {0}-{1} is not provided by any configured APT repository.", name, version);
+                return null;
+            }
+
+            DebianPackage sourceURLDetails = new DebianPackage { Name = resolution.Name, Version = resolution.Version };
+            return GetProperSourceURL(sourceURLDetails, resolution.FileUrls);
+        }
+
+        /// <summary>
+        /// Reads the distribution of a component from the qualifiers of its package url, e.g. "trixie" for
+        /// "pkg:deb/debian/busybox@1.37.0-6%2Bdhi1?os_distro=trixie&amp;os_name=debian&amp;os_version=13".
+        /// </summary>
+        /// <param name="purl"></param>
+        /// <returns>the distributions to search, most specific first</returns>
+        public static List<string> GetDistributionCandidates(string purl)
+        {
+            List<string> candidates = new List<string>();
+            int qualifierStart = purl?.IndexOf('?') ?? -1;
+
+            if (qualifierStart < 0)
+            {
+                return candidates;
+            }
+
+            foreach (string qualifier in purl.Substring(qualifierStart + 1).Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                string[] keyValue = qualifier.Split('=', 2);
+                if (keyValue.Length != 2 || string.IsNullOrWhiteSpace(keyValue[1]))
+                {
+                    continue;
+                }
+
+                string key = keyValue[0].Trim();
+                string value = WebUtility.UrlDecode(keyValue[1]).Trim();
+
+                if (key.Equals("os_distro", StringComparison.OrdinalIgnoreCase))
+                {
+                    candidates.Insert(0, value);
+                }
+                else if (key.Equals("distro", StringComparison.OrdinalIgnoreCase))
+                {
+                    // syft reports the distribution as "<os name>-<os version>", e.g. "debian-13".
+                    candidates.Add(value);
+                    int separator = value.IndexOf('-');
+                    if (separator > 0)
+                    {
+                        candidates.Add(value.Substring(separator + 1));
+                    }
+                }
+            }
+
+            return candidates.Distinct(StringComparer.Ordinal).ToList();
+        }
+
+        /// <summary>
         /// Gets Source Url
         /// </summary>
         /// <param name="name"></param>
         /// <param name="version"></param>
         /// <returns>task</returns>
         private async Task<DebianPackage> GetSourceUrl(string name, string version)
-        {
-            DebianPackage sourceURLDetails = new DebianPackage { Name = name, Version = version };
+        {            DebianPackage sourceURLDetails = new DebianPackage { Name = name, Version = version };
             string packageType = SourcePackageType;
             sourceURLDetails = await GetArchiveResponse(sourceURLDetails, packageType);
 
@@ -1069,6 +1165,8 @@ namespace SIT.Create
                 await RetryHttpClientHandler.ExecuteWithRetryAsync(async () =>
                 {
                     using WebClient webClient = new();
+                    // Proxies and mirrors reject downloads that do not identify their client.
+                    webClient.Headers.Add(HttpRequestHeader.UserAgent, Dataconstant.UserAgent);
                     await webClient.DownloadFileTaskAsync(uri, downloadFilePath);
                 });
                 downloadedPath = downloadFilePath;
@@ -1116,6 +1214,8 @@ namespace SIT.Create
             {
                 httpClient.Dispose();
             }
+
+            (_aptRepositoryService as IDisposable)?.Dispose();
 
             _disposed = true;
         }

--- a/src/SIT.Create/URLHelper.cs
+++ b/src/SIT.Create/URLHelper.cs
@@ -47,6 +47,7 @@ namespace SIT.Create
 
         private const string SrcUrlFailWarnFormat = "Identification of SRC url failed for {0}, Exclude if it is an internal component or manually update the SRC url";
         private const string AportsDirectoryName = "aports";
+        private const string AportsDefaultBranch = "master";
         private const string SourcePackageType = "source";
 
         private bool _disposed;
@@ -103,18 +104,63 @@ namespace SIT.Create
         }
 
         /// <summary>
-        /// Gets Alpine Distro
+        /// Gets the aports branch of a component from the qualifiers of its bom reference, e.g. "3.22-stable" for
+        /// "pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-3.22".
         /// </summary>
         /// <param name="bomRef"></param>
-        /// <returns>distro</returns>
+        /// <returns>the aports branch to check out</returns>
         public static string GetAlpineDistro(string bomRef)
         {
+            string release = GetAlpineRelease(bomRef);
 
-            string[] getDistro = bomRef.Split("distro");
-            string[] getDestroVersion = getDistro[1].Split("-");
-            var output = getDestroVersion[1][..^2];
-            var distro = output + "-stable";
-            return distro;
+            if (string.IsNullOrEmpty(release))
+            {
+                Logger.WarnFormat("GetAlpineDistro(): The Alpine release of {0} is unknown, using the {1} branch of aports.", bomRef, AportsDefaultBranch);
+                return AportsDefaultBranch;
+            }
+
+            return $"{release}-stable";
+        }
+
+        /// <summary>
+        /// Reads the Alpine release from the distribution qualifiers of a package url, e.g. "3.22" for
+        /// "...?distro=alpine-3.22.1" (syft) as well as for "...?os_name=alpine&amp;os_version=3.22" (Docker Scout).
+        /// </summary>
+        /// <param name="purl"></param>
+        /// <returns>the release as "&lt;major&gt;.&lt;minor&gt;", or an empty string if no release is stated</returns>
+        private static string GetAlpineRelease(string purl)
+        {
+            int qualifierStart = purl?.IndexOf('?') ?? -1;
+
+            if (qualifierStart < 0)
+            {
+                return string.Empty;
+            }
+
+            foreach (string qualifier in purl.Substring(qualifierStart + 1).Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                string[] keyValue = qualifier.Split('=', 2);
+                if (keyValue.Length != 2)
+                {
+                    continue;
+                }
+
+                string key = keyValue[0].Trim();
+                if (!key.Equals("distro", StringComparison.OrdinalIgnoreCase)
+                    && !key.Equals("os_distro", StringComparison.OrdinalIgnoreCase)
+                    && !key.Equals("os_version", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                Match release = AlpineReleaseRegex().Match(WebUtility.UrlDecode(keyValue[1]).Trim());
+                if (release.Success)
+                {
+                    return release.Value;
+                }
+            }
+
+            return string.Empty;
         }
 
         /// <summary>
@@ -1227,5 +1273,7 @@ namespace SIT.Create
         private static partial Regex AlpineComponentVersionRegex();
         [GeneratedRegex(@"\=")]
         private static partial Regex AlpinePackagelineRegex();
+        [GeneratedRegex(@"[0-9]+\.[0-9]+")]
+        private static partial Regex AlpineReleaseRegex();
     }
 }

--- a/src/SIT.Scan.UTest/AlpineParserTests.cs
+++ b/src/SIT.Scan.UTest/AlpineParserTests.cs
@@ -215,5 +215,44 @@ namespace SIT.Scan.UTest
             //Assert
             Assert.IsTrue(isUpdated, "Checks For Updated Property In List ");
         }
+
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?arch=x86_64&distro=alpine-3.22", "pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-3.22")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?os_name=alpine&os_version=3.22", "pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-3.22")]
+        [TestCase("pkg:apk/alpine/busybox@1.37.0-r20?arch=x86_64", "pkg:apk/alpine/busybox@1.37.0-r20")]
+        public void ParsePackageConfig_GivenAPurlWithDistributionQualifiers_ReturnsBomRefWithTheDistribution(string purl, string expectedBomRef)
+        {
+            //Arrange
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string OutFolder = Path.GetDirectoryName(exePath);
+            string[] Includes = { "CycloneDX_Alpine.cdx.json" };
+
+            Bom bom = new()
+            {
+                Components = new List<Component>
+                {
+                    new Component() { Name = "busybox", Version = "1.37.0-r20", Purl = purl }
+                }
+            };
+            Mock<ICycloneDXBomParser> cycloneDXBomParser = new Mock<ICycloneDXBomParser>();
+            cycloneDXBomParser.Setup(x => x.ParseCycloneDXBom(It.IsAny<string>())).Returns(bom);
+            AlpineProcessor alpineProcessor = new AlpineProcessor(cycloneDXBomParser.Object, new Mock<ISpdxBomParser>().Object);
+
+            CommonAppSettings appSettings = new CommonAppSettings()
+            {
+                ProjectType = "ALPINE",
+                Alpine = new Config() { Include = Includes },
+                SW360 = new SW360() { IgnoreDevDependency = true },
+                Directory = new SIT.Common.Directory()
+                {
+                    InputFolder = Path.GetFullPath(Path.Combine(OutFolder, "SITScanUTTestFiles"))
+                }
+            };
+
+            //Act
+            Bom listofcomponents = alpineProcessor.ParsePackageFile(appSettings, ref ListUnsupportedComponentsForBom);
+
+            //Assert
+            Assert.That(listofcomponents.Components[0].BomRef, Is.EqualTo(expectedBomRef));
+        }
     }
 }

--- a/src/SIT.Scan/AlpineProcesser.cs
+++ b/src/SIT.Scan/AlpineProcesser.cs
@@ -12,6 +12,7 @@ using SIT.Common.Interface;
 using SIT.Scan.Interface;
 using SIT.Scan.Model;
 using SIT.Services.Interface;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -218,14 +219,55 @@ namespace SIT.Scan
                 BomCreator.bomKpiData.DuplicateComponents = initialCount - listofComponents.Count;
         }
 
+        /// <summary>
+        /// Reads the distribution of a package from the qualifiers of its package url, e.g. "distro=alpine-3.22" for
+        /// "pkg:apk/alpine/busybox@1.37.0-r20?distro=alpine-3.22" (syft) as well as for
+        /// "pkg:apk/alpine/busybox@1.37.0-r20?os_name=alpine&amp;os_version=3.22" (Docker Scout).
+        /// </summary>
+        /// <param name="alpinePackage">Parsed Alpine package information.</param>
+        /// <returns>The distribution qualifier, or an empty string if the package url states no distribution.</returns>
         private static string GetDistro(AlpinePackage alpinePackage)
         {
-            var distroIndex = alpinePackage.PurlID.LastIndexOf("distro");
-            if (distroIndex == -1)
+            int qualifierStart = alpinePackage.PurlID?.IndexOf('?') ?? -1;
+            if (qualifierStart == -1)
             {
                 return string.Empty;
             }
-            return alpinePackage.PurlID[distroIndex..];
+
+            string osName = string.Empty;
+            string osVersion = string.Empty;
+
+            foreach (string qualifier in alpinePackage.PurlID.Substring(qualifierStart + 1).Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                string[] keyValue = qualifier.Split('=', 2);
+                if (keyValue.Length != 2 || string.IsNullOrWhiteSpace(keyValue[1]))
+                {
+                    continue;
+                }
+
+                string key = keyValue[0].Trim();
+                string value = keyValue[1].Trim();
+
+                if (key.Equals("distro", StringComparison.OrdinalIgnoreCase))
+                {
+                    return $"distro={value}";
+                }
+                if (key.Equals("os_name", StringComparison.OrdinalIgnoreCase))
+                {
+                    osName = value;
+                }
+                else if (key.Equals("os_version", StringComparison.OrdinalIgnoreCase))
+                {
+                    osVersion = value;
+                }
+            }
+
+            if (string.IsNullOrEmpty(osName) || string.IsNullOrEmpty(osVersion))
+            {
+                return string.Empty;
+            }
+
+            return $"distro={osName}-{osVersion}";
         }
 
         /// <summary>


### PR DESCRIPTION
This PR allows to add arbitrary APT repositories in addition to the already existing snapshot debian repo. The reason is that clearing container images from for example DHI requires the DHI apt repository so that the sources can be found, but other reasons may include packages installed from apt.llvm.org, download.docker.com or any other 3rd party repository.

Another minor fix includes setting a user agent on the outgoing requests as some CDNs may respond with a 403 when no user-agent is set on some bigger files.

- Added AptRepositoryService class to handle source package resolution through APT archives.
- Introduced IAptRepositoryService interface for defining the contract for APT repository services.
- Created AptIndexEntry, AptSourceResolution, and related models to represent APT index data structures.
- Enhanced ComponentCreator to utilize the new APT repository service for Debian package source URL resolution.
- Updated URLHelper to integrate APT repository service for fetching source URLs based on package URLs.
- Modified existing methods to accommodate new parameters for package URLs and application settings.
- Improved error handling and logging for APT repository interactions.